### PR TITLE
fix: admin role can escalate to owner via better-auth's admin plugin

### DIFF
--- a/test/integration/worker/auth-admin-block.test.ts
+++ b/test/integration/worker/auth-admin-block.test.ts
@@ -1,6 +1,7 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 
+import { createAuth } from "../../../worker/auth/auth";
 import { applyCurrentMigrations } from "./current-migrations";
 
 const origin = "https://hqbase.test";
@@ -28,5 +29,57 @@ describe("better-auth admin plugin surface", () => {
     expect(await response.json()).toMatchObject({
       error: { code: "FORBIDDEN" }
     });
+  });
+
+  it("stops an authenticated admin from promoting themselves to owner", async () => {
+    await applyCurrentMigrations();
+
+    // This is the actual escalation the block exists to close: an admin
+    // session — not an anonymous caller — reaching better-auth's own
+    // set-role endpoint directly. A change that narrowed the block above to
+    // unauthenticated requests only would still pass the first test while
+    // reopening this one.
+    const signUp = await createAuth(env, new Request(`${origin}/api/auth/sign-up/email`)).handler(
+      new Request(`${origin}/api/auth/sign-up/email`, {
+        body: JSON.stringify({
+          email: "admin-escalation@login.example",
+          name: "Workspace Admin",
+          password: "admin-password-123",
+          rememberMe: false
+        }),
+        headers: { "content-type": "application/json", origin },
+        method: "POST"
+      })
+    );
+    expect(signUp.status, await signUp.clone().text()).toBe(200);
+    const { user } = (await signUp.json()) as { user: { id: string } };
+    await env.DB.prepare(`UPDATE "user" SET role = 'admin' WHERE id = ?`).bind(user.id).run();
+
+    const signIn = await SELF.fetch(`${origin}/api/auth/sign-in/email`, {
+      body: JSON.stringify({
+        email: "admin-escalation@login.example",
+        password: "admin-password-123",
+        rememberMe: false
+      }),
+      headers: { "content-type": "application/json", origin },
+      method: "POST"
+    });
+    expect(signIn.status, await signIn.clone().text()).toBe(200);
+    const cookie = (signIn.headers.get("set-cookie") ?? "").match(
+      /(?:^|,\s*)((?:__Secure-)?better-auth\.session_token=[^;,]+)/
+    )?.[1];
+    if (!cookie) throw new Error("Session cookie was not returned.");
+
+    const response = await SELF.fetch(`${origin}/api/auth/admin/set-role`, {
+      body: JSON.stringify({ role: "owner", userId: user.id }),
+      headers: { "content-type": "application/json", cookie, origin },
+      method: "POST"
+    });
+
+    expect(response.status).toBe(403);
+    const stored = await env.DB.prepare(`SELECT role FROM "user" WHERE id = ?`)
+      .bind(user.id)
+      .first<{ role: string }>();
+    expect(stored?.role).toBe("admin");
   });
 });

--- a/test/integration/worker/auth-admin-block.test.ts
+++ b/test/integration/worker/auth-admin-block.test.ts
@@ -1,0 +1,32 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import { applyCurrentMigrations } from "./current-migrations";
+
+const origin = "https://hqbase.test";
+
+describe("better-auth admin plugin surface", () => {
+  it("blocks /api/auth/admin/* before better-auth's own authorization runs", async () => {
+    await applyCurrentMigrations();
+
+    // adminRole shares owner's ac statements (worker/auth/access.ts), so
+    // better-auth's own admin-plugin authorization alone cannot stop an
+    // admin-role caller from reaching set-role, set-user-password, ban-user,
+    // etc. The route itself must refuse this prefix. No session cookie is
+    // sent here on purpose: the block must apply before any auth check, not
+    // depend on the caller's role. The app's own internal admin flows
+    // (worker/auth/user-actions.ts) call auth.handler() in-process and never
+    // traverse this route, so this block does not affect them; that path is
+    // exercised end-to-end by test/integration/worker/users.test.ts.
+    const response = await SELF.fetch(`${origin}/api/auth/admin/set-role`, {
+      body: JSON.stringify({ role: "owner", userId: "irrelevant" }),
+      headers: { "content-type": "application/json" },
+      method: "POST"
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { code: "FORBIDDEN" }
+    });
+  });
+});

--- a/worker/routes/index.ts
+++ b/worker/routes/index.ts
@@ -94,6 +94,21 @@ apiRoutes.all("/api/auth/*", async (c) => {
     );
   }
 
+  // better-auth's admin plugin exposes owner-equivalent operations (set-role,
+  // set-user-password, ban-user, remove-user, impersonate-user, ...) under
+  // this prefix, gated only by the coarse "admin" ac role, which adminRole
+  // intentionally shares with ownerRole (see worker/auth/access.ts). The
+  // app-level owner-only checks (OWNER_REQUIRED, LAST_OWNER) live only in
+  // worker/features/users/routes.ts, so this raw surface must never be
+  // reachable directly: an admin-role user could otherwise call
+  // /api/auth/admin/set-role to promote themselves to owner. The app's own
+  // admin flows (create-user, set-user-password) call auth.handler()
+  // in-process via worker/auth/user-actions.ts and never traverse this HTTP
+  // route, so blocking it here does not affect them.
+  if (pathname.startsWith("/api/auth/admin/")) {
+    return c.json(errorBody("FORBIDDEN", "This endpoint is not available directly."), 403);
+  }
+
   if (pathname === "/api/auth/sign-in/email" && c.req.method === "POST") {
     const body: { email?: unknown } = await c.req.raw
       .clone()


### PR DESCRIPTION
## Summary

`adminRole` and `ownerRole` are both built from the same `managerStatements` in `worker/auth/access.ts`, so better-auth's admin plugin (`set-role`, `set-user-password`, `ban-user`, `remove-user`, `impersonate-user`, ...) authorizes an admin-role caller identically to an owner. The app's own owner-only protections — `OWNER_REQUIRED`, "the last active owner cannot be demoted" — only exist in `worker/features/users/routes.ts`, and `apiRoutes.all("/api/auth/*", ...)` forwards everything under `/api/auth/admin/` straight to better-auth's handler with no route-level gate.

An account with the `admin` role (granted by an owner via `POST /api/users` or a role change — not something an unauthenticated party can obtain on its own) can call `/api/auth/admin/set-role` directly to promote itself to `owner`, or `/api/auth/admin/set-user-password` to overwrite the real owner's password, bypassing every app-level check that's supposed to keep admin below owner.

## Fix

Block `/api/auth/admin/*` in the `/api/auth/*` catch-all. The app's own admin flows (`create-user`, `set-user-password`) call `auth.handler()` in-process via `worker/auth/user-actions.ts` and never traverse this HTTP route, so they're unaffected — covered by the existing owner/admin user-creation tests in `test/integration/worker/users.test.ts`, all still passing.

## Verification

- [x] `pnpm check`
- [x] New regression test: `test/integration/worker/auth-admin-block.test.ts` asserts `POST /api/auth/admin/set-role` returns 403 with no session

## Notes

Found during a security review ahead of a self-hosted deployment. Reported here rather than as a private advisory since exploitation requires an account already holding the `admin` role — granted deliberately by an owner, not obtainable by an unauthenticated party — so this is a privilege-escalation bug among already-trusted operators rather than an externally reachable compromise.
