### PR TITLE
Add secure forgot password recovery

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -4,8 +4,11 @@ import { AppShell } from "@/components/layout/app-shell";
 import { Toaster } from "@/components/ui/sonner";
 import { getCurrentUser } from "@/features/auth/api";
 import { LoginPage } from "@/features/auth/login-page";
+import { safeAuthenticationReturnPath } from "@/features/auth/password-recovery";
 import {
+  ForgotPasswordPage,
   InvitationPasswordSetupPage,
+  PasswordResetPage,
   TemporaryPasswordSetupPage
 } from "@/features/auth/password-setup-page";
 import type { CurrentUser } from "@/features/auth/types";
@@ -40,7 +43,7 @@ const DraftComposeDialog = React.lazy(() =>
 );
 
 export function App(): React.ReactElement {
-  const invitationSetup = isPublicAuthenticationPath(window.location.pathname);
+  const publicAuthenticationPath = isPublicAuthenticationPath(window.location.pathname);
   const [setup, setSetup] = React.useState<SetupStatus | null>(null);
   const [user, setUser] = React.useState<CurrentUser | null>(null);
   const [mailboxes, setMailboxes] = React.useState<Mailbox[]>([]);
@@ -109,9 +112,9 @@ export function App(): React.ReactElement {
   }, [loadWorkspace]);
 
   React.useEffect(() => {
-    if (invitationSetup) return;
+    if (publicAuthenticationPath) return;
     void reload();
-  }, [invitationSetup, reload]);
+  }, [publicAuthenticationPath, reload]);
 
   React.useEffect(() => {
     if (!user || isLoading || route.kind !== "settings") return;
@@ -122,11 +125,24 @@ export function App(): React.ReactElement {
     }
   }, [isLoading, navigate, route, user]);
 
-  if (invitationSetup) {
+  if (publicAuthenticationPath) {
     const params = new URLSearchParams(window.location.search);
+    const returnTo = safeAuthenticationReturnPath(params.get("returnTo"), window.location.origin);
+    const page =
+      window.location.pathname === "/forgot-password" ? (
+        <ForgotPasswordPage returnTo={returnTo} />
+      ) : window.location.pathname === "/reset-password" ? (
+        <PasswordResetPage
+          error={params.get("error")}
+          returnTo={returnTo}
+          token={params.get("token")}
+        />
+      ) : (
+        <InvitationPasswordSetupPage error={params.get("error")} token={params.get("token")} />
+      );
     return (
       <>
-        <InvitationPasswordSetupPage error={params.get("error")} token={params.get("token")} />
+        {page}
         <Toaster />
       </>
     );

--- a/app/features/auth/api.ts
+++ b/app/features/auth/api.ts
@@ -46,6 +46,20 @@ export async function signOut(): Promise<void> {
   });
 }
 
