### PR TITLE
Document native-client OAuth registration in agent instructions

### DIFF
--- a/test/integration/worker/mail-api.test.ts
+++ b/test/integration/worker/mail-api.test.ts
@@ -237,6 +237,8 @@ describe("HQBase Mail API v1", () => {
     );
     expect(instructions).toContain("The person must open it themselves in a browser they control");
     expect(instructions).toContain("Sending and replying are not idempotent");
+    expect(instructions).toContain("`application_type` set to `native`");
+    expect(instructions).toContain("RFC 8252");
     for (const [path, pathItem] of Object.entries(mailApiOpenApi.paths)) {
       for (const method of ["get", "post", "patch", "delete"] as const) {
         if (method in pathItem) {

--- a/test/integration/worker/mail-api.test.ts
+++ b/test/integration/worker/mail-api.test.ts
@@ -239,6 +239,7 @@ describe("HQBase Mail API v1", () => {
     expect(instructions).toContain("Sending and replying are not idempotent");
     expect(instructions).toContain("`application_type` set to `native`");
     expect(instructions).toContain("RFC 8252");
+    expect(instructions).toContain("app-claimed HTTPS, loopback HTTP, and private-use schemes");
     for (const [path, pathItem] of Object.entries(mailApiOpenApi.paths)) {
       for (const method of ["get", "post", "patch", "delete"] as const) {
         if (method in pathItem) {

--- a/worker/features/mail-api/discovery.ts
+++ b/worker/features/mail-api/discovery.ts
@@ -111,7 +111,7 @@ External agents must use an OAuth bearer token. Do not copy or reuse an HQBase b
 
 Prefer Device Authorization for agents, command-line tools, and other clients that cannot safely receive a browser callback. A callback-capable client may instead register \`authorization_code\` and use Authorization Code with PKCE and the S256 challenge method. Both flows require the same resource, scopes, sign-in, and explicit approval.
 
-Native desktop and mobile clients that use Authorization Code with PKCE must register with \`application_type\` set to \`native\` and a private-use redirect URI that follows RFC 8252 §7.1: a reverse-domain scheme with no authority component (for example \`com.example.mail:/oauth/callback\`). Registrations that omit \`application_type\` are treated as web clients and must use \`https\` redirect URIs on non-loopback hosts.
+Native desktop and mobile clients that use Authorization Code with PKCE must register with \`application_type\` set to \`native\`. HQBase accepts the native redirect forms defined by RFC 8252: app-claimed HTTPS, loopback HTTP, and private-use schemes. A private-use redirect must use a reverse-domain scheme with no authority component, for example \`com.example.mail:/oauth/callback\`.
 
 Use this exact OAuth resource and token audience: \`${apiBase}\`. MCP uses separate audiences at \`${origin}/mcp\` and \`${origin}/mcp/full\`; an MCP token cannot be used with the Mail API.
 

--- a/worker/features/mail-api/discovery.ts
+++ b/worker/features/mail-api/discovery.ts
@@ -111,6 +111,8 @@ External agents must use an OAuth bearer token. Do not copy or reuse an HQBase b
 
 Prefer Device Authorization for agents, command-line tools, and other clients that cannot safely receive a browser callback. A callback-capable client may instead register \`authorization_code\` and use Authorization Code with PKCE and the S256 challenge method. Both flows require the same resource, scopes, sign-in, and explicit approval.
 
+Native desktop and mobile clients that use Authorization Code with PKCE must register with \`application_type\` set to \`native\` and a private-use redirect URI that follows RFC 8252 §7.1: a reverse-domain scheme with no authority component (for example \`com.example.mail:/oauth/callback\`). Registrations that omit \`application_type\` are treated as web clients and must use \`https\` redirect URIs on non-loopback hosts.
+
 Use this exact OAuth resource and token audience: \`${apiBase}\`. MCP uses separate audiences at \`${origin}/mcp\` and \`${origin}/mcp/full\`; an MCP token cannot be used with the Mail API.
 
 ## Permissions


### PR DESCRIPTION
## Summary

- The generated agent instructions (`/AGENTS.md`, now `/skills/hqbase-mail/SKILL.md`) describe web and device-code clients, but not what a **native desktop/mobile PKCE client** must send to register.
- Adds one paragraph: register with `application_type: "native"` and an RFC 8252 §7.1 private-use redirect URI (reverse-domain scheme, no authority — e.g. `com.example.mail:/oauth/callback`); registrations without `application_type` are treated as web clients and need `https` redirects.
- Integration test asserts the new text is served.

## Why

Both requirements are already enforced by the server ("web clients require https redirect URIs on non-loopback hosts", then "native private-use redirect URI schemes must be well-formed reverse-domain names, omit the naming authority…"), so a native client discovers them one rejected registration at a time. Found while building [Herald](https://github.com/awizemann/herald), a macOS client, against 1.1.0.

## Validation

- `pnpm check` on this branch: biome, typecheck, build, architecture check, coverage pass; 319/320 unit + integration tests pass. The single failure (`use-draft-autosave.test.tsx` → `localStorage.setItem` undefined) reproduces identically on pristine `main` under Node 26.5 locally and is unrelated to this change.

Refs #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)