### PR TITLE
Add Discord release notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,6 +333,20 @@ jobs:
               throw new Error("Published artifact does not match the signed manifest.");
             }
           '
+      - name: Post complete release notes to Discord
+        id: discord_release
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+        run: |
+          notes_file="$RUNNER_TEMP/hqbase-release-notes.md"
+          gh release view "v${HQBASE_RELEASE_VERSION}" --json body --jq .body > "$notes_file"
+          node scripts/release/notify-discord.mjs "$notes_file"
+      - name: Report a Discord delivery failure
+        if: steps.discord_release.outcome == 'failure'
+        run: >-
+          echo "::warning title=Discord release notification failed::The signed release is valid,
+          but its Discord message was not delivered."
 
   cleanup-failed-draft:
     needs: [candidate, staging]

--- a/scripts/release/notify-discord.mjs
+++ b/scripts/release/notify-discord.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const DISCORD_EMBED_DESCRIPTION_LIMIT = 4096;
+
+const DISCORD_COLOR = 0xff8a3d;
+const MAX_ATTEMPTS = 3;
+const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+export function splitDiscordMarkdown(markdown, limit = DISCORD_EMBED_DESCRIPTION_LIMIT) {
+  const notes = markdown.trim();
+  if (!notes) throw new Error("Release notes are empty.");
+  if (!Number.isInteger(limit) || limit < 1) throw new Error("Discord message limit is invalid.");
+
+  const chunks = [];
+  let remaining = notes;
+  while (remaining.length > limit) {
+    const window = remaining.slice(0, limit);
+    const minimumBreak = Math.floor(limit / 2);
+    const boundaries = [
+      boundaryAfter(window, "\n\n"),
+      boundaryAfter(window, "\n"),
+      boundaryAfter(window, " ")
+    ];
+    const end = boundaries.find((boundary) => boundary >= minimumBreak) ?? limit;
+    chunks.push(remaining.slice(0, end));
+    remaining = remaining.slice(end);
+  }
+  if (remaining) chunks.push(remaining);
+  return chunks;
+}
+
+export function buildDiscordReleaseMessages({ notes, repository, version, publishedAt }) {
+  if (!VERSION_PATTERN.test(version)) throw new Error("Release version must be semantic.");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error("GitHub repository must use owner/name format.");
+  }
+
+  const chunks = splitDiscordMarkdown(notes);
+  const releaseUrl = `https://github.com/${repository}/releases/tag/v${version}`;
+  const timestamp = publishedAt ?? new Date().toISOString();
+
+  return chunks.map((description, index) => {
+    const part = chunks.length > 1 ? ` (${index + 1}/${chunks.length})` : "";
+    return {
+      allowed_mentions: { parse: [] },
+      embeds: [
+        {
+          title:
+            index === 0
+              ? `HQBase ${version} is available${part}`
+              : `HQBase ${version} changes${part}`,
+          url: releaseUrl,
+          description,
+          color: DISCORD_COLOR,
+          footer: { text: "Signed stable release" },
+          timestamp
+        }
+      ]
+    };
+  });
+}
+
+export async function sendDiscordRelease({
+  fetchImpl = globalThis.fetch,
+  notes,
+  repository,
+  sleep = defaultSleep,
+  version,
+  webhookUrl
+}) {
+  const url = discordWebhookUrl(webhookUrl);
+  const messages = buildDiscordReleaseMessages({ notes, repository, version });
+
+  for (const message of messages) {
+    await postDiscordMessage({ fetchImpl, message, sleep, url });
+  }
+
+  return messages.length;
+}
+
+async function postDiscordMessage({ fetchImpl, message, sleep, url }) {
+  let lastError;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    let response;
+    try {
+      response = await fetchImpl(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(message),
+        redirect: "error"
+      });
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error("Discord notification failed.");
+      if (attempt < MAX_ATTEMPTS) await sleep(500 * 2 ** (attempt - 1));
+      continue;
+    }
+
+    if (response.ok) return;
+    lastError = new Error(
+      `Discord rejected the release notification with HTTP ${response.status}.`
+    );
+    if (response.status !== 429 && response.status < 500) throw lastError;
+    if (attempt < MAX_ATTEMPTS) {
+      await sleep(await retryDelay(response, attempt));
+    }
+  }
+  throw lastError ?? new Error("Discord notification failed.");
+}
+
+function boundaryAfter(value, separator) {
+  const index = value.lastIndexOf(separator);
+  return index < 0 ? -1 : index + separator.length;
+}
+
+function discordWebhookUrl(value) {
+  if (!value) throw new Error("DISCORD_WEBHOOK_URL is required.");
+  const url = new URL(value);
+  const officialHost =
+    url.hostname === "discord.com" ||
+    url.hostname.endsWith(".discord.com") ||
+    url.hostname === "discordapp.com" ||
+    url.hostname.endsWith(".discordapp.com");
+  if (
+    url.protocol !== "https:" ||
+    !officialHost ||
+    !/^\/api(?:\/v\d+)?\/webhooks\//.test(url.pathname)
+  ) {
+    throw new Error("DISCORD_WEBHOOK_URL must be an official Discord webhook URL.");
+  }
+  url.searchParams.set("wait", "true");
+  return url;
+}
+
+async function retryDelay(response, attempt) {
+  try {
+    const body = await response.json();
+    if (typeof body.retry_after === "number" && body.retry_after >= 0) {
+      return Math.ceil(body.retry_after * 1000);
+    }
+  } catch {
+    // Discord error responses do not always contain JSON.
+  }
+  return 500 * 2 ** (attempt - 1);
+}
+
+function defaultSleep(milliseconds) {
+  return new Promise((complete) => setTimeout(complete, milliseconds));
+}
+
+export async function main(argv = process.argv.slice(2), environment = process.env) {
+  const notesFile = argv[0];
+  if (!notesFile) throw new Error("A release-notes file is required.");
+  const notes = await readFile(resolve(notesFile), "utf8");
+  const messageCount = await sendDiscordRelease({
+    notes,
+    repository: environment.GITHUB_REPOSITORY ?? "",
+    version: environment.HQBASE_RELEASE_VERSION ?? "",
+    webhookUrl: environment.DISCORD_WEBHOOK_URL
+  });
+  console.log(`Posted the HQBase release notes to Discord in ${messageCount} message(s).`);
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : "Discord notification failed.");
+    process.exitCode = 1;
+  });
+}

