### PR TITLE
Fix N-1 release staging API compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,8 @@ jobs:
           exit 1
       - name: Bootstrap persistent N-1 staging data
         if: needs.candidate.outputs.previous_tag != ''
+        env:
+          HQBASE_STAGING_MAIL_API_BASE_PATH: /api
         run: pnpm test:e2e:staging:lifecycle
       - name: Apply the exact signed candidate
         run: |

--- a/test/e2e/staging/lifecycle.spec.ts
+++ b/test/e2e/staging/lifecycle.spec.ts
@@ -5,6 +5,7 @@ import {
   request as playwrightRequest,
   test
 } from "@playwright/test";
+import { stagingMailApiPath } from "./mail-api-path";
 
 const email = required("HQBASE_STAGING_OWNER_EMAIL");
 const password = required("HQBASE_STAGING_OWNER_PASSWORD");
@@ -154,7 +155,7 @@ test("Track 1 enforces read-only mailbox access and exposes operator diagnostics
     login.ok(),
     `Owner API sign-in failed (${login.status()}): ${await login.text()}`
   ).toBeTruthy();
-  const mailboxesResponse = await request.get("/api/v1/mailboxes");
+  const mailboxesResponse = await request.get(stagingMailApiPath("/mailboxes"));
   expect(mailboxesResponse.ok()).toBeTruthy();
   const mailboxes = (await mailboxesResponse.json()) as Array<{ id: string; address: string }>;
   const mailbox = mailboxes.find((item) => item.address === sender);
@@ -195,13 +196,13 @@ test("Track 1 enforces read-only mailbox access and exposes operator diagnostics
       });
       expect(passwordSetup.ok(), await passwordSetup.text()).toBeTruthy();
     }
-    const visible = await memberRequest.get("/api/v1/mailboxes");
+    const visible = await memberRequest.get(stagingMailApiPath("/mailboxes"));
     expect((await visible.json()) as Array<{ id: string }>).toEqual([
       expect.objectContaining({ id: mailbox?.id })
     ]);
     const revoke = await request.delete(`/api/mailbox-grants/${mailbox?.id}/${member.id}`);
     expect(revoke.status()).toBe(204);
-    const hidden = await memberRequest.get("/api/v1/mailboxes");
+    const hidden = await memberRequest.get(stagingMailApiPath("/mailboxes"));
     expect(hidden.ok()).toBeTruthy();
     expect(await hidden.json()).toEqual([]);
   } finally {

--- a/test/e2e/staging/mail-api-path.ts
+++ b/test/e2e/staging/mail-api-path.ts
@@ -1,0 +1,12 @@
+const supportedBasePaths = new Set(["/api", "/api/v1"]);
+
+export function stagingMailApiPath(
+  path: string,
+  basePath = process.env.HQBASE_STAGING_MAIL_API_BASE_PATH ?? "/api/v1"
+): string {
+  if (!supportedBasePaths.has(basePath)) {
+    throw new Error("HQBASE_STAGING_MAIL_API_BASE_PATH must be /api or /api/v1.");
+  }
+  if (!path.startsWith("/")) throw new Error("Staging Mail API paths must start with /.");
+  return `${basePath}${path}`;
+}

--- a/test/unit/e2e/staging-mail-api-path.test.ts
+++ b/test/unit/e2e/staging-mail-api-path.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { stagingMailApiPath } from "../../e2e/staging/mail-api-path";
+
+const lifecycleSpec = readFileSync(
+  new URL("../../e2e/staging/lifecycle.spec.ts", import.meta.url),
+  "utf8"
+);
+const releaseWorkflow = readFileSync(
+  new URL("../../../.github/workflows/release.yml", import.meta.url),
+  "utf8"
+);
+
+describe("staging Mail API path", () => {
+  it("uses the versioned API for candidate staging by default", () => {
+    expect(stagingMailApiPath("/mailboxes")).toBe("/api/v1/mailboxes");
+  });
+
+  it("supports the compatibility alias while bootstrapping the previous release", () => {
+    expect(stagingMailApiPath("/mailboxes", "/api")).toBe("/api/mailboxes");
+  });
+
+  it("rejects unsupported base paths and malformed route paths", () => {
+    expect(() => stagingMailApiPath("/mailboxes", "/api/v2")).toThrow(
+      "HQBASE_STAGING_MAIL_API_BASE_PATH must be /api or /api/v1."
+    );
+    expect(() => stagingMailApiPath("mailboxes")).toThrow(
+      "Staging Mail API paths must start with /."
+    );
+  });
+
+  it("uses the legacy alias only for the N-1 bootstrap workflow step", () => {
+    expect(lifecycleSpec).not.toContain('"/api/v1/mailboxes"');
+    const bootstrapStart = releaseWorkflow.indexOf(
+      "      - name: Bootstrap persistent N-1 staging data"
+    );
+    const nextStep = releaseWorkflow.indexOf("\n      - name:", bootstrapStart + 1);
+    const bootstrapStep = releaseWorkflow.slice(bootstrapStart, nextStep);
+
+    expect(bootstrapStart).toBeGreaterThan(-1);
+    expect(bootstrapStep).toContain("HQBASE_STAGING_MAIL_API_BASE_PATH: /api");
+    expect(bootstrapStep).toContain("run: pnpm test:e2e:staging:lifecycle");
+  });
+});


### PR DESCRIPTION
## Summary

- make the staging Mail API base path explicit and validated
- use the cookie-only `/api` compatibility alias only while bootstrapping the previous stable release
- keep normal staging and post-upgrade checks on `/api/v1`
- add regression coverage for endpoint selection and release-workflow wiring

## Root cause

The first signed `1.1.0` release attempt correctly installed `1.0.1`, then ran the current lifecycle test to create persistent N-1 data. That test had been updated to call `/api/v1/mailboxes`, but the versioned API does not exist until `1.1.0`, so bootstrap failed before the signed candidate was applied.

The failed workflow deleted its draft release and destroyed its disposable resources. No `v1.1.0` tag or public release was created.

Failed release run: https://github.com/HQBase/hqbase/actions/runs/31903444023

## Safety

The compatibility override is scoped to the single pre-upgrade bootstrap step. Candidate staging continues to default to `/api/v1`, so the release still proves that the new public API works after upgrading.

## Validation

- `pnpm exec vitest run --config vitest.config.ts test/unit/e2e/staging-mail-api-path.test.ts`
- `pnpm check`
- `pnpm deploy:dry-run`

After merge, the release procedure will rerun manual staging E2E and then the complete signed-release workflow from `main`.
