### PR TITLE
fix: generated deployment config should disable preview URLs

### DIFF
--- a/scripts/hqbase/config.mjs
+++ b/scripts/hqbase/config.mjs
@@ -21,6 +21,9 @@ export function createWranglerConfig(manifest) {
     $schema: `${rootFromDeployment}/node_modules/wrangler/config-schema.json`,
     name: manifest.worker.name,
     main: `${rootFromDeployment}/worker/index.ts`,
+    // Matches the repository Wrangler configuration: a mail workspace should be
+    // reachable only on its own hostname, not on per-version preview URLs.
+    preview_urls: false,
     compatibility_date: "2026-07-28",
     compatibility_flags: ["nodejs_compat"],
     assets: {

--- a/test/unit/scripts/install.test.mjs
+++ b/test/unit/scripts/install.test.mjs
@@ -74,6 +74,12 @@ describe("HQBase installation resources", () => {
     expect(generated).toEqual(repository);
   });
 
+  it("keeps preview_urls identical to the repository Wrangler configuration", () => {
+    const config = createWranglerConfig(createManifest("qa", {}));
+
+    expect(config.preview_urls).toBe(repositoryWranglerConfig.preview_urls);
+  });
+
   it("fails closed on incomplete customer-managed OAuth configuration", () => {
     expect(() =>
       cloudflareOAuthConfig({


### PR DESCRIPTION
## Summary

The repository's own `wrangler.jsonc` sets `preview_urls: false` so a mail workspace is reachable only on its configured hostname. The wrangler config generated for a customer deployment (`scripts/hqbase/config.mjs`) didn't set it, so wrangler enabled `workers.dev` preview URLs on deploy by default whenever `workers_dev` wasn't otherwise configured.

## Fix

Set `preview_urls: false` in the generated config, matching the repository's own. Added a regression test asserting the generated config's `preview_urls` stays identical to the repository's.

## Verification

- [x] `pnpm check`
