### PR TITLE
Prepare HQBase 1.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.1.2
+
+- Add secure self-service password recovery from the sign-in page. Recovery links expire after
+  seven days, work once, invalidate older unused password links, and revoke existing sessions after
+  a successful reset.
+- Keep generated customer deployments on their configured hostname by disabling preview URLs.
+- Post complete release notes to the configured Discord webhook only after the signed release and
+  public archive pass verification. Discord delivery failures do not invalidate a release.
+- Improve the repository README so installation, documentation, community, contribution, security,
+  and local-development paths are easier to find.
+
 ## 1.1.1
 
 - Publish the deployment-local Mail API instructions as a valid Agent Skill at

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hqbase",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary

- bump the committed HQBase version to 1.1.2
- add release notes for password recovery, private deployment URLs, verified Discord notifications,
  and README improvements

## Why

These changes are merged and validated on `main`, but customers need a new immutable signed
release before Settings -> Updates can offer them.

## Validation

- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-release-1.1.2-check.log pnpm check`
- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-release-1.1.2-dry-run.log pnpm deploy:dry-run`
- [Staging E2E against `ac4b615`](https://github.com/HQBase/hqbase/actions/runs/31924056795),
  including rendered lifecycle checks, populated backup/restore, and resource cleanup
