### PR TITLE
Stabilize Windows Worker integration tests

### DIFF
--- a/test/integration/worker/current-migrations.ts
+++ b/test/integration/worker/current-migrations.ts
@@ -1,0 +1,10 @@
+import { applyD1Migrations, type D1Migration, env } from "cloudflare:test";
+
+type MigrationTestEnv = Env & {
+  TEST_MIGRATIONS: D1Migration[];
+};
+
+export async function applyCurrentMigrations(): Promise<void> {
+  const testEnv = env as MigrationTestEnv;
+  await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+}

--- a/test/integration/worker/local-seed.test.ts
+++ b/test/integration/worker/local-seed.test.ts
@@ -2,16 +2,8 @@ import { env, SELF } from "cloudflare:test";
 import { hashPassword } from "better-auth/crypto";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import initialMigration from "../../../migrations/0001_initial.sql?raw";
-import workspaceMigration from "../../../migrations/0002_workspace.sql?raw";
-import oauthResourcesMigration from "../../../migrations/0003_oauth_resources.sql?raw";
-import conversationMigration from "../../../migrations/0004_conversations.sql?raw";
-import threadRebuildMigration from "../../../migrations/0005_rebuild_threads.sql?raw";
-import pushMigration from "../../../migrations/0006_push_notifications.sql?raw";
-import userMailPreferencesMigration from "../../../migrations/0007_user_mail_preferences.sql?raw";
-import userOnboardingMigration from "../../../migrations/0008_user_onboarding.sql?raw";
-import loginEmailDomainMigration from "../../../migrations/0009_login_email_domain_isolation.sql?raw";
 import { buildSeedSql } from "../../../scripts/local-seed-fixture.mjs";
+import { applyCurrentMigrations } from "./current-migrations";
 import { migrationStatements } from "./migration-statements";
 
 const origin = "https://hqbase.test";