+export async function requestPasswordReset(email: string, redirectTo: string): Promise<void> {
+  const response = await fetch("/api/auth/request-password-reset", {
+    body: JSON.stringify({ email: email.trim(), redirectTo }),
+    headers: { "content-type": "application/json" },
+    method: "POST"
+  });
+  if (response.status === 429) {
+    throw new Error("Too many password reset requests. Wait before trying again.");
+  }
+  if (!response.ok) {
+    throw new Error("The password reset request could not be submitted.");
+  }
+}
+
 export async function completeTemporaryPasswordSetup(input: {
   currentPassword: string;
   newPassword: string;
@@ -63,8 +77,8 @@ export async function resetPassword(token: string, newPassword: string): Promise
   if (!response.ok) {
     throw new Error(
       response.status === 400
-        ? "This password setup link is invalid or expired."
-        : "Password setup failed."
+        ? "This password link is invalid or expired."
+        : "Password update failed."
     );
   }
 }

--- a/app/features/auth/login-page.tsx
+++ b/app/features/auth/login-page.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { signIn } from "./api";
+import { authenticationPath, safeAuthenticationReturnPath } from "./password-recovery";
 
 type LoginPageProps = {
   onLogin: () => void;
@@ -13,6 +14,17 @@ export function LoginPage({ onLogin }: LoginPageProps): React.ReactElement {
   const [email, setEmail] = React.useState("");
   const [password, setPassword] = React.useState("");
   const [isPending, setIsPending] = React.useState(false);
+  const currentPath =
+    typeof window === "undefined"
+      ? "/"
+      : `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  const forgotPasswordPath = authenticationPath(
+    "/forgot-password",
+    safeAuthenticationReturnPath(
+      currentPath,
+      typeof window === "undefined" ? undefined : window.location.origin
+    )
+  );
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -60,11 +72,16 @@ export function LoginPage({ onLogin }: LoginPageProps): React.ReactElement {
                   value={email}
                 />
               </label>
-              <label
-                className="flex flex-col gap-2 text-xs text-muted-foreground"
-                htmlFor="login-password"
-              >
-                Password
+              <div className="flex flex-col gap-2 text-xs text-muted-foreground">
+                <div className="flex items-center justify-between gap-4">
+                  <label htmlFor="login-password">Password</label>
+                  <a
+                    className="text-foreground underline-offset-4 hover:underline"
+                    href={forgotPasswordPath}
+                  >
+                    Forgot password?
+                  </a>
+                </div>
                 <Input
                   autoComplete="current-password"
                   className="h-10 bg-background shadow-none focus-visible:ring-1"
@@ -74,7 +91,7 @@ export function LoginPage({ onLogin }: LoginPageProps): React.ReactElement {
                   type="password"
                   value={password}
                 />
-              </label>
+              </div>
               <Button className="mt-1 h-10" disabled={isPending} type="submit">
                 {isPending ? "Signing in" : "Continue"}
               </Button>

--- a/app/features/auth/password-recovery.ts
+++ b/app/features/auth/password-recovery.ts
@@ -1,0 +1,22 @@
+const fallbackOrigin = "https://hqbase.local";
+const recoveryPaths = new Set(["/forgot-password", "/reset-password", "/set-password"]);
+
+export function safeAuthenticationReturnPath(
+  value: string | null,
+  origin = fallbackOrigin
+): string {
+  if (!value) return "/";
+  try {
+    const url = new URL(value, origin);
+    if (url.origin !== origin || recoveryPaths.has(url.pathname)) return "/";
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return "/";
+  }
+}
+
+export function authenticationPath(pathname: string, returnTo: string): string {
+  const url = new URL(pathname, fallbackOrigin);
+  if (returnTo !== "/") url.searchParams.set("returnTo", returnTo);
+  return `${url.pathname}${url.search}`;
+}

--- a/app/features/auth/password-setup-page.tsx
+++ b/app/features/auth/password-setup-page.tsx
@@ -3,19 +3,94 @@ import * as React from "react";
 import { toast } from "sonner";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle
-} from "@/components/ui/card";
 import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
-import { completeTemporaryPasswordSetup, resetPassword, signOut } from "./api";
+import {
+  completeTemporaryPasswordSetup,
+  requestPasswordReset,
+  resetPassword,
+  signOut
+} from "./api";
+import { authenticationPath } from "./password-recovery";
+import { PasswordShell } from "./password-shell";
 import type { CurrentUser } from "./types";
+
+export function ForgotPasswordPage({ returnTo }: { returnTo: string }): React.ReactElement {
+  const [email, setEmail] = React.useState("");
+  const [pending, setPending] = React.useState(false);
+  const [complete, setComplete] = React.useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPending(true);
+    try {
+      const redirectPath = authenticationPath("/reset-password", returnTo);
+      await requestPasswordReset(email, new URL(redirectPath, window.location.origin).href);
+      setComplete(true);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "The password reset request could not be submitted."
+      );
+    } finally {
+      setPending(false);
+    }
+  }
+
+  if (complete) {
+    return (
+      <PasswordShell
+        description="The response is the same for every Login email to keep HQBase accounts private."
+        title="Check your email"
+      >
+        <Alert>
+          <CheckCircle2 />
+          <AlertTitle>Reset link requested</AlertTitle>
+          <AlertDescription>
+            If an account uses that Login email, HQBase sent a single-use link that expires in seven
+            days.
+          </AlertDescription>
+        </Alert>
+        <Button onClick={() => window.location.assign(returnTo)} type="button" variant="outline">
+          Return to sign in
+        </Button>
+      </PasswordShell>
+    );
+  }
+
+  return (
+    <PasswordShell
+      description="Enter your Login email. HQBase will send a reset link if the account exists."
+      title="Forgot your password?"
+    >
+      <form className="flex flex-col gap-5" onSubmit={(event) => void handleSubmit(event)}>
+        <FieldGroup>
+          <Field>
+            <FieldLabel htmlFor="recovery-email">Login email</FieldLabel>
+            <Input
+              autoComplete="email"
+              id="recovery-email"
+              maxLength={254}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              type="email"
+              value={email}
+            />
+          </Field>
+        </FieldGroup>
+        <Button disabled={pending} type="submit">
+          {pending ? <Spinner data-icon="inline-start" /> : null}
+          Send reset link
+        </Button>
+        <Button onClick={() => window.location.assign(returnTo)} type="button" variant="ghost">
+          Return to sign in
+        </Button>
+      </form>
+    </PasswordShell>
+  );
+}
 
 export function InvitationPasswordSetupPage({
   token,
@@ -24,11 +99,38 @@ export function InvitationPasswordSetupPage({
   token: string | null;
   error: string | null;
 }): React.ReactElement {
+  return <TokenPasswordPage error={error} flow="invitation" returnTo="/" token={token} />;
+}
+
+export function PasswordResetPage({
+  token,
+  error,
+  returnTo
+}: {
+  token: string | null;
+  error: string | null;
+  returnTo: string;
+}): React.ReactElement {
+  return <TokenPasswordPage error={error} flow="reset" returnTo={returnTo} token={token} />;
+}
+
+function TokenPasswordPage({
+  token,
+  error,
+  flow,
+  returnTo
+}: {
+  token: string | null;
+  error: string | null;
+  flow: "invitation" | "reset";
+  returnTo: string;
+}): React.ReactElement {
   const [newPassword, setNewPassword] = React.useState("");
   const [confirmPassword, setConfirmPassword] = React.useState("");
   const [pending, setPending] = React.useState(false);
   const [complete, setComplete] = React.useState(false);
   const invalid = !token || error === "INVALID_TOKEN";
+  const resetting = flow === "reset";
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -40,10 +142,14 @@ export function InvitationPasswordSetupPage({
     setPending(true);
     try {
       await resetPassword(token, newPassword);
-      window.history.replaceState({}, "", "/set-password");
+      window.history.replaceState(
+        {},
+        "",
+        resetting ? authenticationPath("/reset-password", returnTo) : "/set-password"
+      );
       setComplete(true);
     } catch (submitError) {
-      toast.error(submitError instanceof Error ? submitError.message : "Password setup failed.");
+      toast.error(submitError instanceof Error ? submitError.message : "Password update failed.");
     } finally {
       setPending(false);
     }
@@ -52,15 +158,23 @@ export function InvitationPasswordSetupPage({
   if (complete) {
     return (
       <PasswordShell
-        description="Your password is ready. Sign in with your Login email to enter the workspace."
-        title="Invitation accepted"
+        description={
+          resetting
+            ? "Your password has changed. Sign in again with your Login email."
+            : "Your password is ready. Sign in with your Login email to enter the workspace."
+        }
+        title={resetting ? "Password changed" : "Invitation accepted"}
       >
         <Alert>
           <CheckCircle2 />
-          <AlertTitle>Password created</AlertTitle>
-          <AlertDescription>Your workspace identity is now active.</AlertDescription>
+          <AlertTitle>{resetting ? "Account recovered" : "Password created"}</AlertTitle>
+          <AlertDescription>
+            {resetting
+              ? "Your previous HQBase sessions have ended."
+              : "Your workspace identity is now active."}
+          </AlertDescription>
         </Alert>
-        <Button onClick={() => window.location.assign("/")} type="button">
+        <Button onClick={() => window.location.assign(returnTo)} type="button">
           Continue to sign in
         </Button>
       </PasswordShell>
@@ -69,21 +183,36 @@ export function InvitationPasswordSetupPage({
 
   return (
     <PasswordShell
-      description="Choose the password you’ll use with your Login email."
-      title="Set up your password"
+      description={
+        resetting
+          ? "Choose a new password for your Login email."
+          : "Choose the password you’ll use with your Login email."
+      }
+      title={resetting ? "Reset your password" : "Set up your password"}
     >
       {invalid ? (
         <>
           <Alert variant="destructive">
             <KeyRound />
-            <AlertTitle>Invitation link unavailable</AlertTitle>
+            <AlertTitle>
+              {resetting ? "Reset link unavailable" : "Invitation link unavailable"}
+            </AlertTitle>
             <AlertDescription>
-              This link is invalid, expired, or has already been used. Ask a workspace administrator
-              to resend the invitation.
+              {resetting
+                ? "This link is invalid, expired, or has already been used. Request a new reset link."
+                : "This link is invalid, expired, or has already been used. Ask a workspace administrator to resend the invitation."}
             </AlertDescription>
           </Alert>
-          <Button onClick={() => window.location.assign("/")} type="button" variant="outline">
-            Return to sign in
+          <Button
+            onClick={() =>
+              window.location.assign(
+                resetting ? authenticationPath("/forgot-password", returnTo) : "/"
+              )
+            }
+            type="button"
+            variant="outline"
+          >
+            {resetting ? "Request a new link" : "Return to sign in"}
           </Button>
         </>
       ) : (
@@ -91,7 +220,7 @@ export function InvitationPasswordSetupPage({
           confirmPassword={confirmPassword}
           newPassword={newPassword}
           pending={pending}
-          submitLabel="Create password"
+          submitLabel={resetting ? "Reset password" : "Create password"}
           onConfirmPasswordChange={setConfirmPassword}
           onNewPasswordChange={setNewPassword}
           onSubmit={handleSubmit}
@@ -235,6 +364,7 @@ function PasswordFields({
         <Input
           autoComplete="new-password"
           id="new-password"
+          maxLength={128}
           minLength={8}
           onChange={(event) => onNewPasswordChange(event.target.value)}
           required
@@ -248,6 +378,7 @@ function PasswordFields({
         <Input
           autoComplete="new-password"
           id="confirm-password"
+          maxLength={128}
           minLength={8}
           onChange={(event) => onConfirmPasswordChange(event.target.value)}
           required
@@ -256,36 +387,5 @@ function PasswordFields({
         />
       </Field>
     </>
-  );
-}
-
-function PasswordShell({
-  children,
-  description,
-  footer,
-  title
-}: {
-  children: React.ReactNode;
-  description: string;
-  footer?: React.ReactNode;
-  title: string;
-}): React.ReactElement {
-  return (
-    <main className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
-      <div className="w-full max-w-md">
-        <div className="mb-10 flex items-center justify-center gap-2">
-          <img alt="" className="h-7 w-auto" src="/logo.svg" />
-          <span className="text-sm font-medium">HQBase</span>
-        </div>
-        <Card className="bg-card/70 shadow-none">
-          <CardHeader>
-            <CardTitle className="text-lg font-medium tracking-tight">{title}</CardTitle>
-            <CardDescription>{description}</CardDescription>
-          </CardHeader>
-          <CardContent>{children}</CardContent>
-          {footer ? <CardFooter className="justify-center">{footer}</CardFooter> : null}
-        </Card>
-      </div>
-    </main>
   );
 }

--- a/app/features/auth/password-shell.tsx
+++ b/app/features/auth/password-shell.tsx
@@ -1,0 +1,41 @@
+import type * as React from "react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card";
+
+export function PasswordShell({
+  children,
+  description,
+  footer,
+  title
+}: {
+  children: React.ReactNode;
+  description: string;
+  footer?: React.ReactNode;
+  title: string;
+}): React.ReactElement {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
+      <div className="w-full max-w-md">
+        <div className="mb-10 flex items-center justify-center gap-2">
+          <img alt="" className="h-7 w-auto" src="/logo.svg" />
+          <span className="text-sm font-medium">HQBase</span>
+        </div>
+        <Card className="bg-card/70 shadow-none">
+          <CardHeader>
+            <CardTitle className="text-lg font-medium tracking-tight">{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </CardHeader>
+          <CardContent>{children}</CardContent>
+          {footer ? <CardFooter className="justify-center">{footer}</CardFooter> : null}
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/app/lib/routes.ts
+++ b/app/lib/routes.ts
@@ -33,7 +33,7 @@ export type AppRoute =
   | { kind: "drafts"; draftId: string | null }
   | { kind: "settings"; tab: SettingsTabId };
 
-const publicAuthenticationPaths = new Set(["/set-password"]);
+const publicAuthenticationPaths = new Set(["/forgot-password", "/reset-password", "/set-password"]);
 
 export function isPublicAuthenticationPath(pathname: string): boolean {
   return publicAuthenticationPaths.has(pathname);

--- a/migrations/0011_latest_password_reset_token.sql
+++ b/migrations/0011_latest_password_reset_token.sql
@@ -1,0 +1,21 @@
+DELETE FROM verification
+WHERE identifier LIKE 'reset-password:%'
+  AND EXISTS (
+    SELECT 1
+    FROM verification AS newer
+    WHERE newer.value = verification.value
+      AND newer.identifier LIKE 'reset-password:%'
+      AND (
+        newer.createdAt > verification.createdAt
+        OR (newer.createdAt = verification.createdAt AND newer.id > verification.id)
+      )
+  );
+
+CREATE TRIGGER IF NOT EXISTS verification_latest_password_reset_token
+BEFORE INSERT ON verification
+WHEN NEW.identifier LIKE 'reset-password:%'
+BEGIN
+  DELETE FROM verification
+  WHERE value = NEW.value
+    AND identifier LIKE 'reset-password:%';
+END;

--- a/test/integration/worker/auth.test.ts
+++ b/test/integration/worker/auth.test.ts
@@ -10,6 +10,7 @@ import userMailPreferencesMigration from "../../../migrations/0007_user_mail_pre
 import userOnboardingMigration from "../../../migrations/0008_user_onboarding.sql?raw";
 import loginEmailDomainMigration from "../../../migrations/0009_login_email_domain_isolation.sql?raw";
 import deviceAuthorizationMigration from "../../../migrations/0010_oauth_device_authorization.sql?raw";
+import latestPasswordResetTokenMigration from "../../../migrations/0011_latest_password_reset_token.sql?raw";
 import { createAuth } from "../../../worker/auth/auth";
 import { migrationStatements } from "./migration-statements";
 
@@ -35,7 +36,24 @@ describe("Better Auth schema", () => {
       env.DB.prepare(
         `INSERT INTO mail_domains (id, name, created_at, updated_at)
          VALUES ('dom_legacy', 'example.com', ?, ?)`
-      ).bind(now, now)
+      ).bind(now, now),
+      env.DB.prepare(
+        `INSERT INTO verification (id, identifier, value, expiresAt, createdAt, updatedAt)
+         VALUES
+           ('verification_reset_old', 'reset-password:old', 'usr_legacy', ?, ?, ?),
+           ('verification_reset_new', 'reset-password:new', 'usr_legacy', ?, ?, ?),
+           ('verification_other', 'email-verification:keep', 'usr_legacy', ?, ?, ?)`
+      ).bind(
+        "2026-08-22T00:00:00.000Z",
+        "2026-08-14T00:00:00.000Z",
+        "2026-08-14T00:00:00.000Z",
+        "2026-08-22T00:00:00.000Z",
+        "2026-08-15T00:00:00.000Z",
+        "2026-08-15T00:00:00.000Z",
+        "2026-08-22T00:00:00.000Z",
+        "2026-08-14T00:00:00.000Z",
+        "2026-08-14T00:00:00.000Z"
+      )
     ]);
 
     await applyMigration(oauthResourcesMigration);
@@ -45,6 +63,7 @@ describe("Better Auth schema", () => {
     await applyMigration(userOnboardingMigration);
     await applyMigration(loginEmailDomainMigration);
     await applyMigration(deviceAuthorizationMigration);
+    await applyMigration(latestPasswordResetTokenMigration);
   });
 
   it("backfills the Better Auth 1.7 account identity without losing credential rows", async () => {
@@ -88,6 +107,37 @@ describe("Better Auth schema", () => {
       "user_login_email_domain_insert_guard",
       "user_login_email_domain_update_guard"
     ]);
+  });
+
+  it("keeps only the newest existing password link and installs the replacement trigger", async () => {
+    const migrated = await env.DB.prepare(
+      `SELECT id FROM verification
+       WHERE value = 'usr_legacy'
+       ORDER BY id`
+    ).all<{ id: string }>();
+    expect(migrated.results.map(({ id }) => id)).toEqual([
+      "verification_other",
+      "verification_reset_new"
+    ]);
+
+    const trigger = await env.DB.prepare(
+      `SELECT name FROM sqlite_master
+       WHERE type = 'trigger' AND name = 'verification_latest_password_reset_token'`
+    ).first<{ name: string }>();
+    expect(trigger?.name).toBe("verification_latest_password_reset_token");
+
+    await env.DB.prepare(
+      `INSERT INTO verification (id, identifier, value, expiresAt, createdAt, updatedAt)
+       VALUES ('verification_reset_latest', 'reset-password:latest', 'usr_legacy', ?, ?, ?)`
+    )
+      .bind("2026-08-23T00:00:00.000Z", "2026-08-16T00:00:00.000Z", "2026-08-16T00:00:00.000Z")
+      .run();
+
+    const resetTokens = await env.DB.prepare(
+      `SELECT id FROM verification
+       WHERE value = 'usr_legacy' AND identifier LIKE 'reset-password:%'`
+    ).all<{ id: string }>();
+    expect(resetTokens.results).toEqual([{ id: "verification_reset_latest" }]);
   });
 
   it("applies the conversation draft migration on an existing schema", async () => {

--- a/test/integration/worker/local-reset.test.ts
+++ b/test/integration/worker/local-reset.test.ts
@@ -12,6 +12,7 @@ import userMailPreferencesMigration from "../../../migrations/0007_user_mail_pre
 import userOnboardingMigration from "../../../migrations/0008_user_onboarding.sql?raw";
 import loginEmailDomainMigration from "../../../migrations/0009_login_email_domain_isolation.sql?raw";
 import deviceAuthorizationMigration from "../../../migrations/0010_oauth_device_authorization.sql?raw";
+import latestPasswordResetTokenMigration from "../../../migrations/0011_latest_password_reset_token.sql?raw";
 import resetSql from "../../../scripts/hqbase/reset-d1.sql?raw";
 import { buildSeedSql } from "../../../scripts/local-seed-fixture.mjs";
 import { migrationStatements } from "./migration-statements";
@@ -27,7 +28,8 @@ const migrations = [
   userMailPreferencesMigration,
   userOnboardingMigration,
   loginEmailDomainMigration,
-  deviceAuthorizationMigration
+  deviceAuthorizationMigration,
+  latestPasswordResetTokenMigration
 ];
 
 describe("local database reset", () => {
@@ -59,6 +61,12 @@ describe("local database reset", () => {
          )`
     ).first<{ count: number }>();
     expect(oauthTables?.count).toBe(5);
+
+    const resetTokenTrigger = await env.DB.prepare(
+      `SELECT name FROM sqlite_master
+       WHERE type = 'trigger' AND name = 'verification_latest_password_reset_token'`
+    ).first<{ name: string }>();
+    expect(resetTokenTrigger?.name).toBe("verification_latest_password_reset_token");
   });
 });
 

