### PR TITLE
fix(install): route Worker-owned paths ahead of the SPA asset fallback

### DIFF
--- a/scripts/hqbase/config.mjs
+++ b/scripts/hqbase/config.mjs
@@ -26,7 +26,8 @@ export function createWranglerConfig(manifest) {
     assets: {
       directory: `${rootFromDeployment}/dist`,
       binding: "ASSETS",
-      not_found_handling: "single-page-application"
+      not_found_handling: "single-page-application",
+      run_worker_first: ["/api/*", "/mcp", "/mcp/*", "/.well-known/*"]
     },
     observability: {
       enabled: true,

--- a/test/unit/scripts/install.test.mjs
+++ b/test/unit/scripts/install.test.mjs
@@ -1,7 +1,13 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { createWranglerConfig } from "../../../scripts/hqbase/config.mjs";
 import { cloudflareOAuthConfig, createManifest } from "../../../scripts/hqbase/install.mjs";
 import { updateOAuthManifest } from "../../../scripts/hqbase/oauth.mjs";
+
+const repositoryWranglerConfig = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, "../../../wrangler.jsonc"), "utf8")
+);
 
 describe("HQBase installation resources", () => {
   it("creates a fresh, unowned manifest before provisioning", () => {
@@ -44,6 +50,20 @@ describe("HQBase installation resources", () => {
       CLOUDFLARE_OAUTH_MODE: "customer"
     });
     expect(config.observability.logs.invocation_logs).toBe(false);
+  });
+
+  it("routes Worker-owned paths ahead of the single-page-application fallback", () => {
+    const config = createWranglerConfig(createManifest("qa", {}));
+
+    expect(config.assets.run_worker_first).toEqual(["/api/*", "/mcp", "/mcp/*", "/.well-known/*"]);
+  });
+
+  it("keeps asset routing identical to the repository Wrangler configuration", () => {
+    const config = createWranglerConfig(createManifest("qa", {}));
+    const { directory: _generated, ...generated } = config.assets;
+    const { directory: _repository, ...repository } = repositoryWranglerConfig.assets;
+
+    expect(generated).toEqual(repository);
   });
 
   it("fails closed on incomplete customer-managed OAuth configuration", () => {


### PR DESCRIPTION
Fixes #4.

## Problem

Deployments created with `pnpm hqbase install` cannot complete setup. The generated Wrangler
config omits `run_worker_first`, so Static Assets answers every *navigation* request that does
not match a file with `index.html` and the Worker never runs.

`fetch()` requests still reach the Worker, so the deployment looks healthy — `GET
/api/setup/status` returns real JSON. But the setup wizard's Cloudflare OAuth step is a genuine
top-level navigation to `/api/setup/cloudflare/oauth/start`, and that is swallowed by the SPA
fallback. The redirect to `auth.hqbase.io` never happens, no `hqb_cf_oauth_grant` cookie is
issued, and the next step fails with a misleading `POST /api/setup/cloudflare/access 401`.

`/mcp`, `/mcp/*` and `/.well-known/*` are affected in the same way.

Deployments created with the Deploy-to-Cloudflare button are unaffected — they use the
repository's root `wrangler.jsonc`, which sets `run_worker_first` correctly.

## Result

CLI-installed deployments can complete setup. Verified on a live deployment: after this change
a navigation request to `/api/setup/cloudflare/oauth/start` returns `303` to `auth.hqbase.io`,
`/setup` still returns the SPA shell, and the full wizard runs through `oauth/callback` →
`cloudflare/access` → `cloudflare/zones` → `cloudflare/configure` → `setup/bootstrap` to a
signed-in workspace. `/mcp` and `/.well-known/oauth-protected-resource/mcp` respond as well.

## Change

`scripts/hqbase/config.mjs` now emits the same `run_worker_first` list as the repository's root
`wrangler.jsonc`.

Two tests are added to `test/unit/scripts/install.test.mjs`:

- one asserting the generated `assets.run_worker_first` list directly;
- one asserting the generated `assets` block is identical to the repository config's, ignoring
  `directory`.

The second is the more useful of the pair. The generator hand-maintains a second copy of the
root config and had already drifted from it in two places (`run_worker_first` here, and
`preview_urls`, which is out of scope for this PR). `run_worker_first` is the kind of setting
whose absence produces no error anywhere — just silently wrong routing — so a drift guard turns
the next divergence into a failing test instead of an unusable deployment.

Both new tests were confirmed to fail without the one-line fix and pass with it.

## Affected repositories

`HQBase/hqbase` only. No specification change: this restores intended behaviour rather than
changing it.

Related: #7 fixes the Windows-specific installer failures. The two are independent — this one
applies to every platform — but both have to land before a CLI-installed deployment works on
Windows.

## Local checks

| Check | Result |
|---|---|
| `pnpm install` | pass |
| `pnpm db:migrate:local` | pass, 9 migrations |
| `pnpm check` | biome, typecheck, build pass; 280/281 tests pass |
| `pnpm deploy:dry-run` | pass |

The one failing test is `test/unit/scripts/deploy.test.mjs > generates masked auth and Web Push
secrets when the first Workers Build needs them`, at
`expect(statSync(secretFile).mode & 0o777).toBe(0o600)` — it gets `0o666`. This is a Windows
environment limitation (no POSIX file modes), not a regression: I confirmed it fails identically
on a clean checkout of `main` with no changes applied. Reported separately in #5 along with the
other Windows issues I hit.

## Database, security, recovery

- No schema or migration changes.
- No change to any security boundary. The 401 this fixes was correct behaviour —
  `resolveRuntimeCloudflareGrant` was right to reject a request with no grant cookie. The fault
  was upstream of it, in routing, so nothing about grant handling is relaxed here.
- No recovery considerations. Existing deployments do need a redeploy for the config change to
  take effect, and there is currently no supported command for a config-only redeploy — noted
  in #4.