@@ -19,19 +11,7 @@ const password = "local-seed-password";
 
 describe("local database seed fixture", () => {
   beforeAll(async () => {
-    for (const migration of [
-      initialMigration,
-      workspaceMigration,
-      oauthResourcesMigration,
-      conversationMigration,
-      threadRebuildMigration,
-      pushMigration,
-      userMailPreferencesMigration,
-      userOnboardingMigration,
-      loginEmailDomainMigration
-    ]) {
-      await applyStatements(migration);
-    }
+    await applyCurrentMigrations();
     await applyStatements(
       buildSeedSql(await hashPassword(password), new Date("2026-08-14T18:00:00.000Z"))
     );

--- a/test/integration/worker/mail-api.test.ts
+++ b/test/integration/worker/mail-api.test.ts
@@ -1,17 +1,9 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
 import mailApiOpenApi from "../../../api/hqbase-mail-api-v1.openapi.json";
-import initialMigration from "../../../migrations/0001_initial.sql?raw";
-import workspaceMigration from "../../../migrations/0002_workspace.sql?raw";
-import oauthResourcesMigration from "../../../migrations/0003_oauth_resources.sql?raw";
-import conversationMigration from "../../../migrations/0004_conversations.sql?raw";
-import threadRebuildMigration from "../../../migrations/0005_rebuild_threads.sql?raw";
-import userOnboardingMigration from "../../../migrations/0008_user_onboarding.sql?raw";
-import loginEmailDomainMigration from "../../../migrations/0009_login_email_domain_isolation.sql?raw";
-import deviceAuthorizationMigration from "../../../migrations/0010_oauth_device_authorization.sql?raw";
 import { createAuth } from "../../../worker/auth/auth";
+import { applyCurrentMigrations } from "./current-migrations";
 import { tokenRow } from "./mail-api-token-fixture";
-import { migrationStatements } from "./migration-statements";
 
 const origin = "https://hqbase.test";
 const apiResource = `${origin}/api/v1`;
@@ -26,18 +18,7 @@ let userId = "";
 
 describe("HQBase Mail API v1", () => {
   beforeAll(async () => {
-    for (const migration of [
-      initialMigration,
-      workspaceMigration,
-      oauthResourcesMigration,
-      conversationMigration,
-      threadRebuildMigration,
-      userOnboardingMigration,
-      loginEmailDomainMigration,
-      deviceAuthorizationMigration
-    ]) {
-      await applyMigration(migration);
-    }
+    await applyCurrentMigrations();
 
     const auth = createAuth(env, new Request(`${origin}/api/auth/sign-up/email`));
     const signUp = await auth.handler(
@@ -438,10 +419,4 @@ function extractSessionCookie(response: Response): string {
   const match = serialized.match(/(?:^|,\s*)((?:__Secure-)?better-auth\.session_token=[^;,]+)/);
   if (!match?.[1]) throw new Error("Session cookie was not returned.");
   return match[1];
-}
-
-async function applyMigration(source: string): Promise<void> {
-  for (const statement of migrationStatements(source)) {
-    await env.DB.prepare(statement).run();
-  }
 }

--- a/test/integration/worker/mcp.test.ts
+++ b/test/integration/worker/mcp.test.ts
@@ -1,16 +1,8 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import initialMigration from "../../../migrations/0001_initial.sql?raw";
-import workspaceMigration from "../../../migrations/0002_workspace.sql?raw";
-import oauthResourcesMigration from "../../../migrations/0003_oauth_resources.sql?raw";
-import conversationMigration from "../../../migrations/0004_conversations.sql?raw";
-import threadRebuildMigration from "../../../migrations/0005_rebuild_threads.sql?raw";
-import userOnboardingMigration from "../../../migrations/0008_user_onboarding.sql?raw";
-import loginEmailDomainMigration from "../../../migrations/0009_login_email_domain_isolation.sql?raw";
-import deviceAuthorizationMigration from "../../../migrations/0010_oauth_device_authorization.sql?raw";
 import { hashOAuthToken } from "../../../worker/auth/oauth-token";
-import { migrationStatements } from "./migration-statements";
+import { applyCurrentMigrations } from "./current-migrations";
 
 const origin = "https://hqbase.test";
 const userId = "usr_mcp_member";
@@ -30,18 +22,7 @@ const readToolNames = [
 
 describe("HQBase MCP server", () => {
   beforeAll(async () => {
-    for (const migration of [
-      initialMigration,
-      workspaceMigration,
-      oauthResourcesMigration,
-      conversationMigration,
-      threadRebuildMigration,
-      userOnboardingMigration,
-      loginEmailDomainMigration,
-      deviceAuthorizationMigration
-    ]) {
-      await applyMigration(migration);
-    }
+    await applyCurrentMigrations();
     const now = new Date();
     const storedReadToken = await hashOAuthToken("mcp-hqbase-read-token");
     const storedReadProfileFullToken = await hashOAuthToken("mcp-hqbase-read-profile-full-token");
@@ -510,10 +491,4 @@ function mcpRequest(body: unknown, accessToken?: string, endpoint = "/mcp"): Pro
     headers,
     method: "POST"
   });
-}
-
-async function applyMigration(source: string): Promise<void> {
-  for (const statement of migrationStatements(source)) {
-    await env.DB.prepare(statement).run();
-  }
 }

--- a/test/integration/worker/notifications.test.ts
+++ b/test/integration/worker/notifications.test.ts
@@ -1,14 +1,6 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import initialMigration from "../../../migrations/0001_initial.sql?raw";
-import workspaceMigration from "../../../migrations/0002_workspace.sql?raw";
-import oauthResourcesMigration from "../../../migrations/0003_oauth_resources.sql?raw";
-import conversationMigration from "../../../migrations/0004_conversations.sql?raw";
-import threadRebuildMigration from "../../../migrations/0005_rebuild_threads.sql?raw";
-import pushMigration from "../../../migrations/0006_push_notifications.sql?raw";
-import userOnboardingMigration from "../../../migrations/0008_user_onboarding.sql?raw";
-import loginEmailDomainMigration from "../../../migrations/0009_login_email_domain_isolation.sql?raw";
 import { createAuth } from "../../../worker/auth/auth";
 import {
   countUnreadMessages,
@@ -16,22 +8,11 @@ import {
   removePushSubscription,
   savePushSubscription
 } from "../../../worker/features/notifications/queries";
-import { migrationStatements } from "./migration-statements";
+import { applyCurrentMigrations } from "./current-migrations";
 
 describe("notification persistence", () => {
   beforeAll(async () => {
-    for (const migration of [
-      initialMigration,
-      workspaceMigration,
-      oauthResourcesMigration,
-      conversationMigration,
-      threadRebuildMigration,
-      pushMigration,
-      userOnboardingMigration,
-      loginEmailDomainMigration
-    ]) {
-      await applyMigration(migration);
-    }
+    await applyCurrentMigrations();
     const now = "2026-07-29T12:00:00.000Z";
     await env.DB.batch([
       env.DB.prepare(
@@ -212,12 +193,6 @@ async function insertMessage(
   )
     .bind(id, mailboxId, folder, now, readAt, now, now)
     .run();
-}
-
-async function applyMigration(source: string): Promise<void> {
-  for (const statement of migrationStatements(source)) {
-    await env.DB.prepare(statement).run();
-  }
 }
 
 function extractSessionCookie(response: Response): string {

--- a/test/integration/worker/oauth-device.test.ts
+++ b/test/integration/worker/oauth-device.test.ts
@@ -1,14 +1,9 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import initialMigration from "../../../migrations/0001_initial.sql?raw";
-import workspaceMigration from "../../../migrations/0002_workspace.sql?raw";
-import oauthResourcesMigration from "../../../migrations/0003_oauth_resources.sql?raw";
-import userOnboardingMigration from "../../../migrations/0008_user_onboarding.sql?raw";
-import deviceAuthorizationMigration from "../../../migrations/0010_oauth_device_authorization.sql?raw";
 import { createAuth } from "../../../worker/auth/auth";
 import { deviceCodeGrantType } from "../../../worker/auth/device-authorization";
-import { migrationStatements } from "./migration-statements";
+import { applyCurrentMigrations } from "./current-migrations";
 
 const origin = "https://hqbase.test";
 const apiResource = `${origin}/api/v1`;
@@ -20,15 +15,7 @@ let otherCookie = "";
 
 describe("OAuth Device Authorization Grant", () => {
   beforeAll(async () => {
-    for (const migration of [
-      initialMigration,
-      workspaceMigration,
-      oauthResourcesMigration,
-      userOnboardingMigration,
-      deviceAuthorizationMigration
-    ]) {
-      await applyMigration(migration);
-    }
+    await applyCurrentMigrations();
 
     const owner = await signUp("device-owner@login.example", "Device Owner");
     ownerCookie = owner.cookie;
@@ -315,10 +302,4 @@ function extractSessionCookie(response: Response): string {
   const match = serialized.match(/(?:^|,\s*)((?:__Secure-)?better-auth\.session_token=[^;,]+)/);
   if (!match?.[1]) throw new Error("Session cookie was not returned.");
   return match[1];
-}
-
-async function applyMigration(source: string): Promise<void> {
-  for (const statement of migrationStatements(source)) {
-    await env.DB.prepare(statement).run();
-  }
 }

--- a/test/integration/worker/users.test.ts
+++ b/test/integration/worker/users.test.ts
@@ -1,36 +1,15 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import initialMigration from "../../../migrations/0001_initial.sql?raw";
-import workspaceMigration from "../../../migrations/0002_workspace.sql?raw";
-import oauthResourcesMigration from "../../../migrations/0003_oauth_resources.sql?raw";
-import conversationMigration from "../../../migrations/0004_conversations.sql?raw";
-import threadRebuildMigration from "../../../migrations/0005_rebuild_threads.sql?raw";
-import pushMigration from "../../../migrations/0006_push_notifications.sql?raw";
-import userMailPreferencesMigration from "../../../migrations/0007_user_mail_preferences.sql?raw";
-import userOnboardingMigration from "../../../migrations/0008_user_onboarding.sql?raw";
-import loginEmailDomainMigration from "../../../migrations/0009_login_email_domain_isolation.sql?raw";
 import { createAuth } from "../../../worker/auth/auth";
-import { migrationStatements } from "./migration-statements";
+import { applyCurrentMigrations } from "./current-migrations";
 
 const origin = "https://hqbase.test";
 let ownerCookie = "";
 
 describe("workspace user onboarding", () => {
   beforeAll(async () => {
-    for (const migration of [
-      initialMigration,
-      workspaceMigration,
-      oauthResourcesMigration,
-      conversationMigration,
-      threadRebuildMigration,
-      pushMigration,
-      userMailPreferencesMigration,
-      userOnboardingMigration,
-      loginEmailDomainMigration
-    ]) {
-      await applyMigration(migration);
-    }
+    await applyCurrentMigrations();
 
     const owner = await createAuth(env, new Request(`${origin}/api/auth/sign-up/email`)).handler(
       new Request(`${origin}/api/auth/sign-up/email`, {
@@ -313,10 +292,4 @@ function extractSessionCookie(response: Response): string {
   const match = serialized.match(/(?:^|,\s*)((?:__Secure-)?better-auth\.session_token=[^;,]+)/);
   if (!match?.[1]) throw new Error("Session cookie was not returned.");
   return match[1];
-}
-
-async function applyMigration(source: string): Promise<void> {
-  for (const statement of migrationStatements(source)) {
-    await env.DB.prepare(statement).run();
-  }
 }

--- a/vitest.worker.config.ts
+++ b/vitest.worker.config.ts
@@ -1,33 +1,42 @@
-import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { fileURLToPath } from "node:url";
+import { cloudflareTest, readD1Migrations } from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 
-export default defineConfig({
-  plugins: [
-    cloudflareTest({
-      wrangler: {
-        configPath: "./wrangler.jsonc"
-      },
-      miniflare: {
-        bindings: {
-          BETTER_AUTH_SECRET: "integration-auth-secret-A7x9Q2m4V8p6L1s3",
-          VAPID_PRIVATE_KEY: "integration-vapid-private-key",
-          VAPID_PUBLIC_KEY: "integration-vapid-public-key"
+export default defineConfig(async () => {
+  const migrations = await readD1Migrations(
+    fileURLToPath(new URL("./migrations", import.meta.url))
+  );
+
+  return {
+    plugins: [
+      cloudflareTest({
+        wrangler: {
+          configPath: "./wrangler.jsonc"
         },
-        serviceBindings: {
-          ASSETS: async () => new Response("Not found", { status: 404 })
+        miniflare: {
+          bindings: {
+            BETTER_AUTH_SECRET: "integration-auth-secret-A7x9Q2m4V8p6L1s3",
+            TEST_MIGRATIONS: migrations,
+            VAPID_PRIVATE_KEY: "integration-vapid-private-key",
+            VAPID_PUBLIC_KEY: "integration-vapid-public-key"
+          },
+          serviceBindings: {
+            ASSETS: async () => new Response("Not found", { status: 404 })
+          }
         }
-      }
-    })
-  ],
-  test: {
-    deps: {
-      optimizer: {
-        ssr: {
-          enabled: true,
-          include: ["sanitize-html"]
+      })
+    ],
+    test: {
+      deps: {
+        optimizer: {
+          ssr: {
+            enabled: true,
+            include: ["sanitize-html"]
+          }
         }
-      }
-    },
-    include: ["test/integration/worker/**/*.test.ts"]
-  }
+      },
+      hookTimeout: 30_000,
+      include: ["test/integration/worker/**/*.test.ts"]
+    }
+  };
 });


### PR DESCRIPTION
## Summary

- load the current D1 migrations once in the Vitest configuration and apply them through Cloudflare's batched test helper
- keep the explicit migration-history suites unchanged
- use a finite 30-second Worker hook timeout for slower Windows runners

## Root cause

The Windows quality job intermittently exceeded Vitest's 10-second default while several Worker suites each applied about 129 D1 statements one request at a time. The same test tree passed on the pull request and failed after merge, which points to a load-sensitive test-harness failure instead of a product regression.

## Verification

- [x] `pnpm check`
- [x] `pnpm deploy:dry-run`
- [x] Worker integration suite: 10 files and 46 tests passed; 2.98 seconds of test time within a 13.12-second run
