### PR TITLE
fix(scripts): make the terminal install path and quality gate work on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Biome formats to LF. Without this, a Windows checkout with the common
+# `core.autocrlf=true` setting rewrites every file to CRLF and `pnpm check` fails on
+# essentially the whole repository.
+* text=auto eol=lf
+
+*.png binary
+*.ico binary
+*.wav binary
+*.woff binary
+*.woff2 binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,22 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm check
       - run: pnpm deploy:dry-run
+
+  # The terminal install path is supported on Windows, where process spawning, path handling and
+  # file permissions differ enough that a Linux-only gate cannot cover them.
+  quality-windows:
+    runs-on: windows-latest
+    env:
+      BETTER_AUTH_SECRET: ci-auth-secret-not-used-in-production
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.7.0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm deploy:dry-run

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/coverage-v8": "4.1.10",
     "autoprefixer": "^10.4.21",
+    "cross-spawn": "7.0.6",
     "postcss": "^8.5.23",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.5.2(postcss@8.5.23)
+      cross-spawn:
+        specifier: 7.0.6
+        version: 7.0.6
       postcss:
         specifier: 8.5.23
         version: 8.5.23

--- a/scripts/hqbase/command.mjs
+++ b/scripts/hqbase/command.mjs
@@ -1,5 +1,4 @@
-import { spawnSync } from "node:child_process";
-
+import { spawnProcess } from "../shell.mjs";
 import { rootDir } from "./paths.mjs";
 
 export function run(command, args = [], options = {}) {
@@ -10,7 +9,7 @@ export function run(command, args = [], options = {}) {
   }
 
   console.log(`$ ${label}`);
-  const result = spawnSync(command, args, {
+  const result = spawnProcess(command, args, {
     cwd: rootDir,
     encoding: "utf8",
     env: {
@@ -30,7 +29,10 @@ export function run(command, args = [], options = {}) {
   }
 
   if (result.status !== 0 && !options.allowFailure) {
-    throw new Error(`Command failed (${result.status ?? "signal"}): ${label}`);
+    // A missing status means the child never reported an exit code. On POSIX that is a signal,
+    // but on Windows it is usually a spawn failure whose cause lives only in `result.error`.
+    const detail = result.error ? ` (${result.error.message})` : "";
+    throw new Error(`Command failed (${result.status ?? "no exit code"}): ${label}${detail}`);
   }
 
   return `${stdout}${stderr}`;

--- a/scripts/release/command.mjs
+++ b/scripts/release/command.mjs
@@ -1,27 +1,41 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnProcess } from "../shell.mjs";
 
 function commandEnvironment() {
   return { ...process.env, CI: process.env.CI ?? "true" };
 }
 
+function assertSucceeded(result, command, args) {
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    // A missing status means the child never reported an exit code, so the reason is only in
+    // `result.error` when one is present.
+    throw new Error(
+      `Command failed (${result.status ?? "no exit code"}): ${[command, ...args].join(" ")}`
+    );
+  }
+}
+
 export function run(command, args, cwd) {
-  execFileSync(command, args, {
+  const result = spawnProcess(command, args, {
     cwd,
     env: commandEnvironment(),
     stdio: "inherit"
   });
+  assertSucceeded(result, command, args);
 }
 
 export function capture(command, args, cwd) {
-  return execFileSync(command, args, {
+  const result = spawnProcess(command, args, {
     cwd,
     env: commandEnvironment(),
     encoding: "utf8"
   });
+  assertSucceeded(result, command, args);
+  return result.stdout;
 }
 
 export function attemptRun(command, args, cwd) {
-  return spawnSync(command, args, {
+  return spawnProcess(command, args, {
     cwd,
     env: commandEnvironment(),
     encoding: "utf8"

--- a/scripts/release/deploy.mjs
+++ b/scripts/release/deploy.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
@@ -53,7 +53,7 @@ export async function deploy(options = {}) {
     const archive = resolve(workspace, "release.tar.gz");
     const source = resolve(workspace, "source");
     writeFileSync(archive, bytes);
-    run("mkdir", ["-p", source], root);
+    mkdirSync(source, { recursive: true });
     run("tar", ["-xzf", archive, "-C", source], root);
     const config = normalizeConfig(
       JSON.parse(readFileSync(configFile, "utf8")),

--- a/scripts/release/worker-deploy.mjs
+++ b/scripts/release/worker-deploy.mjs
@@ -1,9 +1,9 @@
 import { randomBytes, randomUUID } from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import webpush from "web-push";
 
+import { createRestrictedDirectory } from "../secure-directory.mjs";
 import { isWorkerNotFound } from "./active-version.mjs";
 import { attemptRun, emitCommandOutput, run } from "./command.mjs";
 
@@ -52,7 +52,9 @@ export function deploySource(cwd, options = {}) {
     deployArgs.push("--var", `HQBASE_INSTALLATION_ID:${options.randomUUID?.() ?? randomUUID()}`);
   }
 
-  const workspace = mkdtempSync(resolve(tmpdir(), "hqbase-secrets-"));
+  // The file below holds the auth secret and VAPID keys for the duration of one deploy, so the
+  // directory has to exclude other accounts before anything is written into it.
+  const workspace = createRestrictedDirectory("hqbase-secrets-");
   const secretsFile = resolve(workspace, "secrets.json");
   try {
     const secrets = {};

--- a/scripts/secure-directory.mjs
+++ b/scripts/secure-directory.mjs
@@ -1,0 +1,121 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+import { spawnProcess } from "./shell.mjs";
+
+const isWindows = process.platform === "win32";
+
+// Windows keeps the machine's trusted principals on every directory, and a member of
+// Administrators can read any file regardless of its access control list by taking ownership or
+// with SeBackupPrivilege. Excluding them is neither achievable nor meaningful — POSIX mode 0700
+// does not keep root out either. What has to be guaranteed is that no *other user* can reach the
+// secrets, which is the same guarantee 0700 gives.
+const ADMINISTRATIVE_TRUSTEES = new Set([
+  "SY",
+  "S-1-5-18", // LocalSystem
+  "BA",
+  "S-1-5-32-544" // BUILTIN\Administrators
+]);
+
+let cachedSid = null;
+
+function runOrThrow(command, args) {
+  const result = spawnProcess(command, args, { encoding: "utf8" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} failed: ${`${result.stdout ?? ""}${result.stderr ?? ""}`.trim()}`);
+  }
+  return result.stdout ?? "";
+}
+
+// `whoami` is a plain executable, so it works in environments where PowerShell module
+// autoloading is unavailable.
+export function currentUserSid() {
+  if (cachedSid) return cachedSid;
+  const sid = /S-1-[\d-]+/.exec(runOrThrow("whoami", ["/user", "/fo", "csv", "/nh"]))?.[0];
+  if (!sid) throw new Error("Could not determine the SID of the current Windows account.");
+  cachedSid = sid;
+  return sid;
+}
+
+// `icacls /save` writes the directory name followed by its security descriptor in SDDL form.
+// Reading the descriptor keeps this independent of the display language and of whether the path
+// arrived in its long or 8.3 short form.
+export function directorySecurityDescriptor(directory) {
+  const aclFile = `${directory}.acl`;
+  try {
+    runOrThrow("icacls", [directory, "/save", aclFile, "/q"]);
+    return readFileSync(aclFile, "utf16le").split(/\r?\n/)[1] ?? "";
+  } finally {
+    rmSync(aclFile, { force: true });
+  }
+}
+
+// SDDL names well-known principals by two-letter alias rather than by SID, so trustees come back
+// as a mix of aliases and raw SIDs.
+export function directoryTrustees(directory) {
+  return [...directorySecurityDescriptor(directory).matchAll(/\(([^)]*)\)/g)]
+    .map((entry) => entry[1].split(";")[5])
+    .filter((trustee) => Boolean(trustee));
+}
+
+function isCurrentAccount(trustee, sid) {
+  if (trustee === sid) return true;
+  // SDDL writes the machine's built-in Administrator as LA instead of as a SID.
+  return trustee === "LA" && sid.endsWith("-500");
+}
+
+// Accounts with access that are neither the current one nor part of the machine's trusted set.
+export function foreignTrustees(directory) {
+  const sid = currentUserSid();
+  return directoryTrustees(directory).filter(
+    (trustee) => !isCurrentAccount(trustee, sid) && !ADMINISTRATIVE_TRUSTEES.has(trustee)
+  );
+}
+
+function restrictDirectory(directory) {
+  if (!isWindows) {
+    chmodSync(directory, 0o700);
+    return;
+  }
+  runOrThrow("icacls", [directory, "/inheritance:r", "/grant:r", `*${currentUserSid()}:(OI)(CI)F`]);
+}
+
+// Returns null when the directory is restricted, otherwise a description of what was observed.
+// The description reaches the operator, so it has to say why the check rejected the directory.
+function restrictionFailure(directory) {
+  if (!isWindows) {
+    const mode = statSync(directory).mode & 0o777;
+    return mode === 0o700 ? null : `mode is 0${mode.toString(8)}, expected 0700`;
+  }
+  const foreign = foreignTrustees(directory);
+  if (foreign.length > 0) {
+    return `access is also granted to [${foreign.join(", ")}]`;
+  }
+  if (
+    !directoryTrustees(directory).some((trustee) => isCurrentAccount(trustee, currentUserSid()))
+  ) {
+    return `the current account has no entry; descriptor was ${directorySecurityDescriptor(directory)}`;
+  }
+  return null;
+}
+
+// Creates a temporary directory no other user can read, and fails closed rather than returning
+// one whose restriction could not be confirmed. Callers put short-lived secrets in here, so an
+// unverified directory is worse than no directory at all.
+export function createRestrictedDirectory(prefix, options = {}) {
+  const restrict = options.restrict ?? restrictDirectory;
+  const directory = mkdtempSync(resolve(tmpdir(), prefix));
+  try {
+    restrict(directory);
+    const failure = restrictionFailure(directory);
+    if (failure) {
+      throw new Error(`The temporary directory ${directory} could not be restricted: ${failure}`);
+    }
+  } catch (error) {
+    rmSync(directory, { recursive: true, force: true });
+    throw error;
+  }
+  return directory;
+}

--- a/scripts/shell.mjs
+++ b/scripts/shell.mjs
@@ -1,0 +1,10 @@
+import crossSpawn from "cross-spawn";
+
+// pnpm and wrangler are installed as `.cmd` shims on Windows, which CreateProcess cannot launch
+// directly. cross-spawn resolves the shim and builds the command line itself, so argv reaches
+// the child unchanged. Node's `shell` option is not an alternative here: it concatenates
+// arguments without escaping them (DEP0190) and still lets cmd.exe expand `%VAR%` inside quoted
+// arguments, which would silently corrupt SQL and any value containing a percent sign.
+export function spawnProcess(command, args = [], options = {}) {
+  return crossSpawn.sync(command, args, options);
+}

--- a/test/unit/scripts/deploy.test.mjs
+++ b/test/unit/scripts/deploy.test.mjs
@@ -1,7 +1,7 @@
 import { createHash, generateKeyPairSync, sign } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   inspectActiveRelease,
@@ -20,6 +20,7 @@ import {
   verifyManifest,
   workerNameFromConfig
 } from "../../../scripts/release/deploy.mjs";
+import { foreignTrustees } from "../../../scripts/secure-directory.mjs";
 
 describe("HQBase release deployment", () => {
   it("verifies product-bound manifests", () => {
@@ -255,7 +256,13 @@ describe("HQBase release deployment", () => {
         expect(args.at(-2)).toBe("--secrets-file");
         expect(cwd).toBe("/customer/repo");
         secretFile = args.at(-1);
-        expect(statSync(secretFile).mode & 0o777).toBe(0o600);
+        // Windows has no POSIX file modes, so the secret is protected there by the access
+        // control list on its containing directory instead of by the file mode.
+        if (process.platform === "win32") {
+          expect(foreignTrustees(dirname(secretFile))).toEqual([]);
+        } else {
+          expect(statSync(secretFile).mode & 0o777).toBe(0o600);
+        }
         expect(JSON.parse(readFileSync(secretFile, "utf8"))).toEqual({
           BETTER_AUTH_SECRET: Buffer.alloc(32, 7).toString("base64url"),
           VAPID_PUBLIC_KEY: "generated-public-key",

--- a/test/unit/scripts/secure-directory.test.mjs
+++ b/test/unit/scripts/secure-directory.test.mjs
@@ -1,0 +1,59 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createRestrictedDirectory,
+  currentUserSid,
+  foreignTrustees
+} from "../../../scripts/secure-directory.mjs";
+
+const isWindows = process.platform === "win32";
+const EVERYONE_SID = "S-1-1-0";
+
+// Loosening the directory has to be expressed differently per platform: chmod widens the mode on
+// POSIX, while on Windows the equivalent is handing an unrelated principal access.
+function grantAccessToEveryone(directory) {
+  spawnSync("icacls", [directory, "/grant", `*${EVERYONE_SID}:(OI)(CI)F`], { encoding: "utf8" });
+}
+
+const loosen = isWindows ? grantAccessToEveryone : (directory) => chmodSync(directory, 0o755);
+
+describe("restricted directory", () => {
+  it("leaves no other account with access", () => {
+    const directory = createRestrictedDirectory("hqbase-secure-test-");
+
+    try {
+      if (isWindows) {
+        expect(foreignTrustees(directory)).toEqual([]);
+      } else {
+        expect(statSync(directory).mode & 0o777).toBe(0o700);
+      }
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(isWindows)("reports an unrelated account as having access", () => {
+    const directory = mkdtempSync(resolve(tmpdir(), "hqbase-secure-foreign-"));
+
+    try {
+      grantAccessToEveryone(directory);
+
+      expect(foreignTrustees(directory)).not.toEqual([]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(isWindows)("identifies the account by SID rather than by name", () => {
+    expect(currentUserSid()).toMatch(/^S-1-[\d-]+$/);
+  });
+
+  it("refuses to hand back a directory it could not restrict", () => {
+    expect(() => createRestrictedDirectory("hqbase-secure-test-", { restrict: loosen })).toThrow(
+      "could not be restricted"
+    );
+  });
+});

--- a/test/unit/scripts/shell.test.mjs
+++ b/test/unit/scripts/shell.test.mjs
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { spawnProcess } from "../../../scripts/shell.mjs";
+
+// The child prints back exactly what it received, so the assertions compare real argv rather
+// than an intermediate quoting representation.
+// `--` stops Node from claiming arguments such as `--config` as its own options.
+const echoArgv = ["-e", "console.log(JSON.stringify(process.argv.slice(1)))", "--"];
+
+function childArgv(args) {
+  const result = spawnProcess(process.execPath, [...echoArgv, ...args], { encoding: "utf8" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`child exited with ${result.status}: ${result.stderr.trim()}`);
+  }
+  return JSON.parse(result.stdout);
+}
+
+describe("child process arguments", () => {
+  it("delivers ordinary arguments unchanged", () => {
+    const args = ["exec", "wrangler", "d1", "create", "hqbase-qa"];
+
+    expect(childArgv(args)).toEqual(args);
+  });
+
+  it("delivers arguments containing whitespace unchanged", () => {
+    const args = ["--config", "C:\\Program Files\\repo\\wrangler.jsonc"];
+
+    expect(childArgv(args)).toEqual(args);
+  });
+
+  it("delivers arguments containing shell metacharacters unchanged", () => {
+    const args = ["a&b", "c|d", "e>f", "g^h", "(i)"];
+
+    expect(childArgv(args)).toEqual(args);
+  });
+
+  it("does not expand environment variable syntax inside arguments", () => {
+    const args = ["literal %USERNAME% here", "$HOME stays literal"];
+
+    expect(childArgv(args)).toEqual(args);
+  });
+
+  it("delivers SQL containing quotes and wildcards unchanged", () => {
+    const args = [
+      "--command",
+      "UPDATE release_state SET installed_version = '1.0.1' WHERE singleton = 1",
+      "--command",
+      "SELECT * FROM mailboxes WHERE address LIKE '%@example.com'"
+    ];
+
+    expect(childArgv(args)).toEqual(args);
+  });
+});


### PR DESCRIPTION
Addresses #5. Partial-install recovery/idempotency and the `wrangler d1 delete` cleanup trap
described there are **not** covered here and remain open.

Related: #6 (merged) fixed a separate, platform-independent defect that also had to land before a
CLI-installed deployment worked.

## Problem

The terminal install path documented in `docs/guides/deployment` cannot run on Windows, and
`pnpm check` — the gate `CONTRIBUTING.md` asks contributors to run — cannot pass there either.

## Result

`node scripts/hqbase/cli.mjs install …` completes on Windows, and `pnpm check` and
`pnpm deploy:dry-run` both pass. The new `quality-windows` job runs the same gate on
`windows-latest`; both jobs are green.

## Changes

### `build: pin checked-out line endings to LF`

The repository has no `.gitattributes`. With `core.autocrlf=true` — the common Windows default —
git rewrites every file to CRLF on checkout and Biome then reports a formatting error for
essentially the whole tree: 359 errors across 363 files, none of them real.

### `fix(release): create the release workspace with fs.mkdirSync`

`scripts/release/deploy.mjs` shelled out to POSIX `mkdir -p`, which does not exist on Windows
(`spawnSync mkdir ENOENT`). `fs.mkdirSync(source, { recursive: true })` is equivalent, drops a
subprocess and has no PATH dependency on any platform.

### `fix(scripts): preserve argv when launching pnpm and wrangler on Windows`

`pnpm` and `wrangler` are `.cmd` shims on Windows, which `CreateProcess` cannot execute, so every
`spawnSync("pnpm", …)` failed before the child started.

The earlier revision of this PR passed them through the shell with hand-rolled quoting. You were
right to reject that, and it was measurably wrong — cmd.exe expands `%VAR%` *inside* quoted
arguments, which no amount of quoting prevents:

```
in : literal %USERNAME% here
out: literal myexy here
```

`executeSql` is a general helper, so a `LIKE '%@example.com'` clause routed through it would have
been corrupted silently.

`scripts/shell.mjs` now wraps `cross-spawn`, which resolves the shim and builds the command line
itself with `shell` off, so argv reaches the child unchanged. `cross-spawn@7.0.6` was already in
the lockfile transitively; this promotes it to a direct devDependency alongside the other
deploy-time tooling such as `wrangler`.

`test/unit/scripts/shell.test.mjs` asserts the property rather than the quoting: it spawns a child
that prints its own argv and compares. The cases cover whitespace, `& | > ^ ( )`, `%VAR%` and
`$HOME`, and SQL containing quotes and `%` wildcards. They run on every platform.

Verified beyond the unit tests: `pnpm hqbase doctor` drives real `wrangler` invocations through
the new runner on Windows, and `DEP0190` no longer appears.

### `fix(release): keep other accounts out of the temporary secrets directory`

The concern was correct and not theoretical. The local install path sets `WORKERS_CI=1`, so it
does write `BETTER_AUTH_SECRET` and the VAPID keys to a temporary file, and on Windows
`mode: 0o600` maps only the read-only bit.

`wrangler deploy --secrets-file` takes a path only — stdin exists for `wrangler secret bulk` but
not here, and splitting the deploy would leave a version without its required secrets — so the
file is unavoidable and the directory has to be protected instead.

`scripts/secure-directory.mjs` adds `createRestrictedDirectory`, which creates the directory,
restricts it (`icacls /inheritance:r /grant:r` on Windows, `chmod 0700` on POSIX), verifies the
result, and deletes the directory and throws if the restriction cannot be confirmed. Nothing is
written into an unverified directory.

**On what "restricted" means.** My first attempt required the directory to carry exactly one
access control entry naming the current account. That is unachievable on Windows and the Windows
CI job proved it — on the runner the directory ends up as:

```
D:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;LA)
```

`/inheritance:r` removes *inherited* entries; SYSTEM and Administrators were explicit and stayed.
More importantly, excluding them is not a meaningful goal: a member of Administrators can read the
file regardless of its ACL by taking ownership or with `SeBackupPrivilege`, and SYSTEM is the
trusted computing base. POSIX `0700` does not keep root out either.

So the check now enforces the guarantee that is both achievable and equivalent to `0700`: **no
account other than the current one and the machine's trusted principals has access.** Anything
else — an inherited user entry, a stray `Everyone` grant — fails the check and the directory is
destroyed unused.

Two details the CI job surfaced that are worth knowing: SDDL names well-known principals by
two-letter alias (`SY`, `BA`, `LA`) rather than by SID, and GitHub's Windows runners execute as the
built-in Administrator (RID 500), which SDDL writes as `LA`. Both are handled explicitly.

The assertion in `deploy.test.mjs` is no longer skipped on Windows: it checks the file mode on
POSIX and that no other account has access to the containing directory on Windows.

### `ci: run the quality gate on Windows`

Adds a `quality-windows` job running the same `pnpm check` and `pnpm deploy:dry-run`. It is a
separate job rather than a matrix on `quality`, so the existing job name — and any branch
protection referring to it — is unchanged.

This job earned its place immediately: it caught the over-strict ACL invariant above, which does
not reproduce on Linux and does not reproduce on a normal Windows developer machine either.

## Affected repositories

`HQBase/hqbase` only. No specification change — none of this alters product behaviour.

## Local checks

| Check | Result |
|---|---|
| `pnpm install` | pass |
| `pnpm db:migrate:local` | pass, 9 migrations |
| `pnpm check` | pass — Biome, typecheck, 288 unit + 28 integration tests, coverage, architecture, build |
| `pnpm deploy:dry-run` | pass |

Windows 11 Pro 26200, Node 24.19.0, pnpm 11.7.0. The same gate was run on `windows-latest` and
`ubuntu-latest` before this revision was pushed.

## Database, security, recovery

- No schema or migration changes.
- Security: the temporary secrets directory is now restricted and verified on both platforms
  rather than relying on a `chmod` that Windows ignores, and the argv change removes unescaped
  command-line concatenation entirely. Neither weakens an existing boundary. The guarantee is
  stated explicitly in the code: no other *user* can reach the secrets, which is what `0700`
  provides on POSIX.
- No recovery considerations.
