### PR TITLE
Document contributor license agreement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,18 @@ HQBase is licensed under AGPL-3.0-only.
 Submission does not guarantee acceptance. Maintainers retain sole discretion over which
 contributions are merged into the official HQBase project.
 
-Unless otherwise agreed in writing, all contributions intentionally submitted to HQBase are
-licensed under AGPL-3.0-only. By submitting a contribution, you confirm that you have the legal
-right to license it under these terms.
+## Contributor License Agreement
+
+Every human-authored contribution requires CLA acceptance before it can be merged, including
+documentation, typo fixes, and other small changes. Maintainers may exempt contributions created
+by automated bots. CLA Assistant will prompt the contributor to review and accept the [HQBase
+Individual Contributor License
+Agreement](https://gist.github.com/bermanto/6a6d2ea2d93119229f871bb186a4168c) through the pull
+request.
+
+Contributors retain copyright in their contributions. Accepted contributions remain available in
+the community project under AGPL-3.0-only. The CLA also permits Berman Digital Ltd. to use and
+license contributions under alternative terms, including commercial terms.
 
 Read the public [Contributing to
 HQBase](https://hqbase.io/docs/maintainers/contributing/) guide for repository ownership,


### PR DESCRIPTION
## Summary

- require CLA acceptance for every human-authored contribution
- explain the CLA Assistant pull request flow and the bot exemption
- document contributor copyright, continued AGPL availability, and alternative licensing rights

## Why

Make the contribution licensing process explicit before a pull request is merged.

## Impact

Contributors can see when CLA acceptance is required and what rights the agreement grants.

## Validation

- `pnpm check`
- `pnpm deploy:dry-run`
- `git diff --check`
