### PR TITLE
fix: OAuth consent page cannot verify the requesting client

### DIFF
--- a/app/features/mcp/consent-page.tsx
+++ b/app/features/mcp/consent-page.tsx
@@ -73,6 +73,7 @@ export function OAuthConsentPage(): React.ReactElement {
   }
 
   const clientName = client?.client_name ?? client?.name ?? "OAuth client";
+  const clientUri = client?.uri;
   return (
     <main className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
       <Card className="w-full max-w-md bg-card/70 shadow-none">
@@ -83,6 +84,26 @@ export function OAuthConsentPage(): React.ReactElement {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-5">
+          {client ? (
+            <div className="space-y-1 rounded-md border bg-muted/40 px-3 py-2 text-xs">
+              <p className="text-muted-foreground">
+                Anyone can register a client with this display name. Verify the details below match
+                the integration you expect before allowing access.
+              </p>
+              {clientUri ? (
+                <p className="break-all">
+                  Homepage: <span className="font-medium">{clientUri}</span>
+                </p>
+              ) : (
+                <p className="text-amber-600 dark:text-amber-500">
+                  This client registered no homepage URL.
+                </p>
+              )}
+              <p className="break-all font-mono text-[11px] text-muted-foreground">
+                Client ID: {clientId}
+              </p>
+            </div>
+          ) : null}
           {requestedScopes.length > 0 ? (
             <ul className="space-y-2 text-sm">
               {requestedScopes.map((scope) => (

--- a/app/features/mcp/consent-page.tsx
+++ b/app/features/mcp/consent-page.tsx
@@ -6,8 +6,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 type OAuthClient = {
   client_id?: string;
   client_name?: string;
+  client_uri?: string;
   name?: string;
-  uri?: string;
 };
 
 const scopeDescriptions: Record<string, string> = {
@@ -73,7 +73,7 @@ export function OAuthConsentPage(): React.ReactElement {
   }
 
   const clientName = client?.client_name ?? client?.name ?? "OAuth client";
-  const clientUri = client?.uri;
+  const clientUri = client?.client_uri;
   return (
     <main className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
       <Card className="w-full max-w-md bg-card/70 shadow-none">


### PR DESCRIPTION
## Summary

Dynamic client registration for HQBase's OAuth provider is unauthenticated and open to anyone, so a `client_name` is not a trustworthy identity — an attacker can register a client named e.g. "HQBase Mail Assistant" and send a logged-in user a link to approve it. `OAuthConsentPage` showed only that display name; `client_id` and the client's homepage URL were fetched into state but never rendered, so a user had no way to spot a mismatch before granting mail access.

## Fix

Surface the `client_id` and homepage URL on the consent screen, with a note that the display name alone doesn't prove identity.

## Verification

- [x] `pnpm check`
