### PR TITLE
Document that conversation actions take a message id

### DIFF
--- a/api/hqbase-mail-api-v1.openapi.json
+++ b/api/hqbase-mail-api-v1.openapi.json
@@ -1015,6 +1015,7 @@
     "/api/v1/conversations/{id}/{action}": {
       "post": {
         "summary": "Update conversation state",
+        "description": "Applies the action to every accessible message in the conversation identified by the message `{id}`.",
         "security": [
           {
             "oauth2": ["mail:write"]
@@ -1091,6 +1092,7 @@
           {
             "in": "path",
             "name": "id",
+            "description": "A message id belonging to the conversation — use `ConversationSummary.id` (the conversation's latest message). The conversation is derived from that message and mailbox access is checked against its mailbox. This is not a thread id; a thread id resolves to no mailbox and is rejected with 403 MAILBOX_FORBIDDEN.",
             "required": true,
             "schema": {
               "type": "string",

--- a/api/hqbase-mail-api-v1.openapi.json
+++ b/api/hqbase-mail-api-v1.openapi.json
@@ -1015,7 +1015,7 @@
     "/api/v1/conversations/{id}/{action}": {
       "post": {
         "summary": "Update conversation state",
-        "description": "Applies the action to every accessible message in the conversation identified by the message `{id}`.",
+        "description": "Applies the action to the accessible part of the conversation identified by the message {id}.",
         "security": [
           {
             "oauth2": ["mail:write"]
@@ -1092,7 +1092,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "A message id belonging to the conversation — use `ConversationSummary.id` (the conversation's latest message). The conversation is derived from that message and mailbox access is checked against its mailbox. This is not a thread id; a thread id resolves to no mailbox and is rejected with 403 MAILBOX_FORBIDDEN.",
+            "description": "Use ConversationSummary.id, the ID of the latest accessible message in the conversation. Do not use threadId. A thread ID does not identify a message and returns 403 MAILBOX_FORBIDDEN.",
             "required": true,
             "schema": {
               "type": "string",

--- a/api/hqbase-mail-api-v1.postman_collection.json
+++ b/api/hqbase-mail-api-v1.postman_collection.json
@@ -395,7 +395,7 @@
                 }
               ]
             },
-            "description": "Update conversation state",
+            "description": "Applies the action to every accessible message in the conversation identified by the message `{id}`.",
             "body": {
               "mode": "raw",
               "raw": "{\n  \"folder\": \"inbox\"\n}",

--- a/api/hqbase-mail-api-v1.postman_collection.json
+++ b/api/hqbase-mail-api-v1.postman_collection.json
@@ -395,7 +395,7 @@
                 }
               ]
             },
-            "description": "Applies the action to every accessible message in the conversation identified by the message `{id}`.",
+            "description": "Applies the action to the accessible part of the conversation identified by the message {id}.",
             "body": {
               "mode": "raw",
               "raw": "{\n  \"folder\": \"inbox\"\n}",


### PR DESCRIPTION
## Summary

- `POST /api/v1/conversations/{id}/{action}` resolves the conversation — and the mailbox used for the access check — from a **message id** (`ConversationSummary.id`, the conversation's latest message). The OpenAPI document left `{id}` undescribed.
- Documents the path parameter and the operation; Postman artifacts regenerated with `node scripts/generate-mail-api-artifacts.mjs --write` (verify passes).

## Why

A client that naturally keys conversations by `threadId` sends the thread id here, which resolves to no mailbox and is rejected with `403 MAILBOX_FORBIDDEN` on star/archive/trash — with no hint that the id was the wrong kind. Found while building [Herald](https://github.com/awizemann/herald), a macOS client, against 1.1.0.

An alternative worth considering separately: also accept a thread id on this route (derive mailboxes from the thread's accessible messages).

## Validation

- `pnpm check` on this branch: biome, typecheck, build, architecture check, coverage pass; 319/320 unit + integration tests pass. The single failure (`use-draft-autosave.test.tsx` → `localStorage.setItem` undefined) reproduces identically on pristine `main` under Node 26.5 locally and is unrelated to this change.

Refs #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)