### PR TITLE
Release HQBase 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.1
+
+- Preserve invitation password setup links so `/set-password?token=...` reaches the password form
+  instead of being normalized to the inbox.
+
 ## 1.0.0
 
 - Publish HQBase as one free and open-source shared email workspace for customer-owned Cloudflare

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hqbase",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary

- bump the committed HQBase version to `1.0.1`
- add the public `1.0.1` changelog entry for the invitation password routing fix

## Why

The signed release workflow reads its version and release notes from `main`. The `v1.0.0` release is immutable, so the merged invitation-routing fix needs a new `1.0.1` candidate.

## Impact

Invitation password links preserve `/set-password?token=...` and reach the intended setup form. The release remains compatible with HQBase `1.0.0` installations.

## Validation

- `CI=true pnpm check`
- `WRANGLER_LOG_PATH=/tmp/hqbase-release-1.0.1-wrangler.log CI=true pnpm deploy:dry-run`

After this PR is reviewed and merged, wait for green `main` CI before manually dispatching the signed release workflow.