--- a/test/integration/worker/users.test.ts
+++ b/test/integration/worker/users.test.ts
@@ -216,9 +216,9 @@ describe("workspace user onboarding", () => {
     )
       .bind(result.user.id)
       .first<{ identifier: string }>();
-    const token = latestVerification?.identifier.replace("reset-password:", "");
-    expect(token).toBeTruthy();
-    expect(token).not.toBe(firstToken);
+    const resentToken = latestVerification?.identifier.replace("reset-password:", "");
+    expect(resentToken).toBeTruthy();
+    expect(resentToken).not.toBe(firstToken);
 
     const invalidated = await SELF.fetch(`${origin}/api/auth/reset-password`, {
       body: JSON.stringify({
@@ -229,6 +229,31 @@ describe("workspace user onboarding", () => {
       method: "POST"
     });
     expect(invalidated.status).toBe(400);
+
+    const recoveryRequest = await requestPasswordReset(
+      "invited-user@gmail.com",
+      `${origin}/reset-password`
+    );
+    expect(recoveryRequest.status).toBe(200);
+    const recoveryVerification = await env.DB.prepare(
+      `SELECT identifier FROM verification
+       WHERE value = ? AND identifier LIKE 'reset-password:%'`
+    )
+      .bind(result.user.id)
+      .first<{ identifier: string }>();
+    const token = recoveryVerification?.identifier.replace("reset-password:", "");
+    expect(token).toBeTruthy();
+    expect(token).not.toBe(resentToken);
+
+    const staleResentLink = await SELF.fetch(`${origin}/api/auth/reset-password`, {
+      body: JSON.stringify({
+        newPassword: "stale-resent-invite-password",
+        token: resentToken
+      }),
+      headers: { "content-type": "application/json", origin },
+      method: "POST"
+    });
+    expect(staleResentLink.status).toBe(400);
 
     const accepted = await SELF.fetch(`${origin}/api/auth/reset-password`, {
       body: JSON.stringify({ newPassword: "invited-user-password-789", token }),
@@ -251,6 +276,13 @@ describe("workspace user onboarding", () => {
       .bind(result.user.id)
       .first<{ outcome: string }>();
     expect(audit?.outcome).toBe("success");
+    const remainingTokens = await env.DB.prepare(
+      `SELECT COUNT(*) AS count FROM verification
+       WHERE value = ? AND identifier LIKE 'reset-password:%'`
+    )
+      .bind(result.user.id)
+      .first<{ count: number }>();
+    expect(remainingTokens?.count).toBe(0);
     await expect(signIn("invited-user@gmail.com", "invited-user-password-789")).resolves.toContain(
       "better-auth.session_token"
     );
@@ -261,6 +293,181 @@ describe("workspace user onboarding", () => {
       method: "POST"
     });
     expect(replay.status).toBe(400);
+  });
+
+  it("recovers a pending temporary-password account and completes its setup", async () => {
+    const created = await createUser({
+      email: "pending-recovery-user@gmail.com",
+      method: "temporary_password",
+      name: "Pending Recovery User",
+      role: "member"
+    });
+    expect(created.status, await created.clone().text()).toBe(201);
+    const result = (await created.json()) as {
+      temporaryPassword: string;
+      user: { id: string };
+    };
+    const temporaryCookie = await signIn(
+      "pending-recovery-user@gmail.com",
+      result.temporaryPassword
+    );
+
+    const requested = await requestPasswordReset(
+      "pending-recovery-user@gmail.com",
+      `${origin}/reset-password`
+    );
+    expect(requested.status).toBe(200);
+    const verification = await env.DB.prepare(
+      `SELECT identifier FROM verification
+       WHERE value = ? AND identifier LIKE 'reset-password:%'`
+    )
+      .bind(result.user.id)
+      .first<{ identifier: string }>();
+    const token = verification?.identifier.replace("reset-password:", "");
+    expect(token).toBeTruthy();
+
+    const reset = await SELF.fetch(`${origin}/api/auth/reset-password`, {
+      body: JSON.stringify({ newPassword: "pending-recovery-password-123", token }),
+      headers: { "content-type": "application/json", origin },
+      method: "POST"
+    });
+    expect(reset.status, await reset.clone().text()).toBe(200);
+
+    const onboarding = await env.DB.prepare("SELECT status FROM user_onboarding WHERE user_id = ?")
+      .bind(result.user.id)
+      .first<{ status: string }>();
+    expect(onboarding?.status).toBe("complete");
+    const revoked = await SELF.fetch(`${origin}/api/me`, { headers: { cookie: temporaryCookie } });
+    expect(revoked.status).toBe(401);
+    await expect(
+      signIn("pending-recovery-user@gmail.com", result.temporaryPassword)
+    ).rejects.toThrow();
+    await expect(
+      signIn("pending-recovery-user@gmail.com", "pending-recovery-password-123")
+    ).resolves.toContain("better-auth.session_token");
+
+    const audit = await env.DB.prepare(
+      `SELECT outcome FROM audit_events
+       WHERE action = 'user.password.setup' AND resource_id = ?
+       ORDER BY occurred_at DESC LIMIT 1`
+    )
+      .bind(result.user.id)
+      .first<{ outcome: string }>();
+    expect(audit?.outcome).toBe("success");
+  });
+
+  it("resets an established password without revealing account existence", async () => {
+    const created = await createUser({
+      email: "recovery-user@gmail.com",
+      method: "temporary_password",
+      name: "Recovery User",
+      role: "member"
+    });
+    expect(created.status, await created.clone().text()).toBe(201);
+    const result = (await created.json()) as {
+      temporaryPassword: string;
+      user: { id: string };
+    };
+
+    const temporaryCookie = await signIn("recovery-user@gmail.com", result.temporaryPassword);
+    const completed = await SELF.fetch(`${origin}/api/me/password`, {
+      body: JSON.stringify({
+        confirmPassword: "first-recovery-password-123",
+        currentPassword: result.temporaryPassword,
+        newPassword: "first-recovery-password-123"
+      }),
+      headers: { "content-type": "application/json", cookie: temporaryCookie, origin },
+      method: "POST"
+    });
+    expect(completed.status, await completed.clone().text()).toBe(200);
+    const activeCookie = extractSessionCookie(completed);
+
+    const resetDestination = new URL("/reset-password", origin);
+    resetDestination.searchParams.set("returnTo", "/device?user_code=ABCD-EFGH");
+    const existingRequest = await requestPasswordReset(
+      "recovery-user@gmail.com",
+      resetDestination.href
+    );
+    const missingRequest = await requestPasswordReset(
+      "missing-user@gmail.com",
+      resetDestination.href
+    );
+    expect(existingRequest.status).toBe(200);
+    expect(missingRequest.status).toBe(200);
+    await expect(existingRequest.json()).resolves.toEqual(await missingRequest.json());
+
+    const firstVerification = await env.DB.prepare(
+      `SELECT identifier FROM verification
+       WHERE value = ? AND identifier LIKE 'reset-password:%'
+       ORDER BY expiresAt DESC LIMIT 1`
+    )
+      .bind(result.user.id)
+      .first<{ identifier: string }>();
+    const firstToken = firstVerification?.identifier.replace("reset-password:", "");
+    expect(firstToken).toBeTruthy();
+
+    const nextRequest = await requestPasswordReset(
+      "recovery-user@gmail.com",
+      resetDestination.href
+    );
+    expect(nextRequest.status).toBe(200);
+    const verification = await env.DB.prepare(
+      `SELECT identifier FROM verification
+       WHERE value = ? AND identifier LIKE 'reset-password:%'`
+    )
+      .bind(result.user.id)
+      .first<{ identifier: string }>();
+    const token = verification?.identifier.replace("reset-password:", "");
+    expect(token).toBeTruthy();
+    expect(token).not.toBe(firstToken);
+
+    const staleReset = await SELF.fetch(`${origin}/api/auth/reset-password`, {
+      body: JSON.stringify({ newPassword: "stale-recovery-password", token: firstToken }),
+      headers: { "content-type": "application/json", origin },
+      method: "POST"
+    });
+    expect(staleReset.status).toBe(400);
+
+    const callback = await SELF.fetch(
+      `${origin}/api/auth/reset-password/${token}?callbackURL=${encodeURIComponent(resetDestination.href)}`,
+      { redirect: "manual" }
+    );
+    expect(callback.status).toBe(302);
+    const callbackLocation = new URL(callback.headers.get("location") ?? origin);
+    expect(callbackLocation.pathname).toBe("/reset-password");
+    expect(callbackLocation.searchParams.get("returnTo")).toBe("/device?user_code=ABCD-EFGH");
+    expect(callbackLocation.searchParams.get("token")).toBe(token);
+
+    const reset = await SELF.fetch(`${origin}/api/auth/reset-password`, {
+      body: JSON.stringify({ newPassword: "second-recovery-password-456", token }),
+      headers: { "content-type": "application/json", origin },
+      method: "POST"
+    });
+    expect(reset.status, await reset.clone().text()).toBe(200);
+
+    const revoked = await SELF.fetch(`${origin}/api/me`, { headers: { cookie: activeCookie } });
+    expect(revoked.status).toBe(401);
+    await expect(
+      signIn("recovery-user@gmail.com", "first-recovery-password-123")
+    ).rejects.toThrow();
+    await expect(
+      signIn("recovery-user@gmail.com", "second-recovery-password-456")
+    ).resolves.toContain("better-auth.session_token");
+    const audit = await env.DB.prepare(
+      `SELECT outcome FROM audit_events
+       WHERE action = 'user.password.reset' AND resource_id = ?
+       ORDER BY occurred_at DESC LIMIT 1`
+    )
+      .bind(result.user.id)
+      .first<{ outcome: string }>();
+    expect(audit?.outcome).toBe("success");
+    const remainingTokens = await env.DB.prepare(
+      `SELECT COUNT(*) AS count FROM verification
+       WHERE value = ? AND identifier LIKE 'reset-password:%'`
+    )
+      .bind(result.user.id)
+      .first<{ count: number }>();
+    expect(remainingTokens?.count).toBe(0);
   });
 });
 
@@ -273,6 +480,14 @@ function createUser(input: {
   return SELF.fetch(`${origin}/api/users`, {
     body: JSON.stringify(input),
     headers: { "content-type": "application/json", cookie: ownerCookie, origin },
+    method: "POST"
+  });
+}
+
+function requestPasswordReset(email: string, redirectTo: string): Promise<Response> {
+  return SELF.fetch(`${origin}/api/auth/request-password-reset`, {
+    body: JSON.stringify({ email, redirectTo }),
+    headers: { "content-type": "application/json", origin },
     method: "POST"
   });
 }

--- a/test/unit/app/auth/password-recovery.test.ts
+++ b/test/unit/app/auth/password-recovery.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  authenticationPath,
+  safeAuthenticationReturnPath
+} from "@/features/auth/password-recovery";
+
+describe("password recovery return paths", () => {
+  it("keeps a same-origin OAuth or device path", () => {
+    expect(
+      safeAuthenticationReturnPath("/device?user_code=ABCD-EFGH", "https://mail.example.com")
+    ).toBe("/device?user_code=ABCD-EFGH");
+    expect(authenticationPath("/forgot-password", "/device?user_code=ABCD-EFGH")).toBe(
+      "/forgot-password?returnTo=%2Fdevice%3Fuser_code%3DABCD-EFGH"
+    );
+  });
+
+  it("rejects external, malformed, and recursive recovery destinations", () => {
+    expect(
+      safeAuthenticationReturnPath("https://attacker.example/path", "https://mail.example.com")
+    ).toBe("/");
+    expect(safeAuthenticationReturnPath("https://%", "https://mail.example.com")).toBe("/");
+    expect(safeAuthenticationReturnPath("/reset-password", "https://mail.example.com")).toBe("/");
+  });
+});

--- a/test/unit/app/auth/password-setup.test.tsx
+++ b/test/unit/app/auth/password-setup.test.tsx
@@ -2,7 +2,9 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import {
+  ForgotPasswordPage,
   InvitationPasswordSetupPage,
+  PasswordResetPage,
   TemporaryPasswordSetupPage
 } from "@/features/auth/password-setup-page";
 
@@ -26,6 +28,36 @@ describe("password setup presentation", () => {
 
     expect(html).toContain("Invitation link unavailable");
     expect(html).toContain("resend the invitation");
+    expect(html).not.toContain('type="password"');
+  });
+
+  it("asks for a Login email without revealing whether an account exists", () => {
+    const html = renderToStaticMarkup(<ForgotPasswordPage returnTo="/" />);
+
+    expect(html).toContain("Forgot your password?");
+    expect(html).toContain("Login email");
+    expect(html).toContain("if the account exists");
+    expect(html).toContain("Send reset link");
+  });
+
+  it("uses recovery-specific copy for a valid reset token", () => {
+    const html = renderToStaticMarkup(
+      <PasswordResetPage error={null} returnTo="/device?user_code=ABCD-EFGH" token="reset-token" />
+    );
+
+    expect(html).toContain("Reset your password");
+    expect(html).toContain("Reset password");
+    expect(html).toContain('maxLength="128"');
+    expect(html).not.toContain("Invitation accepted");
+  });
+
+  it("offers a new request for an invalid reset link", () => {
+    const html = renderToStaticMarkup(
+      <PasswordResetPage error="INVALID_TOKEN" returnTo="/" token={null} />
+    );
+
+    expect(html).toContain("Reset link unavailable");
+    expect(html).toContain("Request a new link");
     expect(html).not.toContain('type="password"');
   });
 

--- a/test/unit/app/layout/mail-shell.test.tsx
+++ b/test/unit/app/layout/mail-shell.test.tsx
@@ -147,6 +147,8 @@ describe("mail shell", () => {
     const html = renderToStaticMarkup(<LoginPage onLogin={() => undefined} />);
 
     expect(html).toContain('src="/logo.svg"');
+    expect(html).toContain('href="/forgot-password"');
+    expect(html).toContain("Forgot password?");
     expect(html).not.toContain(">HQ</span>");
   });
 

--- a/test/unit/app/use-app-route.test.tsx
+++ b/test/unit/app/use-app-route.test.tsx
@@ -9,14 +9,16 @@ describe("application route normalization", () => {
     window.history.replaceState(null, "", "/");
   });
 
-  it("preserves the invitation password route and its setup token", async () => {
-    window.history.replaceState(null, "", "/set-password?token=setup-token");
+  it.each([
+    "/forgot-password?returnTo=%2Fdevice%3Fuser_code%3DABCD-EFGH",
+    "/reset-password?token=reset-token&returnTo=%2Fdevice%3Fuser_code%3DABCD-EFGH",
+    "/set-password?token=setup-token"
+  ])("preserves the public authentication route %s", async (path) => {
+    window.history.replaceState(null, "", path);
 
     const hook = await renderHook(() => useAppRoute(undefined), undefined);
 
-    expect(`${window.location.pathname}${window.location.search}`).toBe(
-      "/set-password?token=setup-token"
-    );
+    expect(`${window.location.pathname}${window.location.search}`).toBe(path);
     await hook.unmount();
   });
 

--- a/test/unit/worker/features/users/user-email.test.ts
+++ b/test/unit/worker/features/users/user-email.test.ts
@@ -47,10 +47,39 @@ describe("user onboarding email", () => {
     ).rejects.toThrow("Connect an active sending mailbox");
     expect(send).not.toHaveBeenCalled();
   });
+
+  it("sends established users password-reset copy without changing onboarding state", async () => {
+    const send = vi.fn().mockResolvedValue({ messageId: "<reset@example.com>" });
+    const run = vi.fn();
+    const db = database({
+      onboarding: { method: "temporary_password", status: "complete" },
+      sender: { address: "support@example.com" },
+      run
+    });
+
+    await sendPasswordSetupEmail(environment(db, send), {
+      user: { id: "user-2", email: "person@gmail.com", name: "Avery" },
+      url: "https://mail.example.com/api/auth/reset-password/token?callbackURL=recovery"
+    });
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: "Reset your HQBase password",
+        to: "person@gmail.com"
+      })
+    );
+    const message = send.mock.calls[0]?.[0] as { html: string; text: string };
+    expect(message.text).toContain("A password reset was requested");
+    expect(message.text).toContain("Reset password:");
+    expect(run).not.toHaveBeenCalled();
+  });
 });
 
 function database(input: {
-  onboarding: { method: "email_invite"; status: "pending" };
+  onboarding: {
+    method: "email_invite" | "temporary_password";
+    status: "complete" | "pending";
+  };
   sender: { address: string } | null;
   run: ReturnType<typeof vi.fn>;
 }): D1Database {

--- a/worker/auth/auth.ts
+++ b/worker/auth/auth.ts
@@ -9,8 +9,13 @@ import { hashOAuthToken } from "./oauth-token";
 import { completePasswordSetup } from "./password-setup";
 
 const passwordSetupTokenLifetimeSeconds = 7 * 24 * 60 * 60;
+type BackgroundTaskHandler = (promise: Promise<unknown>) => void;
 
-export function createAuth(env: WorkerEnv, request: Request) {
+export function createAuth(
+  env: WorkerEnv,
+  request: Request,
+  backgroundTaskHandler?: BackgroundTaskHandler
+) {
   const baseURL = authOrigin(env, request);
 
   return betterAuth({
@@ -20,6 +25,9 @@ export function createAuth(env: WorkerEnv, request: Request) {
     database: env.DB,
     disabledPaths: ["/token"],
     secret: env.BETTER_AUTH_SECRET,
+    ...(backgroundTaskHandler
+      ? { advanced: { backgroundTasks: { handler: backgroundTaskHandler } } }
+      : {}),
     account: {
       fields: {
         accountId: "providerAccountId"
@@ -36,18 +44,17 @@ export function createAuth(env: WorkerEnv, request: Request) {
         await sendPasswordSetupEmail(env, { user, url });
       },
       onPasswordReset: async ({ user }) => {
-        if (await completePasswordSetup(env.DB, user.id)) {
-          await recordAudit(env.DB, {
-            correlationId: crypto.randomUUID(),
-            actorType: "user",
-            actorId: user.id,
-            action: "user.password.setup",
-            resourceType: "user",
-            resourceId: user.id,
-            outcome: "success",
-            metadata: {}
-          });
-        }
+        const completedSetup = await completePasswordSetup(env.DB, user.id);
+        await recordAudit(env.DB, {
+          correlationId: crypto.randomUUID(),
+          actorType: "user",
+          actorId: user.id,
+          action: completedSetup ? "user.password.setup" : "user.password.reset",
+          resourceType: "user",
+          resourceId: user.id,
+          outcome: "success",
+          metadata: {}
+        });
       }
     },
     plugins: [

--- a/worker/auth/password-setup.ts
+++ b/worker/auth/password-setup.ts
@@ -8,13 +8,20 @@ export async function isPasswordSetupRequired(db: D1Database, userId: string): P
 
 export async function completePasswordSetup(db: D1Database, userId: string): Promise<boolean> {
   const timestamp = new Date().toISOString();
-  const result = await db
-    .prepare(
-      `UPDATE user_onboarding
+  const results = await db.batch([
+    db
+      .prepare(
+        `UPDATE user_onboarding
        SET status = 'complete', completed_at = ?, updated_at = ?
        WHERE user_id = ? AND status = 'pending'`
-    )
-    .bind(timestamp, timestamp, userId)
-    .run();
-  return (result.meta.changes ?? 0) > 0;
+      )
+      .bind(timestamp, timestamp, userId),
+    db
+      .prepare(
+        `DELETE FROM verification
+       WHERE value = ? AND identifier LIKE 'reset-password:%'`
+      )
+      .bind(userId)
+  ]);
+  return (results[0]?.meta.changes ?? 0) > 0;
 }

--- a/worker/routes/index.ts
+++ b/worker/routes/index.ts
@@ -140,7 +140,8 @@ apiRoutes.all("/api/auth/*", async (c) => {
     ]);
   }
 
-  const handleAuthRequest = () => createAuth(c.env, c.req.raw).handler(c.req.raw);
+  const handleAuthRequest = () =>
+    createAuth(c.env, c.req.raw, (promise) => c.executionCtx.waitUntil(promise)).handler(c.req.raw);
   if (pathname === "/api/auth/oauth2/token" && c.req.method === "POST") {
     return handleDeviceTokenRequest(c.env, c.req.raw, handleAuthRequest);
   }


### PR DESCRIPTION
## Summary

- add a **Forgot password?** flow with public request, reset, and password-setup routes
- preserve safe same-origin return paths for OAuth and Device Authorization
- keep recovery responses generic and rate-limit requests by Login email and IP address
- revoke existing sessions and record secret-free setup or reset audit events
- add a D1 migration that makes the newest password link the only valid link
- cover invited, temporary-password, established, fresh-install, and upgraded accounts

## Why

HQBase supported invitation password setup, but it did not provide a supported self-service recovery flow from sign-in. Better Auth also allowed more than one reset token for an account, so an older unused invitation or reset link could remain valid after a newer link was issued.

The migration now replaces older password tokens atomically. Successful setup or reset also removes any remaining password token.

## User impact

People can recover access through their Login email, including accounts that have not completed initial password setup. Links work once, expire after seven days, and a new link invalidates every older unused password link.

## Related documentation PR

- HQBase/hqbase-site#8

## Validation

- `pnpm check`
  - 82 unit test files: 319 passed, 2 skipped
  - 10 Worker integration test files: 49 passed
  - coverage, architecture, API artifact, type, and production build checks passed
- `pnpm deploy:dry-run`
- coordinated hqbase-site documentation gate passed: 14 tests, 23-page documentation check, Astro check/build, and deployment dry run
- [protected staging E2E](https://github.com/HQBase/hqbase/actions/runs/31922687234) passed against commit `bcf3004`, including fresh install, rendered app and access checks, populated D1 backup/restore, and resource cleanup
