### PR TITLE
Release HQBase 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.1.0
+
+- Add a stable, versioned Mail API for mailboxes, messages, conversations, attachments, drafts,
+  sending, and replies. API clients can use audience-bound OAuth bearer tokens, while the web app
+  uses the same `/api/v1` routes with its existing session cookie.
+- Publish deployment-local `AGENTS.md`, OpenAPI 3.1, and Postman artifacts so people and AI agents
+  can discover, inspect, and test each installation's API without an HQBase-specific SDK.
+- Add OAuth Device Authorization for agents and command-line clients, including normal-browser
+  approval, short-lived single-use codes, scoped access, and persistent D1-backed verification
+  rate limits.
+- Expand **Connect AI agent** to offer both the existing MCP connection and the deployment's
+  `AGENTS.md` instructions, while keeping REST and MCP tokens isolated by audience.
+- Add deterministic local D1 reset and seed commands for a ready-to-use development workspace.
+- Improve Windows installation and release-script compatibility, protect temporary secret files,
+  route Worker-owned paths ahead of the SPA fallback, and exercise the quality gate on Windows CI.
+
 ## 1.0.1
 
 - Preserve invitation password setup links so `/set-password?token=...` reaches the password form

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hqbase",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary

- bump the committed HQBase version from `1.0.1` to `1.1.0`
- keep the minimum supported upgrade version at `1.0.0`
- add public release notes for all changes merged since `1.0.1`

## Release highlights

- stable `/api/v1` Mail API with session-cookie and audience-bound OAuth access
- deployment-local `AGENTS.md`, OpenAPI 3.1, and Postman artifacts
- OAuth Device Authorization for agents and command-line clients
- persistent D1-backed device-verification rate limiting and isolated REST/MCP audiences
- deterministic local D1 reset and seed workflows
- Windows installer, release-script, temporary-secret, routing, and CI improvements

This is a backwards-compatible feature release, so the minor version advances to `1.1.0` and direct upgrades from `1.0.0` remain supported.

The lightweight changes/delta endpoint is not part of this release, so this PR does not close issue #11.

## Validation

- `pnpm check`
- `pnpm deploy:dry-run`

The signed-release workflow is intentionally not run from this branch. After this PR merges and `main` is green, an authorized maintainer can dispatch it from `main`; it will package and sign the exact commit, upgrade disposable staging from the previous stable release, run staging E2E, and publish only if the candidate passes.