--- a/test/unit/scripts/notify-discord.test.mjs
+++ b/test/unit/scripts/notify-discord.test.mjs
@@ -1,0 +1,132 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildDiscordReleaseMessages,
+  DISCORD_EMBED_DESCRIPTION_LIMIT,
+  sendDiscordRelease,
+  splitDiscordMarkdown
+} from "../../../scripts/release/notify-discord.mjs";
+
+const releaseWorkflow = readFileSync(
+  new URL("../../../.github/workflows/release.yml", import.meta.url),
+  "utf8"
+);
+
+describe("Discord release notifications", () => {
+  it("preserves complete release notes while splitting at readable boundaries", () => {
+    const notes = `${"A".repeat(2800)}\n\n${"B".repeat(2800)}\n- final change`;
+    const chunks = splitDiscordMarkdown(notes);
+
+    expect(chunks.join("")).toBe(notes);
+    expect(chunks.length).toBe(2);
+    expect(chunks.every((chunk) => chunk.length <= DISCORD_EMBED_DESCRIPTION_LIMIT)).toBe(true);
+  });
+
+  it("builds numbered embeds with the full changelog and no mentions", () => {
+    const notes = `## Changes\n\n- ${"First change. ".repeat(400)}\n- @everyone stays plain text.`;
+    const messages = buildDiscordReleaseMessages({
+      notes,
+      repository: "HQBase/hqbase",
+      version: "1.2.3",
+      publishedAt: "2026-08-16T00:00:00.000Z"
+    });
+
+    expect(messages.length).toBeGreaterThan(1);
+    expect(messages.map((message) => message.embeds[0].description).join("")).toBe(notes);
+    expect(messages[0]).toMatchObject({
+      allowed_mentions: { parse: [] },
+      embeds: [
+        {
+          title: `HQBase 1.2.3 is available (1/${messages.length})`,
+          url: "https://github.com/HQBase/hqbase/releases/tag/v1.2.3",
+          footer: { text: "Signed stable release" },
+          timestamp: "2026-08-16T00:00:00.000Z"
+        }
+      ]
+    });
+    expect(messages.at(-1).embeds[0].title).toBe(
+      `HQBase 1.2.3 changes (${messages.length}/${messages.length})`
+    );
+  });
+
+  it("requests confirmed delivery and retries a temporary Discord failure", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ retry_after: 0.01 }), {
+          status: 429,
+          headers: { "content-type": "application/json" }
+        })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "message-id" }), { status: 200 }));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      sendDiscordRelease({
+        fetchImpl,
+        notes: "- Complete release note",
+        repository: "HQBase/hqbase",
+        sleep,
+        version: "1.2.3",
+        webhookUrl: "https://discord.com/api/webhooks/123/secret"
+      })
+    ).resolves.toBe(1);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0][0].toString()).toBe(
+      "https://discord.com/api/webhooks/123/secret?wait=true"
+    );
+    expect(JSON.parse(fetchImpl.mock.calls[0][1].body)).toMatchObject({
+      allowed_mentions: { parse: [] },
+      embeds: [{ description: "- Complete release note" }]
+    });
+    expect(sleep).toHaveBeenCalledWith(10);
+  });
+
+  it("does not retry a permanent Discord rejection", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("Unauthorized", { status: 401 }));
+    const sleep = vi.fn();
+
+    await expect(
+      sendDiscordRelease({
+        fetchImpl,
+        notes: "- Complete release note",
+        repository: "HQBase/hqbase",
+        sleep,
+        version: "1.2.3",
+        webhookUrl: "https://discord.com/api/webhooks/123/secret"
+      })
+    ).rejects.toThrow("HTTP 401");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-Discord URLs without sending release notes", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      sendDiscordRelease({
+        fetchImpl,
+        notes: "- Complete release note",
+        repository: "HQBase/hqbase",
+        version: "1.2.3",
+        webhookUrl: "https://example.com/api/webhooks/123/secret"
+      })
+    ).rejects.toThrow("official Discord webhook URL");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("runs only after public release verification and cannot fail a valid release", () => {
+    const verification = releaseWorkflow.indexOf(
+      "Verify public stable asset, signature, and digest"
+    );
+    const notification = releaseWorkflow.indexOf("Post complete release notes to Discord");
+
+    expect(verification).toBeGreaterThan(-1);
+    expect(notification).toBeGreaterThan(verification);
+    expect(releaseWorkflow).toContain(
+      `DISCORD_WEBHOOK_URL: \${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}`
+    );
+    expect(releaseWorkflow.slice(notification)).toContain("continue-on-error: true");
+  });
+});


### PR DESCRIPTION
## Summary

- Post the exact published GitHub Release notes to the configured Discord webhook after public signature and archive verification.
- Split long notes into numbered messages without dropping changelog content.
- Disable Discord mentions, validate the webhook host, request confirmed delivery, and retry temporary failures.
- Report notification failures as warnings so Discord availability cannot invalidate a signed release.
- Add focused tests for formatting, workflow order, delivery, retries, and failure handling.

## Why

Release announcements should represent only verified stable artifacts and should include the complete changelog without requiring a Discord bot or third-party Action.

## Documentation

- [HQBase/hqbase-site#7](https://github.com/HQBase/hqbase-site/pull/7)

## Verification

- `CI=true pnpm check`
- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-discord-release-notifications-wrangler.log pnpm deploy:dry-run`
- Workflow YAML parsing
