### PR TITLE
Prepare HQBase 1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.1.1
 
 - Publish the deployment-local Mail API instructions as a valid Agent Skill at
   `/skills/hqbase-mail/SKILL.md`, add Copy and Download Skill actions, and redirect the earlier

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hqbase",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump HQBase from 1.1.0 to 1.1.1.
- Finalize the release note for the deployment-local Mail API Agent Skill.
- Publish the Copy Skill and Download Skill actions and the compatibility redirects added in #16.

## Why

The signed stable channel still points to 1.1.0, which predates the Agent Skill fix. The implementation is already merged on `main`; this PR contains only the release metadata needed for the next immutable signed release.

## User impact

After the signed release completes, HQBase owners can update through the normal stable channel and give agents a valid `SKILL.md` instruction file from their own deployment.

## Validation

- [x] `CI=true pnpm check`
- [x] `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-release-1.1.1-wrangler.log pnpm deploy:dry-run`