### PR TITLE
feat(operator): add `hqbase domain` to move a deployment to another custom domain

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -178,6 +178,21 @@ jobs:
           exit 1
       - name: Verify PWA, app shell, access, and operator lifecycle
         run: pnpm test:e2e:staging
+      - name: Move the live portal hostname and move it back
+        env:
+          HQBASE_DOMAIN_API_TOKEN: ${{ secrets.HQBASE_E2E_CLOUDFLARE_API_TOKEN }}
+          HQBASE_DOMAIN_ACCESS_CLIENT_ID: ${{ secrets.HQBASE_E2E_ACCESS_CLIENT_ID }}
+          HQBASE_DOMAIN_ACCESS_CLIENT_SECRET: ${{ secrets.HQBASE_E2E_ACCESS_CLIENT_SECRET }}
+          HQBASE_DOMAIN_MOVE_HOST: move-${{ github.run_id }}.${{ secrets.HQBASE_E2E_EMAIL_DOMAIN }}
+        run: node scripts/test-domain-staging.mjs
+      - name: Recover the staging portal before resource cleanup
+        if: always()
+        env:
+          HQBASE_DOMAIN_API_TOKEN: ${{ secrets.HQBASE_E2E_CLOUDFLARE_API_TOKEN }}
+          HQBASE_DOMAIN_ACCESS_CLIENT_ID: ${{ secrets.HQBASE_E2E_ACCESS_CLIENT_ID }}
+          HQBASE_DOMAIN_ACCESS_CLIENT_SECRET: ${{ secrets.HQBASE_E2E_ACCESS_CLIENT_SECRET }}
+          HQBASE_DOMAIN_MOVE_HOST: move-${{ github.run_id }}.${{ secrets.HQBASE_E2E_EMAIL_DOMAIN }}
+        run: node scripts/test-domain-staging.mjs --cleanup-only
       - name: Exercise populated remote backup and restore
         run: |
           config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"

--- a/scripts/hqbase/cli.mjs
+++ b/scripts/hqbase/cli.mjs
@@ -101,7 +101,7 @@ OAuth options:
   --skip-deploy          Validate and write local deployment configuration without deploying.
   --dry-run              Validate without writing or deploying.
 
-Domain options (moves the canonical portal host; D1, R2, and queues are untouched):
+Domain options (moves the canonical portal host; mail data and resource identities stay in place):
   --app-domain <host>    Attach this hostname and make it the canonical portal host.
   --detach               Remove every custom domain and serve from workers.dev. Requires --yes.
   --keep-service-origin  Keep the machine-facing service origin on the current hostname.
@@ -110,13 +110,12 @@ Domain options (moves the canonical portal host; D1, R2, and queues are untouche
   --auth-url <origin>    Set the service origin explicitly to a canonical HTTPS origin.
   --detach-old           Delete the previous hostname instead of keeping it as a redirect.
                          Requires --yes.
-  --override-existing    Take over a hostname that already routes elsewhere. Requires --yes in a
-                         non-interactive shell.
-  --yes                  Confirm the steps that delete a Cloudflare DNS record or take a hostname.
-  --skip-deploy          Attach and verify without deploying configuration.
+  --yes                  Confirm the steps that delete a Cloudflare DNS record.
   --dry-run              Validate without contacting Cloudflare, writing, or deploying.
 
 The domain command reads and writes Worker custom domains through the Cloudflare API and needs
-CLOUDFLARE_API_TOKEN with Workers Scripts:Edit, Zone:Read, and DNS:Edit.
+HQBASE_DOMAIN_API_TOKEN with Workers Scripts:Edit and Zone:Read. Use a short-lived token and unset
+it after the command. Wrangler keeps using its own login. For a portal protected by Cloudflare
+Access, also set HQBASE_DOMAIN_ACCESS_CLIENT_ID and HQBASE_DOMAIN_ACCESS_CLIENT_SECRET.
 `);
 }

--- a/scripts/hqbase/cli.mjs
+++ b/scripts/hqbase/cli.mjs
@@ -5,6 +5,7 @@ import { backup } from "./backup.mjs";
 import { updateDeployButton } from "./button.mjs";
 import { destroy } from "./destroy.mjs";
 import { doctor } from "./doctor.mjs";
+import { configureDomain } from "./domain.mjs";
 import { install } from "./install.mjs";
 import { configureOAuth } from "./oauth.mjs";
 import { printPostDeploy } from "./postdeploy.mjs";
@@ -29,6 +30,9 @@ try {
       break;
     case "oauth":
       configureOAuth(flags);
+      break;
+    case "domain":
+      configureDomain(flags);
       break;
     case "backup":
       backup(flags);
@@ -64,6 +68,7 @@ Usage:
   pnpm hqbase button --repo-url https://github.com/OWNER/REPO
   pnpm hqbase install --name dev-01 [--domain example.com]
   pnpm hqbase oauth --name dev-01 --mode official|customer
+  pnpm hqbase domain --name dev-01 --app-domain app.example.com|--detach
   pnpm hqbase doctor --name dev-01
   pnpm hqbase backup --name dev-01 [--output backup.json]
   pnpm hqbase restore --name dev-01 --backup backup.json --yes
@@ -94,6 +99,13 @@ OAuth options:
   --client-id <id>       Customer OAuth client ID. Required for customer mode.
   --auth-url <origin>    Exact canonical HTTPS HQBase origin. Required for customer mode.
   --skip-deploy          Validate and write local deployment configuration without deploying.
+  --dry-run              Validate without writing or deploying.
+
+Domain options (moves the Worker; D1, R2, and queues are untouched):
+  --app-domain <host>    Attach this custom Worker domain instead of the current one.
+  --detach               Remove the custom domain and serve from workers.dev.
+  --auth-url <origin>    Set BETTER_AUTH_URL explicitly. Defaults to https://<app-domain> when one was set before.
+  --skip-deploy          Write local deployment configuration without deploying.
   --dry-run              Validate without writing or deploying.
 `);
 }

--- a/scripts/hqbase/cli.mjs
+++ b/scripts/hqbase/cli.mjs
@@ -32,7 +32,7 @@ try {
       configureOAuth(flags);
       break;
     case "domain":
-      configureDomain(flags);
+      await configureDomain(flags);
       break;
     case "backup":
       backup(flags);
@@ -101,11 +101,22 @@ OAuth options:
   --skip-deploy          Validate and write local deployment configuration without deploying.
   --dry-run              Validate without writing or deploying.
 
-Domain options (moves the Worker; D1, R2, and queues are untouched):
-  --app-domain <host>    Attach this custom Worker domain instead of the current one.
-  --detach               Remove the custom domain and serve from workers.dev.
-  --auth-url <origin>    Set BETTER_AUTH_URL explicitly. Defaults to https://<app-domain> when one was set before.
-  --skip-deploy          Write local deployment configuration without deploying.
-  --dry-run              Validate without writing or deploying.
+Domain options (moves the canonical portal host; D1, R2, and queues are untouched):
+  --app-domain <host>    Attach this hostname and make it the canonical portal host.
+  --detach               Remove every custom domain and serve from workers.dev. Requires --yes.
+  --keep-service-origin  Keep the machine-facing service origin on the current hostname.
+  --move-service-origin  Move the service origin to the new hostname. Ends every agent token,
+                         OAuth redirect URI, and webhook registered on the old origin.
+  --auth-url <origin>    Set the service origin explicitly to a canonical HTTPS origin.
+  --detach-old           Delete the previous hostname instead of keeping it as a redirect.
+                         Requires --yes.
+  --override-existing    Take over a hostname that already routes elsewhere. Requires --yes in a
+                         non-interactive shell.
+  --yes                  Confirm the steps that delete a Cloudflare DNS record or take a hostname.
+  --skip-deploy          Attach and verify without deploying configuration.
+  --dry-run              Validate without contacting Cloudflare, writing, or deploying.
+
+The domain command reads and writes Worker custom domains through the Cloudflare API and needs
+CLOUDFLARE_API_TOKEN with Workers Scripts:Edit, Zone:Read, and DNS:Edit.
 `);
 }

--- a/scripts/hqbase/cloudflare-domains.mjs
+++ b/scripts/hqbase/cloudflare-domains.mjs
@@ -1,0 +1,105 @@
+const apiBase = "https://api.cloudflare.com/client/v4";
+
+/**
+ * Worker custom domains are account resources, not Wrangler configuration. Wrangler publishes them
+ * as a side effect of a deploy and, without a TTY, silently sets override_existing_origin and
+ * override_existing_dns_record. The operator therefore reads and writes them through the documented
+ * Cloudflare API, where every override is explicit and every result can be verified.
+ */
+export function requireCloudflareApiToken(environment = process.env) {
+  const token = environment.CLOUDFLARE_API_TOKEN?.trim();
+  if (!token) {
+    throw new Error(
+      "Refusing to continue: set CLOUDFLARE_API_TOKEN for the domain command. The token needs Workers Scripts:Edit, Zone:Read, and DNS:Edit for the target zone."
+    );
+  }
+  return token;
+}
+
+export function createWorkerDomainsClient({ accountId, token, fetchImpl }) {
+  const call = fetchImpl ?? globalThis.fetch;
+
+  async function request(path, init) {
+    const response = await call(`${apiBase}${path}`, {
+      ...init,
+      headers: {
+        ...(init?.body ? { "content-type": "application/json" } : {}),
+        authorization: `Bearer ${token}`
+      }
+    });
+    const body = await response.json();
+    if (!response.ok || body?.success !== true) {
+      const message = body?.errors?.[0]?.message ?? `HTTP ${response.status}`;
+      throw new Error(`Cloudflare rejected ${path}: ${message}`);
+    }
+    return body.result;
+  }
+
+  return {
+    async list() {
+      const result = await request(`/accounts/${accountId}/workers/domains`);
+      return Array.isArray(result) ? result : [];
+    },
+    async attach({ hostname, service, zoneId, zoneName, override = false }) {
+      return request(`/accounts/${accountId}/workers/domains`, {
+        method: "PUT",
+        body: JSON.stringify({
+          environment: "production",
+          hostname,
+          service,
+          zone_id: zoneId,
+          zone_name: zoneName,
+          // Always explicit. Wrangler defaults these to true without a TTY.
+          override_existing_origin: override,
+          override_existing_dns_record: override
+        })
+      });
+    },
+    async remove(id) {
+      return request(`/accounts/${accountId}/workers/domains/${id}`, { method: "DELETE" });
+    },
+    async findZone(hostname) {
+      const labels = hostname.split(".");
+      for (let index = 0; index < labels.length - 1; index += 1) {
+        const candidate = labels.slice(index).join(".");
+        const zones = await request(`/zones?name=${encodeURIComponent(candidate)}`);
+        const zone = Array.isArray(zones) ? zones[0] : null;
+        if (zone?.id) {
+          return { id: zone.id, name: zone.name };
+        }
+      }
+      return null;
+    }
+  };
+}
+
+/**
+ * Decide what an attachment would do before anything is changed in Cloudflare.
+ */
+export function planAttachment(domains, { hostname, service }) {
+  const existing = domains.find((domain) => domain?.hostname === hostname);
+  if (!existing) {
+    return { action: "attach", existing: null };
+  }
+  if (existing.service === service) {
+    return { action: "keep", existing };
+  }
+  return { action: "conflict", existing };
+}
+
+export function assertAttachmentAllowed(plan, { confirmed, hostname, override, service }) {
+  if (plan.action !== "conflict") {
+    return plan;
+  }
+  if (!override) {
+    throw new Error(
+      `Refusing to attach ${hostname}: it already routes to Worker "${plan.existing.service}", not "${service}". Choose another hostname, or re-run with --override-existing --yes to take it over.`
+    );
+  }
+  if (!confirmed) {
+    throw new Error(
+      `Refusing to take over ${hostname} from Worker "${plan.existing.service}" without an explicit confirmation. Re-run with --override-existing --yes.`
+    );
+  }
+  return plan;
+}

--- a/scripts/hqbase/cloudflare-domains.mjs
+++ b/scripts/hqbase/cloudflare-domains.mjs
@@ -6,11 +6,11 @@ const apiBase = "https://api.cloudflare.com/client/v4";
  * override_existing_dns_record. The operator therefore reads and writes them through the documented
  * Cloudflare API, where every override is explicit and every result can be verified.
  */
-export function requireCloudflareApiToken(environment = process.env) {
-  const token = environment.CLOUDFLARE_API_TOKEN?.trim();
+export function requireDomainApiToken(environment = process.env) {
+  const token = environment.HQBASE_DOMAIN_API_TOKEN?.trim();
   if (!token) {
     throw new Error(
-      "Refusing to continue: set CLOUDFLARE_API_TOKEN for the domain command. The token needs Workers Scripts:Edit, Zone:Read, and DNS:Edit for the target zone."
+      "Refusing to continue: set HQBASE_DOMAIN_API_TOKEN for the domain command. Use a short-lived token with Workers Scripts:Edit and Zone:Read, then unset it after the command."
     );
   }
   return token;
@@ -27,7 +27,15 @@ export function createWorkerDomainsClient({ accountId, token, fetchImpl }) {
         authorization: `Bearer ${token}`
       }
     });
-    const body = await response.json();
+    let body;
+    try {
+      body = await response.json();
+    } catch {
+      if (response.ok && init?.method === "DELETE") return null;
+      throw new Error(
+        `Cloudflare returned an unreadable response for ${path} (HTTP ${response.status}).`
+      );
+    }
     if (!response.ok || body?.success !== true) {
       const message = body?.errors?.[0]?.message ?? `HTTP ${response.status}`;
       throw new Error(`Cloudflare rejected ${path}: ${message}`);
@@ -36,11 +44,14 @@ export function createWorkerDomainsClient({ accountId, token, fetchImpl }) {
   }
 
   return {
-    async list() {
-      const result = await request(`/accounts/${accountId}/workers/domains`);
+    async list(filters = {}) {
+      const query = new URLSearchParams({ environment: "production" });
+      if (filters.hostname) query.set("hostname", filters.hostname);
+      if (filters.service) query.set("service", filters.service);
+      const result = await request(`/accounts/${accountId}/workers/domains?${query}`);
       return Array.isArray(result) ? result : [];
     },
-    async attach({ hostname, service, zoneId, zoneName, override = false }) {
+    async attach({ hostname, service, zoneId, zoneName }) {
       return request(`/accounts/${accountId}/workers/domains`, {
         method: "PUT",
         body: JSON.stringify({
@@ -50,8 +61,8 @@ export function createWorkerDomainsClient({ accountId, token, fetchImpl }) {
           zone_id: zoneId,
           zone_name: zoneName,
           // Always explicit. Wrangler defaults these to true without a TTY.
-          override_existing_origin: override,
-          override_existing_dns_record: override
+          override_existing_origin: false,
+          override_existing_dns_record: false
         })
       });
     },
@@ -62,8 +73,11 @@ export function createWorkerDomainsClient({ accountId, token, fetchImpl }) {
       const labels = hostname.split(".");
       for (let index = 0; index < labels.length - 1; index += 1) {
         const candidate = labels.slice(index).join(".");
-        const zones = await request(`/zones?name=${encodeURIComponent(candidate)}`);
-        const zone = Array.isArray(zones) ? zones[0] : null;
+        const query = new URLSearchParams({ "account.id": accountId, name: candidate });
+        const zones = await request(`/zones?${query}`);
+        const zone = Array.isArray(zones)
+          ? zones.find((item) => item?.account?.id === accountId)
+          : null;
         if (zone?.id) {
           return { id: zone.id, name: zone.name };
         }
@@ -87,19 +101,11 @@ export function planAttachment(domains, { hostname, service }) {
   return { action: "conflict", existing };
 }
 
-export function assertAttachmentAllowed(plan, { confirmed, hostname, override, service }) {
+export function assertAttachmentAllowed(plan, { hostname, service }) {
   if (plan.action !== "conflict") {
     return plan;
   }
-  if (!override) {
-    throw new Error(
-      `Refusing to attach ${hostname}: it already routes to Worker "${plan.existing.service}", not "${service}". Choose another hostname, or re-run with --override-existing --yes to take it over.`
-    );
-  }
-  if (!confirmed) {
-    throw new Error(
-      `Refusing to take over ${hostname} from Worker "${plan.existing.service}" without an explicit confirmation. Re-run with --override-existing --yes.`
-    );
-  }
-  return plan;
+  throw new Error(
+    `Refusing to attach ${hostname}: it already routes to Worker "${plan.existing.service}", not "${service}". Remove or move that domain explicitly in Cloudflare before retrying.`
+  );
 }

--- a/scripts/hqbase/config.mjs
+++ b/scripts/hqbase/config.mjs
@@ -94,7 +94,11 @@ export function createWranglerConfig(manifest) {
       : {}),
     ...(manifest.authUrl ? { BETTER_AUTH_URL: manifest.authUrl } : {})
   };
-  const customDomains = [manifest.appDomain].filter(Boolean);
+  // Retired hostnames stay attached so automation, mail discovery, and the 308 portal redirect
+  // keep answering on them until the operator removes them explicitly.
+  const customDomains = [
+    ...new Set([manifest.appDomain, ...(manifest.retiredDomains ?? [])].filter(Boolean))
+  ];
   if (customDomains.length > 0) {
     config.routes = customDomains.map((pattern) => ({ pattern, custom_domain: true }));
   }

--- a/scripts/hqbase/domain-plan.mjs
+++ b/scripts/hqbase/domain-plan.mjs
@@ -46,7 +46,7 @@ export function updateDomainManifest(manifest, input) {
  * origin is served by the hostname that is being replaced, the operator must choose.
  */
 export function resolveServiceOrigin(manifest, input) {
-  const previous = manifest.authUrl;
+  const previous = manifest.authUrl?.replace(/\/$/, "");
   if (input.keepServiceOrigin && input.moveServiceOrigin) {
     throw new Error("Use either --keep-service-origin or --move-service-origin, not both.");
   }
@@ -68,7 +68,8 @@ export function resolveServiceOrigin(manifest, input) {
   }
   if (input.authUrl) {
     assertCanonicalOrigin(input.authUrl);
-    return { authUrl: input.authUrl, moved: previous !== input.authUrl };
+    const authUrl = input.authUrl.replace(/\/$/, "");
+    return { authUrl, moved: previous !== authUrl };
   }
   const ridesOnPortal = Boolean(
     previous && manifest.appDomain && previous === `https://${manifest.appDomain}`
@@ -114,12 +115,12 @@ export function domainChangeNotes(previous, next) {
   } else if (next.authUrl) {
     notes.push(`Service origin ${next.authUrl} is unchanged.`);
   }
-  notes.push("D1, R2, and queues were not modified.");
+  notes.push("Mail data and the D1, R2, and queue resource identities were not modified.");
   return notes;
 }
 
 export function stagedMoveRecord(manifest, target, options = {}) {
-  return {
+  return migrateStagedMoveRecord({
     startedAt: options.now ?? new Date().toISOString(),
     state: "staged",
     fromAppDomain: manifest.appDomain ?? null,
@@ -129,18 +130,36 @@ export function stagedMoveRecord(manifest, target, options = {}) {
     detachOld: Boolean(options.detachOld),
     attachedDomainId: null,
     attachedByThisRun: false,
-    deployed: false
+    targetZoneId: null,
+    configurationDeployAttempted: false,
+    canonicalUpdateAttempted: false,
+    pendingRemoval: null,
+    removedDomains: []
+  });
+}
+
+export function migrateStagedMoveRecord(move) {
+  return {
+    ...move,
+    attachedDomainId: move.attachedDomainId ?? null,
+    attachedByThisRun: Boolean(move.attachedByThisRun),
+    targetZoneId: move.targetZoneId ?? null,
+    configurationDeployAttempted: Boolean(move.configurationDeployAttempted),
+    canonicalUpdateAttempted: Boolean(move.canonicalUpdateAttempted),
+    pendingRemoval: move.pendingRemoval ?? null,
+    removedDomains: move.removedDomains ?? []
   };
 }
 
-export function assertResumable(manifest, target) {
+export function assertResumable(manifest, target, options = {}) {
   const move = manifest.domainMove;
   if (!move) {
     return;
   }
   if (
     move.toAppDomain !== (target.appDomain ?? null) ||
-    move.toAuthUrl !== (target.authUrl ?? null)
+    move.toAuthUrl !== (target.authUrl ?? null) ||
+    Boolean(move.detachOld) !== Boolean(options.detachOld)
   ) {
     throw new Error(
       `Refusing to continue: deployment "${manifest.name}" has an unfinished domain move to ${move.toAppDomain ?? "the default hostname"} started at ${move.startedAt}. Re-run the same move to resume it, or repair the manifest from verified Cloudflare records.`
@@ -154,7 +173,9 @@ function resolveRetiredDomains(manifest, input) {
     return [];
   }
   if (input.detachOld) {
-    retired.clear();
+    if (manifest.appDomain) {
+      retired.delete(manifest.appDomain);
+    }
   } else if (manifest.appDomain && manifest.appDomain !== input.appDomain) {
     retired.add(manifest.appDomain);
   }

--- a/scripts/hqbase/domain-plan.mjs
+++ b/scripts/hqbase/domain-plan.mjs
@@ -1,0 +1,215 @@
+import { cloudflareOAuthConfig } from "./install.mjs";
+
+const hostPattern = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z][a-z0-9-]{0,62}$/;
+
+/**
+ * The proposed manifest. Nothing here is written until every Cloudflare step is verified.
+ */
+export function updateDomainManifest(manifest, input) {
+  if (input.detach && input.appDomain) {
+    throw new Error("Use either --app-domain or --detach, not both.");
+  }
+  if (!input.detach && !input.appDomain) {
+    throw new Error("Domain change requires --app-domain <host> or --detach.");
+  }
+  const appDomain = input.detach ? undefined : normalizeHost(input.appDomain);
+  const { authUrl } = resolveServiceOrigin(manifest, { ...input, appDomain });
+  if (input.detachOld && manifest.appDomain && hostOf(authUrl) === manifest.appDomain) {
+    throw new Error(
+      `Refusing to detach ${manifest.appDomain}: it serves the machine-facing service origin ${authUrl}. Move the service origin first, or keep the hostname attached.`
+    );
+  }
+  const cloudflareOAuth = manifest.cloudflareOAuth ?? { mode: "official" };
+  const retiredDomains = resolveRetiredDomains(manifest, {
+    appDomain,
+    authUrl,
+    detach: input.detach,
+    detachOld: input.detachOld
+  });
+
+  return {
+    ...manifest,
+    appDomain,
+    authUrl,
+    retiredDomains,
+    // Re-validate customer-managed OAuth against the service origin; official mode is unaffected.
+    cloudflareOAuth: cloudflareOAuthConfig({
+      authUrl,
+      clientId: cloudflareOAuth.clientId,
+      mode: cloudflareOAuth.mode
+    })
+  };
+}
+
+/**
+ * A portal change never changes the webhook, recovery, or automation origin. When the service
+ * origin is served by the hostname that is being replaced, the operator must choose.
+ */
+export function resolveServiceOrigin(manifest, input) {
+  const previous = manifest.authUrl;
+  if (input.keepServiceOrigin && input.moveServiceOrigin) {
+    throw new Error("Use either --keep-service-origin or --move-service-origin, not both.");
+  }
+  if (input.detach) {
+    if (input.authUrl) {
+      throw new Error(
+        "--auth-url cannot survive --detach because the deployment keeps no custom hostname. Use --move-service-origin to fall back to the request origin."
+      );
+    }
+    if (!previous) {
+      return { authUrl: undefined, moved: false };
+    }
+    if (!input.moveServiceOrigin) {
+      throw new Error(
+        `Refusing to detach: ${previous} is the machine-facing service origin and it is served by the custom domain. Re-run with --move-service-origin to fall back to the request origin, and re-register every agent token, OAuth redirect URI, and webhook.`
+      );
+    }
+    return { authUrl: undefined, moved: true };
+  }
+  if (input.authUrl) {
+    assertCanonicalOrigin(input.authUrl);
+    return { authUrl: input.authUrl, moved: previous !== input.authUrl };
+  }
+  const ridesOnPortal = Boolean(
+    previous && manifest.appDomain && previous === `https://${manifest.appDomain}`
+  );
+  if (!ridesOnPortal) {
+    return { authUrl: previous, moved: false };
+  }
+  if (input.moveServiceOrigin) {
+    return { authUrl: `https://${input.appDomain}`, moved: true };
+  }
+  if (input.keepServiceOrigin) {
+    return { authUrl: previous, moved: false };
+  }
+  throw new Error(
+    `Refusing to move the portal: ${previous} is also the machine-facing service origin. Re-run with --keep-service-origin to keep the old hostname attached for automation, or --move-service-origin to move the auth issuer, Mail API audience, and MCP audience to the new hostname.`
+  );
+}
+
+export function domainChangeNotes(previous, next) {
+  const notes = [];
+  if (previous.appDomain && previous.appDomain !== next.appDomain) {
+    const retired = (next.retiredDomains ?? []).includes(previous.appDomain);
+    notes.push(
+      retired
+        ? `${previous.appDomain} stays attached and redirects browsers to the new portal; API, MCP, and mail discovery on it are unchanged.`
+        : `${previous.appDomain} is detached from the Worker and its DNS record is deleted.`
+    );
+  }
+  if (next.appDomain && previous.appDomain !== next.appDomain) {
+    notes.push(
+      `${next.appDomain} must be a zone in this Cloudflare account; the attach step creates its DNS record and certificate.`
+    );
+  }
+  if (previous.authUrl !== next.authUrl) {
+    notes.push(
+      `Service origin changed to ${next.authUrl ?? "the request origin"}: existing sessions end, and every agent token, OAuth redirect URI, and webhook must be re-registered.`
+    );
+    if (next.cloudflareOAuth?.mode === "customer") {
+      notes.push(
+        `Customer-managed OAuth: re-register the redirect URIs on ${next.authUrl} for /api/setup/cloudflare/oauth/callback, /api/updates/cloudflare/oauth/callback, and /api/domains/cloudflare/oauth/callback.`
+      );
+    }
+  } else if (next.authUrl) {
+    notes.push(`Service origin ${next.authUrl} is unchanged.`);
+  }
+  notes.push("D1, R2, and queues were not modified.");
+  return notes;
+}
+
+export function stagedMoveRecord(manifest, target, options = {}) {
+  return {
+    startedAt: options.now ?? new Date().toISOString(),
+    state: "staged",
+    fromAppDomain: manifest.appDomain ?? null,
+    toAppDomain: target.appDomain ?? null,
+    fromAuthUrl: manifest.authUrl ?? null,
+    toAuthUrl: target.authUrl ?? null,
+    detachOld: Boolean(options.detachOld),
+    attachedDomainId: null,
+    attachedByThisRun: false,
+    deployed: false
+  };
+}
+
+export function assertResumable(manifest, target) {
+  const move = manifest.domainMove;
+  if (!move) {
+    return;
+  }
+  if (
+    move.toAppDomain !== (target.appDomain ?? null) ||
+    move.toAuthUrl !== (target.authUrl ?? null)
+  ) {
+    throw new Error(
+      `Refusing to continue: deployment "${manifest.name}" has an unfinished domain move to ${move.toAppDomain ?? "the default hostname"} started at ${move.startedAt}. Re-run the same move to resume it, or repair the manifest from verified Cloudflare records.`
+    );
+  }
+}
+
+function resolveRetiredDomains(manifest, input) {
+  const retired = new Set(manifest.retiredDomains ?? []);
+  if (input.detach) {
+    return [];
+  }
+  if (input.detachOld) {
+    retired.clear();
+  } else if (manifest.appDomain && manifest.appDomain !== input.appDomain) {
+    retired.add(manifest.appDomain);
+  }
+  if (input.appDomain) {
+    retired.delete(input.appDomain);
+  }
+  const serviceHost = hostOf(input.authUrl);
+  if (
+    serviceHost &&
+    serviceHost !== input.appDomain &&
+    !retired.has(serviceHost) &&
+    !input.detach
+  ) {
+    // The service origin must keep answering, so its hostname stays attached.
+    retired.add(serviceHost);
+  }
+  return [...retired];
+}
+
+export function hostOf(origin) {
+  if (!origin) {
+    return undefined;
+  }
+  try {
+    return new URL(origin).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+function assertCanonicalOrigin(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("--auth-url must be a valid canonical HTTPS origin.");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("--auth-url must be a canonical HTTPS origin without a path.");
+  }
+}
+
+function normalizeHost(value) {
+  const host = String(value).trim().toLowerCase().replace(/\.$/, "");
+  if (!hostPattern.test(host)) {
+    throw new Error(
+      `--app-domain must be a bare hostname such as app.example.com (got "${value}").`
+    );
+  }
+  return host;
+}

--- a/scripts/hqbase/domain-recovery.mjs
+++ b/scripts/hqbase/domain-recovery.mjs
@@ -1,0 +1,168 @@
+import { writeWranglerConfig } from "./config.mjs";
+import { configPath } from "./manifest.mjs";
+
+export function domainSnapshot(domain) {
+  return {
+    hostname: domain.hostname,
+    service: domain.service,
+    zoneId: domain.zone_id ?? domain.zoneId ?? null,
+    zoneName: domain.zone_name ?? domain.zoneName ?? null
+  };
+}
+
+export function uniqueDomains(domains) {
+  const unique = new Map();
+  for (const domain of domains) {
+    if (domain?.hostname) unique.set(domain.hostname, domain);
+  }
+  return [...unique.values()];
+}
+
+export async function assertManagedHosts(context, manifest = context.committed) {
+  const { domains } = context;
+  const expected = uniqueDomains(
+    [manifest.appDomain, ...(manifest.retiredDomains ?? [])]
+      .filter(Boolean)
+      .map((hostname) => ({ hostname }))
+  );
+  for (const { hostname } of expected) {
+    const records = await domains.list({ hostname });
+    const owner = records.find((record) => record?.hostname === hostname)?.service;
+    if (owner !== manifest.worker.name) {
+      throw new Error(
+        `Refusing to continue: saved hostname ${hostname} routes to ${owner ? `Worker "${owner}"` : "no Worker"}, not "${manifest.worker.name}".`
+      );
+    }
+  }
+}
+
+export async function restoreDomain(context, snapshot) {
+  const { committed, domains } = context;
+  const records = await domains.list({ hostname: snapshot.hostname });
+  const current = records.find((record) => record?.hostname === snapshot.hostname);
+  if (current?.service === committed.worker.name) return;
+  if (current) {
+    throw new Error(
+      `${snapshot.hostname} now routes to Worker "${current.service}"; HQBase will not take it over.`
+    );
+  }
+  const zone =
+    snapshot.zoneId && snapshot.zoneName
+      ? { id: snapshot.zoneId, name: snapshot.zoneName }
+      : await domains.findZone(snapshot.hostname);
+  if (!zone) throw new Error(`No Cloudflare zone serves ${snapshot.hostname}.`);
+  await domains.attach({
+    hostname: snapshot.hostname,
+    service: committed.worker.name,
+    zoneId: zone.id,
+    zoneName: zone.name
+  });
+  const restored = (await domains.list({ hostname: snapshot.hostname })).some(
+    (record) => record?.hostname === snapshot.hostname && record?.service === committed.worker.name
+  );
+  if (!restored) throw new Error(`Cloudflare did not restore ${snapshot.hostname}.`);
+}
+
+export async function removeDomainForWorker(context, hostname) {
+  const { committed, domains } = context;
+  const records = await domains.list({ hostname });
+  const attached = records.find(
+    (record) => record?.hostname === hostname && record?.service === committed.worker.name
+  );
+  if (!attached) return;
+  await domains.remove(attached.id);
+  const remains = (await domains.list({ hostname })).some(
+    (record) => record?.hostname === hostname && record?.service === committed.worker.name
+  );
+  if (remains) throw new Error(`Cloudflare still reports ${hostname} on the HQBase Worker.`);
+}
+
+export async function rollbackDomainMove(context, move, cause) {
+  const { committed, target } = context;
+  const reason = cause instanceof Error ? cause.message : String(cause);
+  console.error(`Domain move failed after step "${move.state}": ${reason}`);
+  const failures = [];
+  const recover = async (label, action) => {
+    try {
+      await action();
+    } catch (error) {
+      failures.push({ label, message: error instanceof Error ? error.message : String(error) });
+    }
+  };
+
+  const removed = uniqueDomains([...(move.removedDomains ?? []), move.pendingRemoval]);
+  for (const domain of removed) {
+    await recover(`reattach ${domain.hostname}`, () => restoreDomain(context, domain));
+  }
+  if (move.configurationDeployAttempted) {
+    await recover("restore Worker configuration", async () => {
+      writeWranglerConfig(committed);
+      await context.deployConfiguration({
+        accountId: committed.accountId,
+        configFile: configPath(committed.name),
+        runCommand: context.runCommand
+      });
+    });
+  }
+  if (move.canonicalUpdateAttempted) {
+    await recover("restore canonical portal", () =>
+      context.setCanonicalPortal({
+        hostname: committed.appDomain ?? null,
+        manifest: committed,
+        runCommand: context.runCommand
+      })
+    );
+  }
+  if (failures.length === 0 && move.attachedByThisRun && target.appDomain) {
+    await recover(`detach ${target.appDomain}`, () =>
+      removeDomainForWorker(context, target.appDomain)
+    );
+  }
+  await recover("verify restored domains", () => assertManagedHosts(context));
+  if (move.canonicalUpdateAttempted) {
+    await recover("verify restored canonical portal", async () => {
+      const actual = await context.readCanonicalPortal({
+        manifest: committed,
+        runCommand: context.runCommand
+      });
+      if (actual !== (committed.appDomain ?? null)) {
+        throw new Error(
+          `D1 reports ${actual ?? "no canonical portal"}, not ${committed.appDomain ?? "no canonical portal"}.`
+        );
+      }
+    });
+  }
+
+  writeWranglerConfig(committed);
+  if (failures.length === 0) {
+    delete committed.domainMove;
+    try {
+      context.checkpoint(committed);
+      console.error("The failed domain move was fully rolled back.");
+      return;
+    } catch (error) {
+      failures.push({
+        label: "save restored deployment record",
+        message: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  move.state = "recovery-required";
+  move.recoveryFailures = failures.map((failure) => failure.label);
+  committed.domainMove = move;
+  try {
+    context.checkpoint(committed);
+  } catch (error) {
+    failures.push({
+      label: "save recovery record",
+      message: error instanceof Error ? error.message : String(error)
+    });
+  }
+  for (const failure of failures) {
+    console.error(`Rollback is incomplete (${failure.label}): ${failure.message}`);
+  }
+  console.error(
+    "The deployment remains locked for recovery. Re-run the same domain command after you correct the reported Cloudflare or local-file error."
+  );
+}

--- a/scripts/hqbase/domain-runtime.mjs
+++ b/scripts/hqbase/domain-runtime.mjs
@@ -1,0 +1,145 @@
+import { randomUUID } from "node:crypto";
+
+import { configPath } from "./manifest.mjs";
+
+const discoveryPath = "/api/v1/openapi.json";
+const defaultProbeTimeoutMs = 5_000;
+
+export function setCanonicalPortal({ hostname, manifest, runCommand, zoneId }) {
+  const statements = [];
+  if (hostname) {
+    const quotedHostname = quoteSql(hostname);
+    const quotedZoneId = zoneId ? quoteSql(zoneId) : "NULL";
+    statements.push(
+      `INSERT INTO workspace_hosts (id, hostname, zone_id, kind, is_canonical, status, verified_at, created_at, updated_at) VALUES (${quoteSql(`host_${randomUUID()}`)}, ${quotedHostname}, ${quotedZoneId}, 'portal', 0, 'ready', datetime('now'), datetime('now'), datetime('now')) ON CONFLICT(hostname) DO UPDATE SET zone_id = COALESCE(excluded.zone_id, workspace_hosts.zone_id), status = 'ready', verified_at = datetime('now'), updated_at = datetime('now')`,
+      `UPDATE workspace_hosts SET is_canonical = 0, updated_at = datetime('now') WHERE kind = 'portal' AND is_canonical = 1 AND hostname <> ${quotedHostname}`,
+      `UPDATE workspace_hosts SET is_canonical = 1, updated_at = datetime('now') WHERE kind = 'portal' AND hostname = ${quotedHostname}`
+    );
+  } else {
+    statements.push(
+      "UPDATE workspace_hosts SET is_canonical = 0, updated_at = datetime('now') WHERE kind = 'portal'"
+    );
+  }
+
+  executeD1(manifest, statements, runCommand);
+  const actual = readCanonicalPortal({ manifest, runCommand });
+  if (actual !== (hostname ?? null)) {
+    throw new Error(
+      `Refusing to continue: D1 reports canonical portal ${actual ?? "none"}, not ${hostname ?? "none"}.`
+    );
+  }
+}
+
+export function readCanonicalPortal({ manifest, runCommand }) {
+  const output = executeD1(
+    manifest,
+    ["SELECT hostname FROM workspace_hosts WHERE kind = 'portal' AND is_canonical = 1"],
+    runCommand
+  );
+  return canonicalHostnameFromD1Output(output);
+}
+
+export function canonicalHostnameFromD1Output(output) {
+  let payload;
+  try {
+    payload = JSON.parse(output);
+  } catch {
+    throw new Error("Could not parse the canonical portal check from Wrangler JSON output.");
+  }
+  const batches = Array.isArray(payload) ? payload : [payload];
+  const result = [...batches].reverse().find((candidate) => Array.isArray(candidate?.results));
+  if (!result) {
+    throw new Error("Wrangler did not return the canonical portal check result.");
+  }
+  if (result.results.length > 1) {
+    throw new Error("D1 reports more than one canonical portal hostname.");
+  }
+  const hostname = result.results[0]?.hostname;
+  if (hostname == null) return null;
+  if (typeof hostname !== "string" || !hostname) {
+    throw new Error("Wrangler returned an invalid canonical portal hostname.");
+  }
+  return hostname;
+}
+
+export function createDomainProbe(
+  environment = process.env,
+  fetchImpl = globalThis.fetch,
+  options = {}
+) {
+  const clientId = environment.HQBASE_DOMAIN_ACCESS_CLIENT_ID?.trim();
+  const clientSecret = environment.HQBASE_DOMAIN_ACCESS_CLIENT_SECRET?.trim();
+  const timeoutMs = options.timeoutMs ?? defaultProbeTimeoutMs;
+  if (Boolean(clientId) !== Boolean(clientSecret)) {
+    throw new Error(
+      "Set both HQBASE_DOMAIN_ACCESS_CLIENT_ID and HQBASE_DOMAIN_ACCESS_CLIENT_SECRET, or neither."
+    );
+  }
+  return async (url) => {
+    const response = await fetchImpl(url, {
+      headers: {
+        accept: "application/json",
+        ...(clientId
+          ? {
+              "cf-access-client-id": clientId,
+              "cf-access-client-secret": clientSecret
+            }
+          : {})
+      },
+      redirect: "error",
+      signal: AbortSignal.timeout(timeoutMs)
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const document = await response.json();
+    return document?.servers?.[0]?.url;
+  };
+}
+
+export async function probeServiceOrigin({ origin, probe, retry }) {
+  const { attempts, delayMs } = retry;
+  let lastError = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const advertised = await probe(`${origin}${discoveryPath}`);
+      if (typeof advertised === "string" && advertised) return advertised.replace(/\/$/, "");
+      lastError = new Error("the installation did not advertise a service origin");
+    } catch (error) {
+      lastError = error;
+    }
+    if (attempt < attempts) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error(
+    `Refusing to continue: ${origin} did not serve a healthy HQBase installation (${lastError?.message ?? "no response"}). DNS or the certificate is not ready.`
+  );
+}
+
+function executeD1(manifest, statements, runCommand) {
+  return runCommand(
+    "pnpm",
+    [
+      "exec",
+      "wrangler",
+      "d1",
+      "execute",
+      manifest.d1.name,
+      "--remote",
+      "--yes",
+      "--json",
+      "--command",
+      `${statements.join("; ")};`,
+      "--config",
+      configPath(manifest.name)
+    ],
+    {
+      env: { CLOUDFLARE_ACCOUNT_ID: manifest.accountId },
+      quiet: true,
+      stdoutOnly: true
+    }
+  );
+}
+
+function quoteSql(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}

--- a/scripts/hqbase/domain.mjs
+++ b/scripts/hqbase/domain.mjs
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { optionalBoolean, optionalString, requireString } from "./args.mjs";
+import { run } from "./command.mjs";
+import { writeWranglerConfig } from "./config.mjs";
+import { cloudflareOAuthConfig } from "./install.mjs";
+import { configPath, loadManifest, writeManifest } from "./manifest.mjs";
+import { rootDir } from "./paths.mjs";
+
+const hostPattern = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z][a-z0-9-]{0,62}$/;
+
+/**
+ * Move a deployment to a different custom Worker domain without touching D1, R2, or queues.
+ *
+ *   pnpm hqbase domain --name dev-01 --app-domain app.example.com [--auth-url https://app.example.com]
+ *   pnpm hqbase domain --name dev-01 --detach
+ */
+export function configureDomain(flags) {
+  const name = requireString(flags, "name");
+  const dryRun = optionalBoolean(flags, "dry-run");
+  const skipDeploy = optionalBoolean(flags, "skip-deploy");
+  const previous = loadManifest(name);
+  const manifest = updateDomainManifest(previous, {
+    appDomain: optionalString(flags, "app-domain"),
+    authUrl: optionalString(flags, "auth-url"),
+    detach: optionalBoolean(flags, "detach")
+  });
+
+  writeManifest(manifest, { dryRun });
+  writeWranglerConfig(manifest, { dryRun });
+  if (!skipDeploy) {
+    // wrangler validates assets.directory even though a trigger deploy uploads nothing from it.
+    if (!dryRun) fs.mkdirSync(path.join(rootDir, "dist"), { recursive: true });
+    // Custom domains are Worker triggers: apply them from the config without re-uploading code,
+    // so the running release (and its vars/secrets) stays exactly as it is.
+    run("pnpm", ["exec", "wrangler", "triggers", "deploy", "--config", configPath(name)], {
+      dryRun
+    });
+    if (previous.authUrl !== manifest.authUrl && !dryRun) {
+      // BETTER_AUTH_URL is a var, which only a Worker deploy can change.
+      run("node", ["scripts/release/deploy.mjs", "--config", configPath(name)]);
+    }
+  }
+
+  const target = manifest.appDomain
+    ? `custom domain ${manifest.appDomain}`
+    : "the default workers.dev hostname";
+  console.log(
+    dryRun
+      ? `HQBase deployment "${name}" domain configuration is valid (${target}).`
+      : `HQBase deployment "${name}" now serves from ${target}.`
+  );
+  for (const note of domainChangeNotes(previous, manifest)) {
+    console.log(`  - ${note}`);
+  }
+}
+
+export function updateDomainManifest(manifest, input) {
+  if (input.detach && input.appDomain) {
+    throw new Error("Use either --app-domain or --detach, not both.");
+  }
+  if (!input.detach && !input.appDomain) {
+    throw new Error("Domain change requires --app-domain <host> or --detach.");
+  }
+  const appDomain = input.detach ? undefined : normalizeHost(input.appDomain);
+  const authUrl = resolveAuthUrl(manifest, appDomain, input.authUrl);
+  const cloudflareOAuth = manifest.cloudflareOAuth ?? { mode: "official" };
+
+  return {
+    ...manifest,
+    version: 2,
+    appDomain,
+    authUrl,
+    // Re-validate customer-managed OAuth against the new origin; official mode is unaffected.
+    cloudflareOAuth: cloudflareOAuthConfig({
+      authUrl,
+      clientId: cloudflareOAuth.clientId,
+      mode: cloudflareOAuth.mode
+    })
+  };
+}
+
+export function domainChangeNotes(previous, next) {
+  const notes = [];
+  if (previous.appDomain && previous.appDomain !== next.appDomain) {
+    notes.push(
+      `Cloudflare detaches ${previous.appDomain} from the Worker on deploy; its DNS record is removed automatically.`
+    );
+  }
+  if (next.appDomain && previous.appDomain !== next.appDomain) {
+    notes.push(
+      `${next.appDomain} must be a zone in this Cloudflare account; the deploy creates its DNS record and certificate.`
+    );
+  }
+  if (previous.authUrl !== next.authUrl) {
+    notes.push(
+      `Auth origin changed to ${next.authUrl ?? "the request origin"}: existing sessions are invalidated and users must sign in again.`
+    );
+    if (next.cloudflareOAuth?.mode === "customer") {
+      notes.push(
+        `Customer-managed OAuth: re-register the redirect URIs on ${next.authUrl} for /api/setup/cloudflare/oauth/callback, /api/updates/cloudflare/oauth/callback, and /api/domains/cloudflare/oauth/callback.`
+      );
+    }
+  }
+  notes.push("D1, R2, and queues were not modified.");
+  return notes;
+}
+
+function resolveAuthUrl(manifest, appDomain, explicit) {
+  if (explicit) {
+    return explicit;
+  }
+  if (!manifest.authUrl) {
+    return undefined;
+  }
+  // The previous canonical origin no longer exists once the domain moves; follow the new host.
+  return appDomain ? `https://${appDomain}` : undefined;
+}
+
+function normalizeHost(value) {
+  const host = String(value).trim().toLowerCase().replace(/\.$/, "");
+  if (!hostPattern.test(host)) {
+    throw new Error(
+      `--app-domain must be a bare hostname such as app.example.com (got "${value}").`
+    );
+  }
+  return host;
+}

--- a/scripts/hqbase/domain.mjs
+++ b/scripts/hqbase/domain.mjs
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -7,7 +6,7 @@ import {
   assertAttachmentAllowed,
   createWorkerDomainsClient,
   planAttachment,
-  requireCloudflareApiToken
+  requireDomainApiToken
 } from "./cloudflare-domains.mjs";
 import { run } from "./command.mjs";
 import { writeWranglerConfig } from "./config.mjs";
@@ -15,17 +14,24 @@ import {
   assertResumable,
   domainChangeNotes,
   hostOf,
+  migrateStagedMoveRecord,
   stagedMoveRecord,
   updateDomainManifest
 } from "./domain-plan.mjs";
+import { assertManagedHosts, domainSnapshot, rollbackDomainMove } from "./domain-recovery.mjs";
+import {
+  createDomainProbe,
+  probeServiceOrigin,
+  readCanonicalPortal,
+  setCanonicalPortal
+} from "./domain-runtime.mjs";
 import { configPath, loadManifest, writeManifest } from "./manifest.mjs";
 import { rootDir } from "./paths.mjs";
 import { prepareManifest, resolveCloudflareAccount } from "./resources.mjs";
 
-const discoveryPath = "/api/v1/openapi.json";
-
 /**
- * Move a deployment to a different canonical portal hostname without touching D1, R2, or queues.
+ * Move a deployment to a different canonical portal hostname without changing mail data or the
+ * identities of its D1, R2, and queue resources.
  *
  * The workspace has one mutable canonical portal hostname and one stable machine-facing service
  * origin (BETTER_AUTH_URL: the auth issuer, the Mail API audience, and the MCP audience). A portal
@@ -34,13 +40,20 @@ const discoveryPath = "/api/v1/openapi.json";
  *
  *   pnpm hqbase domain --name dev-01 --app-domain app.example.com
  *   pnpm hqbase domain --name dev-01 --app-domain app.example.com --move-service-origin
- *   pnpm hqbase domain --name dev-01 --detach --auth-url https://mail.example.com --yes
+ *   pnpm hqbase domain --name dev-01 --detach --move-service-origin --yes
  */
 export async function configureDomain(flags, options = {}) {
   const name = requireString(flags, "name");
   const dryRun = optionalBoolean(flags, "dry-run");
-  const skipDeploy = optionalBoolean(flags, "skip-deploy");
   const yes = optionalBoolean(flags, "yes");
+  if (flags["skip-deploy"] !== undefined) {
+    throw new Error("--skip-deploy is not supported because a partial domain move is unsafe.");
+  }
+  if (flags["override-existing"] !== undefined) {
+    throw new Error(
+      "--override-existing is not supported. Move or remove the conflicting hostname in Cloudflare before retrying."
+    );
+  }
   const environment = options.environment ?? process.env;
   const runCommand = options.runCommand ?? run;
   const checkpoint = options.checkpoint ?? writeManifest;
@@ -50,15 +63,14 @@ export async function configureDomain(flags, options = {}) {
     detach: optionalBoolean(flags, "detach"),
     detachOld: optionalBoolean(flags, "detach-old"),
     keepServiceOrigin: optionalBoolean(flags, "keep-service-origin"),
-    moveServiceOrigin: optionalBoolean(flags, "move-service-origin"),
-    override: optionalBoolean(flags, "override-existing")
+    moveServiceOrigin: optionalBoolean(flags, "move-service-origin")
   };
 
-  const committed = loadManifest(name);
-  const proposed = updateDomainManifest(committed, input);
+  const loaded = loadManifest(name);
 
   if (dryRun) {
-    reportPlan(name, committed, proposed, { dryRun: true });
+    const proposed = updateDomainManifest(loaded, input);
+    reportPlan(name, loaded, proposed, { dryRun: true });
     return proposed;
   }
   if ((input.detach || input.detachOld) && !yes) {
@@ -67,35 +79,48 @@ export async function configureDomain(flags, options = {}) {
     );
   }
 
-  const accountId = resolveCloudflareAccount(committed.accountId, { environment, runCommand });
-  const verified = prepareManifest(committed, accountId, {
+  const domainApiToken = options.domains ? null : requireDomainApiToken(environment);
+  const accountId = resolveCloudflareAccount(loaded.accountId, { environment, runCommand });
+  const verified = prepareManifest(loaded, accountId, {
     allowDomainMove: true,
     checkpoint,
     runCommand
   });
+  const proposed = updateDomainManifest(verified, input);
   const target = { ...proposed, accountId: verified.accountId };
-  assertResumable(verified, target);
+  assertResumable(verified, target, { detachOld: input.detachOld });
 
   const domains =
     options.domains ??
     createWorkerDomainsClient({
       accountId: verified.accountId,
-      token: requireCloudflareApiToken(environment)
+      token: domainApiToken
     });
   const context = {
     checkpoint,
     committed: verified,
     deployConfiguration: options.deployConfiguration ?? defaultDeployConfiguration,
     domains,
-    confirmed: yes,
-    override: input.override,
-    probe: options.probe ?? defaultProbe,
-    retry: options.retry ?? { attempts: 10, delayMs: 3000 },
+    probe: options.probe ?? createDomainProbe(environment),
+    retry: options.retry ?? { attempts: 150, delayMs: 2000 },
     runCommand,
-    skipDeploy,
+    setCanonicalPortal: options.setCanonicalPortal ?? setCanonicalPortal,
+    readCanonicalPortal: options.readCanonicalPortal ?? readCanonicalPortal,
     target
   };
 
+  if (!verified.domainMove) {
+    await assertManagedHosts(context);
+    const canonical = await context.readCanonicalPortal({
+      manifest: verified,
+      runCommand: context.runCommand
+    });
+    if (canonical !== (verified.appDomain ?? null)) {
+      throw new Error(
+        `Refusing to continue: D1 reports ${canonical ?? "no canonical portal"}, not the saved hostname ${verified.appDomain ?? "none"}.`
+      );
+    }
+  }
   const move = stageMove(verified, target, { checkpoint, detachOld: input.detachOld });
   try {
     if (target.appDomain) {
@@ -105,9 +130,10 @@ export async function configureDomain(flags, options = {}) {
     await cutover(context, move);
     await redirect(context, move);
     await detachRetiredHosts(context, move);
+    await assertManagedHosts(context, target);
     commitMove(context, move);
   } catch (error) {
-    await rollback(context, move, error);
+    await rollbackDomainMove(context, move, error);
     throw error;
   }
 
@@ -117,7 +143,8 @@ export async function configureDomain(flags, options = {}) {
 
 function stageMove(manifest, target, options) {
   const move =
-    manifest.domainMove ?? stagedMoveRecord(manifest, target, { detachOld: options.detachOld });
+    (manifest.domainMove && migrateStagedMoveRecord(manifest.domainMove)) ??
+    stagedMoveRecord(manifest, target, { detachOld: options.detachOld });
   manifest.domainMove = move;
   options.checkpoint(manifest);
   return move;
@@ -126,18 +153,17 @@ function stageMove(manifest, target, options) {
 async function attachHost(context, move) {
   const { committed, domains, target } = context;
   const hostname = target.appDomain;
-  const plan = planAttachment(await domains.list(), {
+  const plan = planAttachment(await domains.list({ hostname }), {
     hostname,
     service: committed.worker.name
   });
   assertAttachmentAllowed(plan, {
     hostname,
-    confirmed: context.confirmed,
-    override: context.override,
     service: committed.worker.name
   });
   if (plan.action === "keep") {
     move.attachedDomainId = plan.existing.id ?? null;
+    move.targetZoneId = plan.existing.zone_id ?? plan.existing.zoneId ?? null;
     move.state = "attached";
     context.checkpoint(committed);
     return;
@@ -150,16 +176,16 @@ async function attachHost(context, move) {
     );
   }
   move.state = "attaching";
+  move.attachedByThisRun = true;
   context.checkpoint(committed);
   const attached = await domains.attach({
     hostname,
     service: committed.worker.name,
     zoneId: zone.id,
-    zoneName: zone.name,
-    override: context.override
+    zoneName: zone.name
   });
   move.attachedDomainId = attached?.id ?? null;
-  move.attachedByThisRun = true;
+  move.targetZoneId = attached?.zone_id ?? attached?.zoneId ?? zone.id;
   move.state = "attached";
   context.checkpoint(committed);
 }
@@ -167,7 +193,9 @@ async function attachHost(context, move) {
 async function verifyHost(context, move) {
   const { committed, domains, target } = context;
   const hostname = target.appDomain;
-  const attached = (await domains.list()).find((domain) => domain?.hostname === hostname);
+  const attached = (await domains.list({ hostname })).find(
+    (domain) => domain?.hostname === hostname
+  );
   if (!attached || attached.service !== committed.worker.name) {
     throw new Error(
       `Refusing to continue: Cloudflare does not report ${hostname} as a custom domain of Worker "${committed.worker.name}".`
@@ -181,19 +209,16 @@ async function verifyHost(context, move) {
 async function cutover(context, move) {
   const { committed, target } = context;
   writeWranglerConfig(target);
-  if (context.skipDeploy) {
-    move.state = "cutover";
-    context.checkpoint(committed);
-    return;
-  }
   // wrangler validates assets.directory even for a configuration deployment.
   fs.mkdirSync(path.join(rootDir, "dist"), { recursive: true });
-  context.deployConfiguration({
+  move.configurationDeployAttempted = true;
+  move.state = "deploying";
+  context.checkpoint(committed);
+  await context.deployConfiguration({
     accountId: committed.accountId,
     configFile: configPath(committed.name),
     runCommand: context.runCommand
   });
-  move.deployed = true;
   move.state = "cutover";
   context.checkpoint(committed);
 
@@ -211,31 +236,15 @@ async function cutover(context, move) {
 
 async function redirect(context, move) {
   const { committed, target } = context;
-  if (!target.appDomain || context.skipDeploy) {
-    return;
-  }
-  const statements = [
-    `INSERT INTO workspace_hosts (id, hostname, zone_id, kind, is_canonical, status, verified_at, created_at, updated_at) VALUES ('host_${randomUUID()}', '${target.appDomain}', NULL, 'portal', 0, 'ready', datetime('now'), datetime('now'), datetime('now')) ON CONFLICT(hostname) DO UPDATE SET status = 'ready', verified_at = datetime('now'), updated_at = datetime('now')`,
-    "UPDATE workspace_hosts SET is_canonical = 0, updated_at = datetime('now') WHERE kind = 'portal'",
-    `UPDATE workspace_hosts SET is_canonical = 1, updated_at = datetime('now') WHERE hostname = '${target.appDomain}'`
-  ];
-  context.runCommand(
-    "pnpm",
-    [
-      "exec",
-      "wrangler",
-      "d1",
-      "execute",
-      committed.d1.name,
-      "--remote",
-      "--yes",
-      "--command",
-      `${statements.join("; ")};`,
-      "--config",
-      configPath(committed.name)
-    ],
-    { env: { CLOUDFLARE_ACCOUNT_ID: committed.accountId } }
-  );
+  move.canonicalUpdateAttempted = true;
+  move.state = "redirecting";
+  context.checkpoint(committed);
+  await context.setCanonicalPortal({
+    hostname: target.appDomain ?? null,
+    manifest: target,
+    runCommand: context.runCommand,
+    zoneId: move.targetZoneId
+  });
   move.state = "redirected";
   context.checkpoint(committed);
 }
@@ -244,22 +253,29 @@ async function detachRetiredHosts(context, move) {
   const { committed, domains, target } = context;
   const keep = new Set([target.appDomain, ...(target.retiredDomains ?? [])].filter(Boolean));
   const owned = new Set([committed.appDomain, ...(committed.retiredDomains ?? [])].filter(Boolean));
-  const removable = (list) =>
-    list.filter(
-      (domain) =>
-        domain?.service === committed.worker.name &&
-        owned.has(domain.hostname) &&
-        !keep.has(domain.hostname)
+  for (const hostname of [...owned].filter((candidate) => !keep.has(candidate))) {
+    const domain = (await domains.list({ hostname })).find(
+      (candidate) =>
+        candidate?.hostname === hostname && candidate?.service === committed.worker.name
     );
-
-  for (const domain of removable(await domains.list())) {
+    if (!domain) continue;
+    move.pendingRemoval = domainSnapshot(domain);
+    move.state = "detaching";
+    context.checkpoint(committed);
     await domains.remove(domain.id);
-  }
-  const stale = removable(await domains.list());
-  if (stale.length > 0) {
-    throw new Error(
-      `Refusing to finish: Cloudflare still reports ${stale.map((domain) => domain.hostname).join(", ")} as a custom domain of Worker "${committed.worker.name}".`
+    const stillAttached = (await domains.list({ hostname })).some(
+      (candidate) =>
+        candidate?.hostname === hostname && candidate?.service === committed.worker.name
     );
+    if (stillAttached) {
+      throw new Error(
+        `Refusing to finish: Cloudflare still reports ${hostname} as a custom domain of Worker "${committed.worker.name}".`
+      );
+    }
+    move.removedDomains ??= [];
+    move.removedDomains.push(move.pendingRemoval);
+    move.pendingRemoval = null;
+    context.checkpoint(committed);
   }
   move.state = "detached";
   context.checkpoint(committed);
@@ -274,73 +290,8 @@ function commitMove(context, move) {
   writeWranglerConfig(next);
 }
 
-async function rollback(context, move, cause) {
-  const { committed, domains, target } = context;
-  console.error(`Domain move failed after step "${move.state}": ${cause.message}`);
-  try {
-    if (move.deployed) {
-      writeWranglerConfig(committed);
-      if (!context.skipDeploy) {
-        context.deployConfiguration({
-          accountId: committed.accountId,
-          configFile: configPath(committed.name),
-          runCommand: context.runCommand
-        });
-      }
-      move.deployed = false;
-    }
-    if (move.attachedByThisRun && move.attachedDomainId && !context.override) {
-      await domains.remove(move.attachedDomainId);
-      move.attachedByThisRun = false;
-      move.attachedDomainId = null;
-    }
-    move.state = "rolled-back";
-  } catch (rollbackError) {
-    console.error(`Rollback is incomplete: ${rollbackError.message}`);
-  } finally {
-    committed.domainMove = move;
-    context.checkpoint(committed);
-    writeWranglerConfig(committed);
-    console.error(
-      `The saved deployment record still describes ${committed.appDomain ?? "the default hostname"}. Re-run the same command to resume, or inspect Cloudflare and repair "${committed.name}".`
-    );
-    if (move.attachedByThisRun && move.attachedDomainId) {
-      console.error(
-        `Custom domain recovery: DELETE /accounts/${committed.accountId}/workers/domains/${move.attachedDomainId} removes ${target.appDomain}.`
-      );
-    }
-  }
-}
-
 async function probeOrigin(context, origin) {
-  const { attempts, delayMs } = context.retry;
-  let lastError = null;
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    try {
-      const advertised = await context.probe(`${origin}${discoveryPath}`);
-      if (typeof advertised === "string" && advertised) {
-        return advertised.replace(/\/$/, "");
-      }
-      lastError = new Error("the installation did not advertise a service origin");
-    } catch (error) {
-      lastError = error;
-    }
-    if (attempt < attempts) {
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-    }
-  }
-  throw new Error(
-    `Refusing to continue: ${origin} did not serve a healthy HQBase installation (${lastError?.message ?? "no response"}). DNS or the certificate is not ready.`
-  );
-}
-
-async function defaultProbe(url) {
-  const response = await fetch(url, { headers: { accept: "application/json" } });
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`);
-  }
-  const document = await response.json();
-  return document?.servers?.[0]?.url;
+  return probeServiceOrigin({ origin, probe: context.probe, retry: context.retry });
 }
 
 function defaultDeployConfiguration({ accountId, configFile, runCommand }) {

--- a/scripts/hqbase/domain.mjs
+++ b/scripts/hqbase/domain.mjs
@@ -1,129 +1,366 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
 import { optionalBoolean, optionalString, requireString } from "./args.mjs";
+import {
+  assertAttachmentAllowed,
+  createWorkerDomainsClient,
+  planAttachment,
+  requireCloudflareApiToken
+} from "./cloudflare-domains.mjs";
 import { run } from "./command.mjs";
 import { writeWranglerConfig } from "./config.mjs";
-import { cloudflareOAuthConfig } from "./install.mjs";
+import {
+  assertResumable,
+  domainChangeNotes,
+  hostOf,
+  stagedMoveRecord,
+  updateDomainManifest
+} from "./domain-plan.mjs";
 import { configPath, loadManifest, writeManifest } from "./manifest.mjs";
 import { rootDir } from "./paths.mjs";
+import { prepareManifest, resolveCloudflareAccount } from "./resources.mjs";
 
-const hostPattern = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z][a-z0-9-]{0,62}$/;
+const discoveryPath = "/api/v1/openapi.json";
 
 /**
- * Move a deployment to a different custom Worker domain without touching D1, R2, or queues.
+ * Move a deployment to a different canonical portal hostname without touching D1, R2, or queues.
  *
- *   pnpm hqbase domain --name dev-01 --app-domain app.example.com [--auth-url https://app.example.com]
- *   pnpm hqbase domain --name dev-01 --detach
+ * The workspace has one mutable canonical portal hostname and one stable machine-facing service
+ * origin (BETTER_AUTH_URL: the auth issuer, the Mail API audience, and the MCP audience). A portal
+ * move follows attach, verify, cutover, redirect, and it never moves the service origin unless the
+ * operator asks for that explicitly.
+ *
+ *   pnpm hqbase domain --name dev-01 --app-domain app.example.com
+ *   pnpm hqbase domain --name dev-01 --app-domain app.example.com --move-service-origin
+ *   pnpm hqbase domain --name dev-01 --detach --auth-url https://mail.example.com --yes
  */
-export function configureDomain(flags) {
+export async function configureDomain(flags, options = {}) {
   const name = requireString(flags, "name");
   const dryRun = optionalBoolean(flags, "dry-run");
   const skipDeploy = optionalBoolean(flags, "skip-deploy");
-  const previous = loadManifest(name);
-  const manifest = updateDomainManifest(previous, {
+  const yes = optionalBoolean(flags, "yes");
+  const environment = options.environment ?? process.env;
+  const runCommand = options.runCommand ?? run;
+  const checkpoint = options.checkpoint ?? writeManifest;
+  const input = {
     appDomain: optionalString(flags, "app-domain"),
     authUrl: optionalString(flags, "auth-url"),
-    detach: optionalBoolean(flags, "detach")
-  });
-
-  writeManifest(manifest, { dryRun });
-  writeWranglerConfig(manifest, { dryRun });
-  if (!skipDeploy) {
-    // wrangler validates assets.directory even though a trigger deploy uploads nothing from it.
-    if (!dryRun) fs.mkdirSync(path.join(rootDir, "dist"), { recursive: true });
-    // Custom domains are Worker triggers: apply them from the config without re-uploading code,
-    // so the running release (and its vars/secrets) stays exactly as it is.
-    run("pnpm", ["exec", "wrangler", "triggers", "deploy", "--config", configPath(name)], {
-      dryRun
-    });
-    if (previous.authUrl !== manifest.authUrl && !dryRun) {
-      // BETTER_AUTH_URL is a var, which only a Worker deploy can change.
-      run("node", ["scripts/release/deploy.mjs", "--config", configPath(name)]);
-    }
-  }
-
-  const target = manifest.appDomain
-    ? `custom domain ${manifest.appDomain}`
-    : "the default workers.dev hostname";
-  console.log(
-    dryRun
-      ? `HQBase deployment "${name}" domain configuration is valid (${target}).`
-      : `HQBase deployment "${name}" now serves from ${target}.`
-  );
-  for (const note of domainChangeNotes(previous, manifest)) {
-    console.log(`  - ${note}`);
-  }
-}
-
-export function updateDomainManifest(manifest, input) {
-  if (input.detach && input.appDomain) {
-    throw new Error("Use either --app-domain or --detach, not both.");
-  }
-  if (!input.detach && !input.appDomain) {
-    throw new Error("Domain change requires --app-domain <host> or --detach.");
-  }
-  const appDomain = input.detach ? undefined : normalizeHost(input.appDomain);
-  const authUrl = resolveAuthUrl(manifest, appDomain, input.authUrl);
-  const cloudflareOAuth = manifest.cloudflareOAuth ?? { mode: "official" };
-
-  return {
-    ...manifest,
-    version: 2,
-    appDomain,
-    authUrl,
-    // Re-validate customer-managed OAuth against the new origin; official mode is unaffected.
-    cloudflareOAuth: cloudflareOAuthConfig({
-      authUrl,
-      clientId: cloudflareOAuth.clientId,
-      mode: cloudflareOAuth.mode
-    })
+    detach: optionalBoolean(flags, "detach"),
+    detachOld: optionalBoolean(flags, "detach-old"),
+    keepServiceOrigin: optionalBoolean(flags, "keep-service-origin"),
+    moveServiceOrigin: optionalBoolean(flags, "move-service-origin"),
+    override: optionalBoolean(flags, "override-existing")
   };
+
+  const committed = loadManifest(name);
+  const proposed = updateDomainManifest(committed, input);
+
+  if (dryRun) {
+    reportPlan(name, committed, proposed, { dryRun: true });
+    return proposed;
+  }
+  if ((input.detach || input.detachOld) && !yes) {
+    throw new Error(
+      "Removing a custom domain deletes its Cloudflare DNS record and requires --yes."
+    );
+  }
+
+  const accountId = resolveCloudflareAccount(committed.accountId, { environment, runCommand });
+  const verified = prepareManifest(committed, accountId, {
+    allowDomainMove: true,
+    checkpoint,
+    runCommand
+  });
+  const target = { ...proposed, accountId: verified.accountId };
+  assertResumable(verified, target);
+
+  const domains =
+    options.domains ??
+    createWorkerDomainsClient({
+      accountId: verified.accountId,
+      token: requireCloudflareApiToken(environment)
+    });
+  const context = {
+    checkpoint,
+    committed: verified,
+    deployConfiguration: options.deployConfiguration ?? defaultDeployConfiguration,
+    domains,
+    confirmed: yes,
+    override: input.override,
+    probe: options.probe ?? defaultProbe,
+    retry: options.retry ?? { attempts: 10, delayMs: 3000 },
+    runCommand,
+    skipDeploy,
+    target
+  };
+
+  const move = stageMove(verified, target, { checkpoint, detachOld: input.detachOld });
+  try {
+    if (target.appDomain) {
+      await attachHost(context, move);
+      await verifyHost(context, move);
+    }
+    await cutover(context, move);
+    await redirect(context, move);
+    await detachRetiredHosts(context, move);
+    commitMove(context, move);
+  } catch (error) {
+    await rollback(context, move, error);
+    throw error;
+  }
+
+  reportPlan(name, verified, target, { dryRun: false });
+  return target;
 }
 
-export function domainChangeNotes(previous, next) {
-  const notes = [];
-  if (previous.appDomain && previous.appDomain !== next.appDomain) {
-    notes.push(
-      `Cloudflare detaches ${previous.appDomain} from the Worker on deploy; its DNS record is removed automatically.`
+function stageMove(manifest, target, options) {
+  const move =
+    manifest.domainMove ?? stagedMoveRecord(manifest, target, { detachOld: options.detachOld });
+  manifest.domainMove = move;
+  options.checkpoint(manifest);
+  return move;
+}
+
+async function attachHost(context, move) {
+  const { committed, domains, target } = context;
+  const hostname = target.appDomain;
+  const plan = planAttachment(await domains.list(), {
+    hostname,
+    service: committed.worker.name
+  });
+  assertAttachmentAllowed(plan, {
+    hostname,
+    confirmed: context.confirmed,
+    override: context.override,
+    service: committed.worker.name
+  });
+  if (plan.action === "keep") {
+    move.attachedDomainId = plan.existing.id ?? null;
+    move.state = "attached";
+    context.checkpoint(committed);
+    return;
+  }
+
+  const zone = await domains.findZone(hostname);
+  if (!zone) {
+    throw new Error(
+      `Refusing to attach ${hostname}: no Cloudflare zone in account ${committed.accountId} serves it.`
     );
   }
-  if (next.appDomain && previous.appDomain !== next.appDomain) {
-    notes.push(
-      `${next.appDomain} must be a zone in this Cloudflare account; the deploy creates its DNS record and certificate.`
+  move.state = "attaching";
+  context.checkpoint(committed);
+  const attached = await domains.attach({
+    hostname,
+    service: committed.worker.name,
+    zoneId: zone.id,
+    zoneName: zone.name,
+    override: context.override
+  });
+  move.attachedDomainId = attached?.id ?? null;
+  move.attachedByThisRun = true;
+  move.state = "attached";
+  context.checkpoint(committed);
+}
+
+async function verifyHost(context, move) {
+  const { committed, domains, target } = context;
+  const hostname = target.appDomain;
+  const attached = (await domains.list()).find((domain) => domain?.hostname === hostname);
+  if (!attached || attached.service !== committed.worker.name) {
+    throw new Error(
+      `Refusing to continue: Cloudflare does not report ${hostname} as a custom domain of Worker "${committed.worker.name}".`
     );
   }
-  if (previous.authUrl !== next.authUrl) {
-    notes.push(
-      `Auth origin changed to ${next.authUrl ?? "the request origin"}: existing sessions are invalidated and users must sign in again.`
-    );
-    if (next.cloudflareOAuth?.mode === "customer") {
-      notes.push(
-        `Customer-managed OAuth: re-register the redirect URIs on ${next.authUrl} for /api/setup/cloudflare/oauth/callback, /api/updates/cloudflare/oauth/callback, and /api/domains/cloudflare/oauth/callback.`
+  await probeOrigin(context, `https://${hostname}`);
+  move.state = "verified";
+  context.checkpoint(committed);
+}
+
+async function cutover(context, move) {
+  const { committed, target } = context;
+  writeWranglerConfig(target);
+  if (context.skipDeploy) {
+    move.state = "cutover";
+    context.checkpoint(committed);
+    return;
+  }
+  // wrangler validates assets.directory even for a configuration deployment.
+  fs.mkdirSync(path.join(rootDir, "dist"), { recursive: true });
+  context.deployConfiguration({
+    accountId: committed.accountId,
+    configFile: configPath(committed.name),
+    runCommand: context.runCommand
+  });
+  move.deployed = true;
+  move.state = "cutover";
+  context.checkpoint(committed);
+
+  const probeHost = target.appDomain ?? hostOf(target.authUrl);
+  if (probeHost) {
+    const advertised = await probeOrigin(context, `https://${probeHost}`);
+    const expected = target.authUrl ?? `https://${probeHost}`;
+    if (advertised !== expected) {
+      throw new Error(
+        `Refusing to continue: ${probeHost} advertises the service origin ${advertised}, not ${expected}. BETTER_AUTH_URL was not deployed.`
       );
     }
   }
-  notes.push("D1, R2, and queues were not modified.");
-  return notes;
 }
 
-function resolveAuthUrl(manifest, appDomain, explicit) {
-  if (explicit) {
-    return explicit;
+async function redirect(context, move) {
+  const { committed, target } = context;
+  if (!target.appDomain || context.skipDeploy) {
+    return;
   }
-  if (!manifest.authUrl) {
-    return undefined;
-  }
-  // The previous canonical origin no longer exists once the domain moves; follow the new host.
-  return appDomain ? `https://${appDomain}` : undefined;
+  const statements = [
+    `INSERT INTO workspace_hosts (id, hostname, zone_id, kind, is_canonical, status, verified_at, created_at, updated_at) VALUES ('host_${randomUUID()}', '${target.appDomain}', NULL, 'portal', 0, 'ready', datetime('now'), datetime('now'), datetime('now')) ON CONFLICT(hostname) DO UPDATE SET status = 'ready', verified_at = datetime('now'), updated_at = datetime('now')`,
+    "UPDATE workspace_hosts SET is_canonical = 0, updated_at = datetime('now') WHERE kind = 'portal'",
+    `UPDATE workspace_hosts SET is_canonical = 1, updated_at = datetime('now') WHERE hostname = '${target.appDomain}'`
+  ];
+  context.runCommand(
+    "pnpm",
+    [
+      "exec",
+      "wrangler",
+      "d1",
+      "execute",
+      committed.d1.name,
+      "--remote",
+      "--yes",
+      "--command",
+      `${statements.join("; ")};`,
+      "--config",
+      configPath(committed.name)
+    ],
+    { env: { CLOUDFLARE_ACCOUNT_ID: committed.accountId } }
+  );
+  move.state = "redirected";
+  context.checkpoint(committed);
 }
 
-function normalizeHost(value) {
-  const host = String(value).trim().toLowerCase().replace(/\.$/, "");
-  if (!hostPattern.test(host)) {
+async function detachRetiredHosts(context, move) {
+  const { committed, domains, target } = context;
+  const keep = new Set([target.appDomain, ...(target.retiredDomains ?? [])].filter(Boolean));
+  const owned = new Set([committed.appDomain, ...(committed.retiredDomains ?? [])].filter(Boolean));
+  const removable = (list) =>
+    list.filter(
+      (domain) =>
+        domain?.service === committed.worker.name &&
+        owned.has(domain.hostname) &&
+        !keep.has(domain.hostname)
+    );
+
+  for (const domain of removable(await domains.list())) {
+    await domains.remove(domain.id);
+  }
+  const stale = removable(await domains.list());
+  if (stale.length > 0) {
     throw new Error(
-      `--app-domain must be a bare hostname such as app.example.com (got "${value}").`
+      `Refusing to finish: Cloudflare still reports ${stale.map((domain) => domain.hostname).join(", ")} as a custom domain of Worker "${committed.worker.name}".`
     );
   }
-  return host;
+  move.state = "detached";
+  context.checkpoint(committed);
+}
+
+function commitMove(context, move) {
+  const { committed, target } = context;
+  move.state = "committed";
+  const next = { ...committed, ...target };
+  delete next.domainMove;
+  context.checkpoint(next);
+  writeWranglerConfig(next);
+}
+
+async function rollback(context, move, cause) {
+  const { committed, domains, target } = context;
+  console.error(`Domain move failed after step "${move.state}": ${cause.message}`);
+  try {
+    if (move.deployed) {
+      writeWranglerConfig(committed);
+      if (!context.skipDeploy) {
+        context.deployConfiguration({
+          accountId: committed.accountId,
+          configFile: configPath(committed.name),
+          runCommand: context.runCommand
+        });
+      }
+      move.deployed = false;
+    }
+    if (move.attachedByThisRun && move.attachedDomainId && !context.override) {
+      await domains.remove(move.attachedDomainId);
+      move.attachedByThisRun = false;
+      move.attachedDomainId = null;
+    }
+    move.state = "rolled-back";
+  } catch (rollbackError) {
+    console.error(`Rollback is incomplete: ${rollbackError.message}`);
+  } finally {
+    committed.domainMove = move;
+    context.checkpoint(committed);
+    writeWranglerConfig(committed);
+    console.error(
+      `The saved deployment record still describes ${committed.appDomain ?? "the default hostname"}. Re-run the same command to resume, or inspect Cloudflare and repair "${committed.name}".`
+    );
+    if (move.attachedByThisRun && move.attachedDomainId) {
+      console.error(
+        `Custom domain recovery: DELETE /accounts/${committed.accountId}/workers/domains/${move.attachedDomainId} removes ${target.appDomain}.`
+      );
+    }
+  }
+}
+
+async function probeOrigin(context, origin) {
+  const { attempts, delayMs } = context.retry;
+  let lastError = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const advertised = await context.probe(`${origin}${discoveryPath}`);
+      if (typeof advertised === "string" && advertised) {
+        return advertised.replace(/\/$/, "");
+      }
+      lastError = new Error("the installation did not advertise a service origin");
+    } catch (error) {
+      lastError = error;
+    }
+    if (attempt < attempts) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error(
+    `Refusing to continue: ${origin} did not serve a healthy HQBase installation (${lastError?.message ?? "no response"}). DNS or the certificate is not ready.`
+  );
+}
+
+async function defaultProbe(url) {
+  const response = await fetch(url, { headers: { accept: "application/json" } });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const document = await response.json();
+  return document?.servers?.[0]?.url;
+}
+
+function defaultDeployConfiguration({ accountId, configFile, runCommand }) {
+  runCommand(
+    "node",
+    ["scripts/release/deploy.mjs", "--config", configFile, "--configuration-only"],
+    { env: { CLOUDFLARE_ACCOUNT_ID: accountId } }
+  );
+}
+
+function reportPlan(name, previous, next, options) {
+  const target = next.appDomain
+    ? `custom domain ${next.appDomain}`
+    : "the default workers.dev hostname";
+  console.log(
+    options.dryRun
+      ? `HQBase deployment "${name}" domain configuration is valid (${target}).`
+      : `HQBase deployment "${name}" now serves from ${target}.`
+  );
+  for (const note of domainChangeNotes(previous, next)) {
+    console.log(`  - ${note}`);
+  }
 }

--- a/scripts/hqbase/lifecycle-manifest.mjs
+++ b/scripts/hqbase/lifecycle-manifest.mjs
@@ -86,7 +86,12 @@ export function migrateVersion2(manifest, accountId) {
   };
 }
 
-export function assertUnambiguousManifest(manifest) {
+export function assertUnambiguousManifest(manifest, options = {}) {
+  if (manifest.domainMove && !options.allowDomainMove) {
+    throw new Error(
+      `Refusing to continue: deployment "${manifest.name}" has an unfinished domain move to ${manifest.domainMove.toAppDomain ?? "the default hostname"} in state "${manifest.domainMove.state}". Finish or roll it back with "pnpm hqbase domain" before any other lifecycle command.`
+    );
+  }
   for (const [path, resource] of [
     ["d1", manifest.d1],
     ["r2", manifest.r2],

--- a/scripts/hqbase/resources.mjs
+++ b/scripts/hqbase/resources.mjs
@@ -61,7 +61,7 @@ export function prepareManifest(manifest, accountId, options = {}) {
     );
   }
 
-  assertUnambiguousManifest(current);
+  assertUnambiguousManifest(current, { allowDomainMove: options.allowDomainMove });
   const d1 = inspectD1(current, current.d1, { runCommand });
   inspectR2(current, current.r2, { runCommand });
   const primary = inspectQueue(current, current.queue.primary, { runCommand });

--- a/scripts/release/deploy.mjs
+++ b/scripts/release/deploy.mjs
@@ -70,6 +70,23 @@ export async function deploy(options = {}) {
     run("pnpm", ["build"], source);
     const activeRelease = inspectActiveRelease(source, config.name);
     const releaseTag = hqbaseReleaseTag(manifest.version, manifest.artifact.sha256);
+    if (options.configurationOnly) {
+      // A configuration deployment re-applies routes and Worker variables for the release that is
+      // already active. `wrangler triggers deploy` is experimental and never updates variables.
+      if (!activeRelease) {
+        throw new Error(
+          "Refusing to deploy configuration: the Worker has no active signed HQBase release."
+        );
+      }
+      if (activeRelease.version !== manifest.version || activeRelease.tag !== releaseTag) {
+        throw new Error(
+          `Refusing to deploy configuration: the Worker runs HQBase ${activeRelease.version}, not the signed stable release ${manifest.version}. Update the deployment first.`
+        );
+      }
+      deployConfiguration(source, config.name, releaseTag);
+      console.log(`HQBase ${manifest.version} configuration deployed.`);
+      return;
+    }
     if (!activeRelease) {
       applyMigrations(source);
       deploySource(source, { releaseTag });
@@ -186,6 +203,35 @@ export function assertSourceDeployConfig(
   return repositoryConfig;
 }
 
+export function deployConfiguration(source, workerName, releaseTag, options = {}) {
+  const runCommand = options.run ?? run;
+  const inspect = options.inspect ?? inspectActiveRelease;
+  const before = inspect(source, workerName);
+  runCommand(
+    "pnpm",
+    [
+      "exec",
+      "wrangler",
+      "deploy",
+      "--keep-vars",
+      "--config",
+      "wrangler.jsonc",
+      "--tag",
+      releaseTag,
+      "--var",
+      `HQBASE_WORKER_NAME:${workerName}`
+    ],
+    source
+  );
+  const after = inspect(source, workerName);
+  if (!after || after.tag !== releaseTag || after.versionId === before?.versionId) {
+    throw new Error(
+      "Refusing to continue: Cloudflare does not report a new active version for the configuration deployment."
+    );
+  }
+  return after;
+}
+
 function sourceDeploy(cwd) {
   run("pnpm", ["build"], cwd);
   run("pnpm", ["db:migrate:remote"], cwd);
@@ -237,5 +283,5 @@ function quote(value) {
 if (process.argv[1] && resolve(process.argv[1]) === resolve(import.meta.filename)) {
   const configIndex = process.argv.indexOf("--config");
   const configFile = configIndex >= 0 ? process.argv[configIndex + 1] : undefined;
-  await deploy({ configFile });
+  await deploy({ configFile, configurationOnly: process.argv.includes("--configuration-only") });
 }

--- a/scripts/release/deploy.mjs
+++ b/scripts/release/deploy.mjs
@@ -84,6 +84,7 @@ export async function deploy(options = {}) {
         );
       }
       deployConfiguration(source, config.name, releaseTag);
+      recordWorkerDeployed();
       console.log(`HQBase ${manifest.version} configuration deployed.`);
       return;
     }
@@ -213,6 +214,7 @@ export function deployConfiguration(source, workerName, releaseTag, options = {}
       "exec",
       "wrangler",
       "deploy",
+      "--strict",
       "--keep-vars",
       "--config",
       "wrangler.jsonc",

--- a/scripts/test-domain-staging.mjs
+++ b/scripts/test-domain-staging.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+import { run } from "./hqbase/command.mjs";
+import { configureDomain } from "./hqbase/domain.mjs";
+import { loadManifest } from "./hqbase/manifest.mjs";
+
+const deployment = required("DEPLOYMENT_NAME");
+const originalHost = new URL(required("HQBASE_STAGING_URL")).hostname;
+const moveHost = required("HQBASE_DOMAIN_MOVE_HOST");
+const cleanupOnly = process.argv.includes("--cleanup-only");
+
+if (moveHost === originalHost) {
+  throw new Error("HQBASE_DOMAIN_MOVE_HOST must differ from the staging portal hostname.");
+}
+
+const options = { deployConfiguration: deployReviewedSource };
+let primaryError = null;
+let recoveryError = null;
+if (cleanupOnly) {
+  await recoverOriginal();
+  assertManifest(originalHost, originalHost);
+} else {
+  try {
+    await configureDomain(
+      {
+        name: deployment,
+        "app-domain": moveHost,
+        "keep-service-origin": true
+      },
+      options
+    );
+    assertManifest(moveHost, originalHost);
+
+    await restoreOriginal();
+    assertManifest(originalHost, originalHost);
+  } catch (error) {
+    primaryError = error;
+  } finally {
+    try {
+      await recoverOriginal();
+    } catch (error) {
+      recoveryError = error;
+    }
+  }
+  if (recoveryError) {
+    throw new AggregateError(
+      [primaryError, recoveryError].filter(Boolean),
+      "The staging domain move and its cleanup both failed."
+    );
+  }
+  if (primaryError) throw primaryError;
+}
+
+async function recoverOriginal() {
+  let lastError = null;
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      await ensureOriginal();
+      assertManifest(originalHost, originalHost);
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+async function ensureOriginal() {
+  const current = loadManifest(deployment);
+  if (current.domainMove?.toAppDomain === moveHost) {
+    await configureDomain(
+      {
+        name: deployment,
+        "app-domain": moveHost,
+        "keep-service-origin": true
+      },
+      options
+    );
+  } else if (current.domainMove?.toAppDomain === originalHost) {
+    await restoreOriginal();
+  } else if (current.domainMove) {
+    throw new Error(
+      `Cannot recover unexpected move to ${current.domainMove.toAppDomain ?? "none"}.`
+    );
+  }
+  if (loadManifest(deployment).appDomain !== originalHost) await restoreOriginal();
+}
+
+async function restoreOriginal() {
+  return configureDomain(
+    {
+      name: deployment,
+      "app-domain": originalHost,
+      "detach-old": true,
+      "keep-service-origin": true,
+      yes: true
+    },
+    options
+  );
+}
+
+function deployReviewedSource({ accountId, configFile, runCommand = run }) {
+  runCommand(
+    "pnpm",
+    ["exec", "wrangler", "deploy", "--strict", "--keep-vars", "--config", configFile],
+    { env: { CLOUDFLARE_ACCOUNT_ID: accountId } }
+  );
+}
+
+function assertManifest(appDomain, authHost) {
+  const current = loadManifest(deployment);
+  const currentAuthHost = current.authUrl ? new URL(current.authUrl).hostname : null;
+  if (current.appDomain !== appDomain || currentAuthHost !== authHost) {
+    throw new Error(
+      `Unexpected staging domain state: portal=${current.appDomain ?? "none"}, service=${current.authUrl ?? "request origin"}.`
+    );
+  }
+  if (current.domainMove) throw new Error("The staging domain move did not commit cleanly.");
+}
+
+function required(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required.`);
+  return value;
+}

--- a/test/e2e/staging/lifecycle.spec.ts
+++ b/test/e2e/staging/lifecycle.spec.ts
@@ -61,6 +61,7 @@ test("HQBase web lifecycle remains healthy", async ({ page, request }) => {
         ownerEmail: email,
         ownerName: "HQBase E2E Owner",
         ownerPassword: password,
+        portalHostname: new URL(stagingUrl).hostname,
         primaryDomain: domain
       },
       headers: { cookie: grantCookie }

--- a/test/unit/scripts/deploy.test.mjs
+++ b/test/unit/scripts/deploy.test.mjs
@@ -12,6 +12,7 @@ import {
 import {
   assertSourceDeployConfig,
   compareVersions,
+  deployConfiguration,
   deploySource,
   executeSql,
   hqbaseReleaseTag,
@@ -46,6 +47,31 @@ describe("HQBase release deployment", () => {
     expect(() => verifyManifest({ ...envelope, signature: invalidSignature }, encoded)).toThrow(
       "signature"
     );
+  });
+  it("verifies that a configuration deployment produced a new active version", () => {
+    const commands = [];
+    const versions = [
+      { versionId: "version-1", version: "1.2.3", tag: "hqbase:1.2.3" },
+      { versionId: "version-2", version: "1.2.3", tag: "hqbase:1.2.3" }
+    ];
+    const inspect = () => versions.shift() ?? versions[0];
+
+    expect(
+      deployConfiguration("/source", "hqbase-qa", "hqbase:1.2.3", {
+        inspect,
+        run: (command, args) => commands.push([command, ...args].join(" "))
+      })
+    ).toMatchObject({ versionId: "version-2" });
+    expect(commands[0]).toContain("wrangler deploy --keep-vars");
+    expect(commands[0]).toContain("--tag hqbase:1.2.3");
+
+    const unchanged = { versionId: "version-1", version: "1.2.3", tag: "hqbase:1.2.3" };
+    expect(() =>
+      deployConfiguration("/source", "hqbase-qa", "hqbase:1.2.3", {
+        inspect: () => unchanged,
+        run: () => {}
+      })
+    ).toThrowError(/new active version/);
   });
   it("selects only newer semantic releases", () => {
     expect(compareVersions("0.2.0", "0.1.9")).toBeGreaterThan(0);

--- a/test/unit/scripts/deploy.test.mjs
+++ b/test/unit/scripts/deploy.test.mjs
@@ -62,7 +62,9 @@ describe("HQBase release deployment", () => {
         run: (command, args) => commands.push([command, ...args].join(" "))
       })
     ).toMatchObject({ versionId: "version-2" });
-    expect(commands[0]).toContain("wrangler deploy --keep-vars");
+    expect(commands[0]).toContain("wrangler deploy");
+    expect(commands[0]).toContain("--keep-vars");
+    expect(commands[0]).toContain("--strict");
     expect(commands[0]).toContain("--tag hqbase:1.2.3");
 
     const unchanged = { versionId: "version-1", version: "1.2.3", tag: "hqbase:1.2.3" };

--- a/test/unit/scripts/domain.test.mjs
+++ b/test/unit/scripts/domain.test.mjs
@@ -1,19 +1,27 @@
 import fs from "node:fs";
-import { afterEach, describe, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   createWorkerDomainsClient,
   planAttachment,
-  requireCloudflareApiToken
+  requireDomainApiToken
 } from "../../../scripts/hqbase/cloudflare-domains.mjs";
 import { createWranglerConfig } from "../../../scripts/hqbase/config.mjs";
 import { configureDomain } from "../../../scripts/hqbase/domain.mjs";
 import {
   assertResumable,
   domainChangeNotes,
+  migrateStagedMoveRecord,
   resolveServiceOrigin,
+  stagedMoveRecord,
   updateDomainManifest
 } from "../../../scripts/hqbase/domain-plan.mjs";
+import {
+  canonicalHostnameFromD1Output,
+  createDomainProbe,
+  setCanonicalPortal
+} from "../../../scripts/hqbase/domain-runtime.mjs";
 import { assertUnambiguousManifest } from "../../../scripts/hqbase/lifecycle-manifest.mjs";
 import {
   configPath,
@@ -77,18 +85,40 @@ function fakeWrangler() {
   return { calls, runCommand };
 }
 
-function fakeDomains(initial = []) {
+function fakeDomains(
+  initial = [
+    {
+      id: "domain-old.example.com",
+      hostname: "old.example.com",
+      service: "hqbase-qa",
+      zone_id: "zone-1",
+      zone_name: "example.com"
+    }
+  ]
+) {
   const records = [...initial];
   const calls = [];
   return {
     calls,
     records,
-    async list() {
-      return records.map((record) => ({ ...record }));
+    async list(filters = {}) {
+      return records
+        .filter(
+          (record) =>
+            (!filters.hostname || record.hostname === filters.hostname) &&
+            (!filters.service || record.service === filters.service)
+        )
+        .map((record) => ({ ...record }));
     },
-    async attach({ hostname, service, override }) {
-      calls.push({ kind: "attach", hostname, service, override });
-      const record = { id: `domain-${hostname}`, hostname, service };
+    async attach({ hostname, service, zoneId, zoneName }) {
+      calls.push({ kind: "attach", hostname, service, zoneId, zoneName });
+      const record = {
+        id: `domain-${hostname}`,
+        hostname,
+        service,
+        zone_id: zoneId,
+        zone_name: zoneName
+      };
       const index = records.findIndex((candidate) => candidate.hostname === hostname);
       if (index >= 0) {
         records[index] = record;
@@ -115,30 +145,39 @@ function harness(overrides = {}) {
   const wrangler = fakeWrangler();
   const domains = overrides.domains ?? fakeDomains();
   const deploys = [];
+  const canonical = { hostname: overrides.canonicalHostname ?? "old.example.com" };
   return {
+    canonical,
     domains,
     deploys,
     wrangler,
     options: {
       domains,
       deployConfiguration: (input) => deploys.push(input),
-      environment: { CLOUDFLARE_API_TOKEN: "token" },
+      environment: { HQBASE_DOMAIN_API_TOKEN: "token" },
       probe: overrides.probe ?? (async () => "https://new.example.com"),
+      readCanonicalPortal: async () => canonical.hostname,
       retry: { attempts: 1, delayMs: 0 },
       runCommand: wrangler.runCommand,
+      setCanonicalPortal: async ({ hostname }) => {
+        canonical.hostname = hostname;
+      },
       ...overrides.options
     }
   };
 }
 
-afterEach(() => {
+function clean() {
   fs.rmSync(deploymentDir(deployment), { recursive: true, force: true });
-});
+}
+
+beforeEach(clean);
+afterEach(clean);
 
 describe("operator domain command", () => {
   it("attaches, verifies, cuts over, and commits the manifest only after Cloudflare confirms", async () => {
     install();
-    const { domains, deploys, options, wrangler } = harness();
+    const { canonical, domains, deploys, options } = harness();
 
     await configureDomain(
       { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
@@ -154,7 +193,7 @@ describe("operator domain command", () => {
     expect(saved.d1).toEqual(manifest().d1);
     expect(saved.r2).toEqual(manifest().r2);
     expect(saved.queue).toEqual(manifest().queue);
-    expect(wrangler.calls.some((call) => call.includes("d1 execute"))).toBe(true);
+    expect(canonical.hostname).toBe("new.example.com");
   });
 
   it("keeps the old hostname attached and records the canonical portal host", async () => {
@@ -162,7 +201,7 @@ describe("operator domain command", () => {
     const domains = fakeDomains([
       { id: "domain-old.example.com", hostname: "old.example.com", service: "hqbase-qa" }
     ]);
-    const { options, wrangler } = harness({
+    const { canonical, options } = harness({
       domains,
       probe: async () => "https://old.example.com"
     });
@@ -180,8 +219,7 @@ describe("operator domain command", () => {
       "new.example.com",
       "old.example.com"
     ]);
-    const redirect = wrangler.calls.find((call) => call.includes("d1 execute"));
-    expect(redirect).toMatch(/is_canonical = 1[\s\S]*new\.example\.com/);
+    expect(canonical.hostname).toBe("new.example.com");
     expect(JSON.parse(fs.readFileSync(configPath(deployment), "utf8")).routes).toEqual([
       { pattern: "new.example.com", custom_domain: true },
       { pattern: "old.example.com", custom_domain: true }
@@ -211,12 +249,43 @@ describe("operator domain command", () => {
     expect(loadManifest(deployment).retiredDomains).toEqual([]);
   });
 
+  it("preserves other retired hostnames when it deletes the previous portal", async () => {
+    install({ retiredDomains: ["legacy.example.com"] });
+    const domains = fakeDomains([
+      { id: "domain-old.example.com", hostname: "old.example.com", service: "hqbase-qa" },
+      {
+        id: "domain-legacy.example.com",
+        hostname: "legacy.example.com",
+        service: "hqbase-qa"
+      }
+    ]);
+    const { options } = harness({ domains });
+
+    await configureDomain(
+      {
+        name: deployment,
+        "app-domain": "new.example.com",
+        "move-service-origin": true,
+        "detach-old": true,
+        yes: true
+      },
+      options
+    );
+
+    expect(domains.calls).toContainEqual({ kind: "remove", id: "domain-old.example.com" });
+    expect(domains.calls).not.toContainEqual({
+      kind: "remove",
+      id: "domain-legacy.example.com"
+    });
+    expect(loadManifest(deployment).retiredDomains).toEqual(["legacy.example.com"]);
+  });
+
   it("really deletes the custom domain and its DNS record on detach", async () => {
     install();
     const domains = fakeDomains([
       { id: "domain-old.example.com", hostname: "old.example.com", service: "hqbase-qa" }
     ]);
-    const { deploys, options } = harness({ domains });
+    const { canonical, deploys, options } = harness({ domains });
 
     await configureDomain(
       { name: deployment, detach: true, "move-service-origin": true, yes: true },
@@ -228,6 +297,7 @@ describe("operator domain command", () => {
     const saved = loadManifest(deployment);
     expect(saved.appDomain).toBeUndefined();
     expect(saved.authUrl).toBeUndefined();
+    expect(canonical.hostname).toBeNull();
     expect(deploys).toHaveLength(1);
     const config = JSON.parse(fs.readFileSync(configPath(deployment), "utf8"));
     expect(config.routes).toBeUndefined();
@@ -278,6 +348,7 @@ describe("operator domain command", () => {
   it("refuses a hostname that already routes to another Worker", async () => {
     install();
     const domains = fakeDomains([
+      { id: "domain-old", hostname: "old.example.com", service: "hqbase-qa" },
       { id: "domain-new", hostname: "new.example.com", service: "someone-else" }
     ]);
     const { options } = harness({ domains });
@@ -291,7 +362,7 @@ describe("operator domain command", () => {
     expect(domains.calls).toEqual([]);
   });
 
-  it("refuses to take over a hostname without an explicit confirmation", async () => {
+  it("refuses the legacy hostname takeover flag", async () => {
     install();
     const domains = fakeDomains([
       { id: "domain-new", hostname: "new.example.com", service: "someone-else" }
@@ -308,9 +379,29 @@ describe("operator domain command", () => {
         },
         options
       )
-    ).rejects.toThrowError(/without an explicit confirmation/);
+    ).rejects.toThrowError(/--override-existing is not supported/);
     expect(domains.calls).toEqual([]);
     expect(loadManifest(deployment).appDomain).toBe("old.example.com");
+  });
+
+  it("refuses the legacy partial-deployment flag before it changes anything", async () => {
+    install();
+    const { domains, options } = harness();
+    const before = fs.readFileSync(manifestPath(deployment), "utf8");
+
+    await expect(
+      configureDomain(
+        {
+          name: deployment,
+          "app-domain": "new.example.com",
+          "move-service-origin": true,
+          "skip-deploy": true
+        },
+        options
+      )
+    ).rejects.toThrowError(/--skip-deploy is not supported/);
+    expect(fs.readFileSync(manifestPath(deployment), "utf8")).toBe(before);
+    expect(domains.calls).toEqual([]);
   });
 
   it("rolls back the attachment and keeps the saved record when verification fails", async () => {
@@ -331,14 +422,57 @@ describe("operator domain command", () => {
     ).rejects.toThrowError(/did not serve a healthy HQBase installation/);
 
     expect(domains.calls.map((call) => call.kind)).toEqual(["attach", "remove"]);
-    expect(domains.records).toEqual([]);
+    expect(domains.records.map((record) => record.hostname)).toEqual(["old.example.com"]);
     const saved = loadManifest(deployment);
     expect(saved.appDomain).toBe("old.example.com");
     expect(saved.authUrl).toBe("https://old.example.com");
-    expect(saved.domainMove.state).toBe("rolled-back");
+    expect(saved.domainMove).toBeUndefined();
     expect(JSON.parse(fs.readFileSync(configPath(deployment), "utf8")).routes).toEqual([
       { pattern: "old.example.com", custom_domain: true }
     ]);
+  });
+
+  it("rolls back an attachment when Cloudflare applies it but the response is lost", async () => {
+    install();
+    const domains = fakeDomains();
+    const attach = domains.attach;
+    domains.attach = async (input) => {
+      await attach(input);
+      throw new Error("Cloudflare response was lost");
+    };
+    const { options } = harness({ domains });
+
+    await expect(
+      configureDomain(
+        { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+        options
+      )
+    ).rejects.toThrowError(/response was lost/);
+
+    expect(domains.records.map((record) => record.hostname)).toEqual(["old.example.com"]);
+    expect(loadManifest(deployment).domainMove).toBeUndefined();
+  });
+
+  it("waits for an asynchronous configuration deployment before it probes", async () => {
+    install();
+    let deployed = false;
+    const { options } = harness({
+      probe: async () => (deployed ? "https://new.example.com" : "https://old.example.com"),
+      options: {
+        deployConfiguration: async () => {
+          await Promise.resolve();
+          deployed = true;
+        }
+      }
+    });
+
+    await configureDomain(
+      { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+      options
+    );
+
+    expect(deployed).toBe(true);
+    expect(loadManifest(deployment).appDomain).toBe("new.example.com");
   });
 
   it("redeploys the previous configuration when the cutover fails", async () => {
@@ -368,6 +502,111 @@ describe("operator domain command", () => {
     expect(JSON.parse(fs.readFileSync(configPath(deployment), "utf8")).vars.BETTER_AUTH_URL).toBe(
       "https://old.example.com"
     );
+  });
+
+  it("rolls back an ambiguous configuration deployment", async () => {
+    install();
+    let deployments = 0;
+    const { domains, options } = harness({
+      options: {
+        deployConfiguration: () => {
+          deployments += 1;
+          if (deployments === 1) throw new Error("Wrangler disconnected after upload");
+        }
+      }
+    });
+
+    await expect(
+      configureDomain(
+        { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+        options
+      )
+    ).rejects.toThrowError(/disconnected after upload/);
+
+    expect(deployments).toBe(2);
+    expect(domains.records.map((record) => record.hostname)).toEqual(["old.example.com"]);
+    expect(loadManifest(deployment).domainMove).toBeUndefined();
+  });
+
+  it("restores a domain when Cloudflare deletes it but the response fails", async () => {
+    install();
+    const domains = fakeDomains();
+    const remove = domains.remove;
+    domains.remove = async (id) => {
+      await remove(id);
+      if (id === "domain-old.example.com") throw new Error("Cloudflare response was lost");
+    };
+    const { canonical, deploys, options } = harness({ domains });
+
+    await expect(
+      configureDomain(
+        {
+          name: deployment,
+          "app-domain": "new.example.com",
+          "move-service-origin": true,
+          "detach-old": true,
+          yes: true
+        },
+        options
+      )
+    ).rejects.toThrowError(/response was lost/);
+
+    expect(canonical.hostname).toBe("old.example.com");
+    expect(deploys).toHaveLength(2);
+    expect(domains.records.map((record) => record.hostname)).toEqual(["old.example.com"]);
+    expect(loadManifest(deployment).domainMove).toBeUndefined();
+  });
+
+  it("keeps the deployment locked when rollback is incomplete", async () => {
+    install();
+    const { options } = harness({
+      options: {
+        deployConfiguration: () => {
+          throw new Error("Cloudflare is unavailable");
+        }
+      }
+    });
+
+    await expect(
+      configureDomain(
+        { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+        options
+      )
+    ).rejects.toThrowError(/Cloudflare is unavailable/);
+
+    const saved = loadManifest(deployment);
+    expect(saved.domainMove).toMatchObject({
+      state: "recovery-required",
+      recoveryFailures: ["restore Worker configuration"]
+    });
+    expect(() => assertUnambiguousManifest(saved)).toThrowError(/unfinished domain move/);
+  });
+
+  it("runs rollback when a step rejects with a non-Error value", async () => {
+    install();
+    const { options } = harness({
+      options: {
+        deployConfiguration: () => {
+          throw null;
+        }
+      }
+    });
+
+    let rejection = "not rejected";
+    try {
+      await configureDomain(
+        { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+        options
+      );
+    } catch (error) {
+      rejection = error;
+    }
+
+    expect(rejection).toBeNull();
+    expect(loadManifest(deployment).domainMove).toMatchObject({
+      state: "recovery-required",
+      recoveryFailures: ["restore Worker configuration"]
+    });
   });
 
   it("does not write anything for a dry run", async () => {
@@ -402,8 +641,7 @@ describe("operator domain command", () => {
         toAuthUrl: "https://new.example.com",
         detachOld: false,
         attachedDomainId: "domain-new.example.com",
-        attachedByThisRun: true,
-        deployed: false
+        attachedByThisRun: true
       }
     });
     const domains = fakeDomains([
@@ -429,6 +667,32 @@ describe("operator domain command", () => {
     expect(saved.domainMove).toBeUndefined();
     expect(domains.calls.filter((call) => call.kind === "attach")).toEqual([]);
   });
+
+  it("migrates a complete version 2 manifest before it builds the target", async () => {
+    const legacy = {
+      ...manifest(),
+      version: 2,
+      accountId: undefined,
+      d1: { name: "hqbase-qa", id: manifest().d1.id, created: true, reused: false },
+      r2: { bucket: "hqbase-qa-mail", created: true, reused: false },
+      queue: {
+        name: "hqbase-qa-jobs",
+        deadLetterName: "hqbase-qa-jobs-dlq",
+        created: true
+      }
+    };
+    writeManifest(legacy);
+    const { options } = harness();
+
+    await configureDomain(
+      { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+      options
+    );
+
+    const saved = loadManifest(deployment);
+    expect(saved.version).toBe(3);
+    expect(saved.queue).toEqual(manifest().queue);
+  });
 });
 
 describe("operator domain contract", () => {
@@ -445,6 +709,51 @@ describe("operator domain contract", () => {
         { appDomain: "new.example.com" }
       )
     ).toThrowError(/--keep-service-origin|--move-service-origin/);
+  });
+
+  it("normalizes an explicit service origin before it compares or stores it", () => {
+    expect(
+      resolveServiceOrigin(
+        { appDomain: "old.example.com", authUrl: "https://service.example.com" },
+        { appDomain: "new.example.com", authUrl: "https://service.example.com/" }
+      )
+    ).toEqual({ authUrl: "https://service.example.com", moved: false });
+  });
+
+  it("normalizes a stored service origin when it builds the next manifest", () => {
+    const after = updateDomainManifest(manifest({ authUrl: "https://old.example.com/" }), {
+      appDomain: "new.example.com",
+      keepServiceOrigin: true
+    });
+
+    expect(after.authUrl).toBe("https://old.example.com");
+    expect(after.retiredDomains).toEqual(["old.example.com"]);
+  });
+
+  it("adds recovery defaults to fresh and earlier staged move records", () => {
+    const defaults = {
+      attachedDomainId: null,
+      attachedByThisRun: false,
+      targetZoneId: null,
+      configurationDeployAttempted: false,
+      canonicalUpdateAttempted: false,
+      pendingRemoval: null,
+      removedDomains: []
+    };
+    expect(
+      stagedMoveRecord(manifest(), { appDomain: "new.example.com", authUrl: undefined })
+    ).toMatchObject(defaults);
+    expect(
+      migrateStagedMoveRecord({
+        startedAt: "2026-08-17T00:00:00.000Z",
+        state: "attached",
+        fromAppDomain: "old.example.com",
+        toAppDomain: "new.example.com",
+        fromAuthUrl: "https://old.example.com",
+        toAuthUrl: "https://old.example.com",
+        detachOld: false
+      })
+    ).toMatchObject(defaults);
   });
 
   it("keeps the service origin hostname attached when the portal moves away from it", () => {
@@ -520,11 +829,33 @@ describe("operator domain contract", () => {
     expect(notes).toMatch(/old\.example\.com stays attached and redirects/);
     expect(notes).toMatch(/new\.example\.com must be a zone/);
     expect(notes).toMatch(/Service origin changed to https:\/\/new\.example\.com/);
-    expect(notes).toMatch(/D1, R2, and queues were not modified/);
+    expect(notes).toMatch(/resource identities were not modified/);
   });
 });
 
 describe("Cloudflare custom domain seam", () => {
+  it("uses an exact hostname filter so a later API page cannot hide a match", async () => {
+    const requests = [];
+    const client = createWorkerDomainsClient({
+      accountId,
+      token: "token",
+      fetchImpl: async (url) => {
+        requests.push(url);
+        return {
+          ok: true,
+          async json() {
+            return { success: true, result: [] };
+          }
+        };
+      }
+    });
+
+    await client.list({ hostname: "new.example.com" });
+
+    expect(requests[0]).toContain("environment=production");
+    expect(requests[0]).toContain("hostname=new.example.com");
+  });
+
   it("never lets Cloudflare override an origin or DNS record implicitly", async () => {
     const requests = [];
     const client = createWorkerDomainsClient({
@@ -559,6 +890,22 @@ describe("Cloudflare custom domain seam", () => {
     expect(requests[1].url).toMatch(/\/workers\/domains\/domain-1$/);
   });
 
+  it("accepts an empty successful response when Cloudflare deletes a domain", async () => {
+    const client = createWorkerDomainsClient({
+      accountId,
+      token: "token",
+      fetchImpl: async () => ({
+        ok: true,
+        status: 204,
+        async json() {
+          throw new SyntaxError("Unexpected end of JSON input");
+        }
+      })
+    });
+
+    await expect(client.remove("domain-1")).resolves.toBeNull();
+  });
+
   it("classifies an attachment before anything is changed", () => {
     const domains = [{ id: "a", hostname: "app.example.com", service: "other-worker" }];
     expect(planAttachment(domains, { hostname: "app.example.com", service: "hqbase-qa" })).toEqual({
@@ -575,7 +922,125 @@ describe("Cloudflare custom domain seam", () => {
   });
 
   it("requires an explicit Cloudflare API token", () => {
-    expect(() => requireCloudflareApiToken({})).toThrowError(/CLOUDFLARE_API_TOKEN/);
-    expect(requireCloudflareApiToken({ CLOUDFLARE_API_TOKEN: " token " })).toBe("token");
+    expect(() => requireDomainApiToken({})).toThrowError(/HQBASE_DOMAIN_API_TOKEN/);
+    expect(requireDomainApiToken({ HQBASE_DOMAIN_API_TOKEN: " token " })).toBe("token");
+  });
+
+  it("adds Cloudflare Access service-token headers only when both values are set", async () => {
+    const requests = [];
+    const probe = createDomainProbe(
+      {
+        HQBASE_DOMAIN_ACCESS_CLIENT_ID: "client-id",
+        HQBASE_DOMAIN_ACCESS_CLIENT_SECRET: "client-secret"
+      },
+      async (url, init) => {
+        requests.push({ url, init });
+        return {
+          ok: true,
+          async json() {
+            return { servers: [{ url: "https://service.example.com" }] };
+          }
+        };
+      }
+    );
+
+    await expect(probe("https://app.example.com/api/v1/openapi.json")).resolves.toBe(
+      "https://service.example.com"
+    );
+    expect(requests[0].init.headers).toMatchObject({
+      "cf-access-client-id": "client-id",
+      "cf-access-client-secret": "client-secret"
+    });
+    expect(() => createDomainProbe({ HQBASE_DOMAIN_ACCESS_CLIENT_ID: "client-id" })).toThrowError(
+      /both HQBASE_DOMAIN_ACCESS/
+    );
+  });
+
+  it("aborts a stalled discovery request after its deadline", async () => {
+    let requestSignal;
+    const probe = createDomainProbe(
+      {},
+      async (_url, init) => {
+        requestSignal = init.signal;
+        return new Promise((_resolve, reject) => {
+          init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true });
+        });
+      },
+      { timeoutMs: 10 }
+    );
+
+    await expect(probe("https://app.example.com/api/v1/openapi.json")).rejects.toMatchObject({
+      name: "TimeoutError"
+    });
+    expect(requestSignal.aborted).toBe(true);
+  });
+
+  it("rejects ambiguous canonical portal query results", () => {
+    expect(
+      canonicalHostnameFromD1Output(
+        JSON.stringify([{ results: [{ hostname: "app.example.com" }] }])
+      )
+    ).toBe("app.example.com");
+    expect(() =>
+      canonicalHostnameFromD1Output(
+        JSON.stringify([
+          { results: [{ hostname: "one.example.com" }, { hostname: "two.example.com" }] }
+        ])
+      )
+    ).toThrowError(/more than one canonical/);
+  });
+
+  it("records the verified Cloudflare zone on a new portal row", () => {
+    const calls = [];
+    setCanonicalPortal({
+      hostname: "app.example.com",
+      manifest: manifest(),
+      runCommand: (_command, args) => {
+        calls.push(args);
+        return JSON.stringify([{ results: [{ hostname: "app.example.com" }] }]);
+      },
+      zoneId: "zone-1"
+    });
+
+    const sql = calls[0].at(calls[0].indexOf("--command") + 1);
+    expect(sql).toContain("'zone-1'");
+    expect(sql.indexOf("SET is_canonical = 0")).toBeLessThan(sql.indexOf("SET is_canonical = 1"));
+  });
+
+  it("moves the canonical marker without violating the unique portal index", () => {
+    const database = new DatabaseSync(":memory:");
+    try {
+      database.exec(
+        fs.readFileSync(new URL("../../../migrations/0001_initial.sql", import.meta.url), "utf8")
+      );
+      database.exec(
+        fs.readFileSync(new URL("../../../migrations/0002_workspace.sql", import.meta.url), "utf8")
+      );
+      database.exec(`
+        INSERT INTO workspace_hosts VALUES
+          ('old', 'old.example.com', 'zone-1', 'portal', 0, 'ready', NULL, 'now', 'now'),
+          ('new', 'new.example.com', 'zone-1', 'portal', 1, 'ready', NULL, 'now', 'now');
+      `);
+
+      setCanonicalPortal({
+        hostname: "old.example.com",
+        manifest: manifest(),
+        runCommand: (_command, args) => {
+          const sql = args.at(args.indexOf("--command") + 1);
+          if (sql.startsWith("SELECT")) {
+            return JSON.stringify([{ results: database.prepare(sql).all() }]);
+          }
+          database.exec(sql);
+          return "";
+        },
+        zoneId: "zone-1"
+      });
+
+      expect(
+        database.prepare("SELECT hostname FROM workspace_hosts WHERE is_canonical = 1").get()
+      ).toEqual({ hostname: "old.example.com" });
+    } finally {
+      database.close();
+    }
   });
 });

--- a/test/unit/scripts/domain.test.mjs
+++ b/test/unit/scripts/domain.test.mjs
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { createWranglerConfig } from "../../../scripts/hqbase/config.mjs";
+import { domainChangeNotes, updateDomainManifest } from "../../../scripts/hqbase/domain.mjs";
+
+function manifest(overrides = {}) {
+  return {
+    version: 2,
+    name: "qa",
+    worker: { name: "hqbase-qa" },
+    d1: { name: "hqbase-qa", id: "d1-id", reused: false },
+    r2: { bucket: "hqbase-qa-mail", reused: false },
+    queue: { name: "hqbase-qa-jobs", deadLetterName: "hqbase-qa-jobs-dlq" },
+    appDomain: "old.example.com",
+    authUrl: undefined,
+    cloudflareOAuth: { mode: "official" },
+    email: null,
+    ...overrides
+  };
+}
+
+describe("operator domain move", () => {
+  it("swaps the custom domain and leaves data resources untouched", () => {
+    const before = manifest();
+    const after = updateDomainManifest(before, { appDomain: "New.Example.com." });
+
+    expect(after.appDomain).toBe("new.example.com");
+    expect(after.d1).toEqual(before.d1);
+    expect(after.r2).toEqual(before.r2);
+    expect(after.queue).toEqual(before.queue);
+    expect(after.authUrl).toBeUndefined();
+    expect(createWranglerConfig(after).routes).toEqual([
+      { pattern: "new.example.com", custom_domain: true }
+    ]);
+  });
+
+  it("follows the new host when a canonical auth origin was previously pinned", () => {
+    const after = updateDomainManifest(manifest({ authUrl: "https://old.example.com" }), {
+      appDomain: "new.example.com"
+    });
+
+    expect(after.authUrl).toBe("https://new.example.com");
+    expect(createWranglerConfig(after).vars.BETTER_AUTH_URL).toBe("https://new.example.com");
+  });
+
+  it("honors an explicit --auth-url", () => {
+    const after = updateDomainManifest(manifest(), {
+      appDomain: "new.example.com",
+      authUrl: "https://login.example.com"
+    });
+
+    expect(after.authUrl).toBe("https://login.example.com");
+  });
+
+  it("detaches the custom domain and drops the derived auth origin", () => {
+    const after = updateDomainManifest(manifest({ authUrl: "https://old.example.com" }), {
+      detach: true
+    });
+
+    expect(after.appDomain).toBeUndefined();
+    expect(after.authUrl).toBeUndefined();
+    expect(createWranglerConfig(after).routes).toBeUndefined();
+    expect(createWranglerConfig(after).vars.BETTER_AUTH_URL).toBeUndefined();
+  });
+
+  it("keeps customer-managed OAuth valid on the new origin", () => {
+    const after = updateDomainManifest(
+      manifest({
+        authUrl: "https://old.example.com",
+        cloudflareOAuth: { mode: "customer", clientId: "customer-client" }
+      }),
+      { appDomain: "new.example.com" }
+    );
+
+    expect(after.cloudflareOAuth).toEqual({ mode: "customer", clientId: "customer-client" });
+    expect(after.authUrl).toBe("https://new.example.com");
+  });
+
+  it("refuses to detach when customer-managed OAuth needs a canonical origin", () => {
+    expect(() =>
+      updateDomainManifest(
+        manifest({
+          authUrl: "https://old.example.com",
+          cloudflareOAuth: { mode: "customer", clientId: "customer-client" }
+        }),
+        { detach: true }
+      )
+    ).toThrowError(/requires --auth-url/);
+  });
+
+  it("rejects invalid or conflicting input", () => {
+    expect(() => updateDomainManifest(manifest(), {})).toThrowError(/--app-domain/);
+    expect(() =>
+      updateDomainManifest(manifest(), { appDomain: "a.example.com", detach: true })
+    ).toThrowError(/not both/);
+    expect(() =>
+      updateDomainManifest(manifest(), { appDomain: "https://a.example.com/x" })
+    ).toThrowError(/bare hostname/);
+    expect(() => updateDomainManifest(manifest(), { appDomain: "localhost" })).toThrowError(
+      /bare hostname/
+    );
+  });
+
+  it("explains the operational consequences of a move", () => {
+    const before = manifest({ authUrl: "https://old.example.com" });
+    const after = updateDomainManifest(before, { appDomain: "new.example.com" });
+    const notes = domainChangeNotes(before, after).join("\n");
+
+    expect(notes).toMatch(/detaches old.example.com/);
+    expect(notes).toMatch(/new.example.com must be a zone/);
+    expect(notes).toMatch(/sign in again/);
+    expect(notes).toMatch(/D1, R2, and queues were not modified/);
+  });
+});

--- a/test/unit/scripts/domain.test.mjs
+++ b/test/unit/scripts/domain.test.mjs
@@ -1,89 +1,482 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
 
+import {
+  createWorkerDomainsClient,
+  planAttachment,
+  requireCloudflareApiToken
+} from "../../../scripts/hqbase/cloudflare-domains.mjs";
 import { createWranglerConfig } from "../../../scripts/hqbase/config.mjs";
-import { domainChangeNotes, updateDomainManifest } from "../../../scripts/hqbase/domain.mjs";
+import { configureDomain } from "../../../scripts/hqbase/domain.mjs";
+import {
+  assertResumable,
+  domainChangeNotes,
+  resolveServiceOrigin,
+  updateDomainManifest
+} from "../../../scripts/hqbase/domain-plan.mjs";
+import { assertUnambiguousManifest } from "../../../scripts/hqbase/lifecycle-manifest.mjs";
+import {
+  configPath,
+  deploymentDir,
+  loadManifest,
+  manifestPath,
+  writeManifest
+} from "../../../scripts/hqbase/manifest.mjs";
+
+const accountId = "a".repeat(32);
+const deployment = "domain-command-test";
 
 function manifest(overrides = {}) {
   return {
-    version: 2,
-    name: "qa",
-    worker: { name: "hqbase-qa" },
-    d1: { name: "hqbase-qa", id: "d1-id", reused: false },
-    r2: { bucket: "hqbase-qa-mail", reused: false },
-    queue: { name: "hqbase-qa-jobs", deadLetterName: "hqbase-qa-jobs-dlq" },
+    version: 3,
+    name: deployment,
+    accountId,
+    worker: { name: "hqbase-qa", deployed: true },
+    d1: { name: "hqbase-qa", id: "11111111-1111-4111-8111-111111111111", ownership: "created" },
+    r2: { bucket: "hqbase-qa-mail", ownership: "created" },
+    queue: {
+      primary: { name: "hqbase-qa-jobs", id: "1".repeat(32), ownership: "created" },
+      deadLetter: { name: "hqbase-qa-jobs-dlq", id: "2".repeat(32), ownership: "created" }
+    },
     appDomain: "old.example.com",
-    authUrl: undefined,
+    authUrl: "https://old.example.com",
     cloudflareOAuth: { mode: "official" },
     email: null,
     ...overrides
   };
 }
 
-describe("operator domain move", () => {
-  it("swaps the custom domain and leaves data resources untouched", () => {
-    const before = manifest();
-    const after = updateDomainManifest(before, { appDomain: "New.Example.com." });
+function install(overrides = {}) {
+  const record = manifest(overrides);
+  writeManifest(record);
+  return record;
+}
 
-    expect(after.appDomain).toBe("new.example.com");
-    expect(after.d1).toEqual(before.d1);
-    expect(after.r2).toEqual(before.r2);
-    expect(after.queue).toEqual(before.queue);
-    expect(after.authUrl).toBeUndefined();
-    expect(createWranglerConfig(after).routes).toEqual([
-      { pattern: "new.example.com", custom_domain: true }
+/** A fake Wrangler that answers only the identity checks the operator performs. */
+function fakeWrangler() {
+  const calls = [];
+  const runCommand = (command, args = []) => {
+    calls.push([command, ...args].join(" "));
+    const label = args.join(" ");
+    if (label.includes("whoami")) {
+      return JSON.stringify({ accounts: [{ id: accountId, name: "QA" }] });
+    }
+    if (label.includes("d1 list")) {
+      return JSON.stringify([{ uuid: "11111111-1111-4111-8111-111111111111", name: "hqbase-qa" }]);
+    }
+    if (label.includes("r2 bucket info")) {
+      return JSON.stringify({ name: "hqbase-qa-mail" });
+    }
+    if (label.includes("queues info")) {
+      const name = args[args.indexOf("info") + 1];
+      const id = name.endsWith("-dlq") ? "2".repeat(32) : "1".repeat(32);
+      return `Queue Name: ${name}\nQueue ID: ${id}\n`;
+    }
+    return "";
+  };
+  return { calls, runCommand };
+}
+
+function fakeDomains(initial = []) {
+  const records = [...initial];
+  const calls = [];
+  return {
+    calls,
+    records,
+    async list() {
+      return records.map((record) => ({ ...record }));
+    },
+    async attach({ hostname, service, override }) {
+      calls.push({ kind: "attach", hostname, service, override });
+      const record = { id: `domain-${hostname}`, hostname, service };
+      const index = records.findIndex((candidate) => candidate.hostname === hostname);
+      if (index >= 0) {
+        records[index] = record;
+      } else {
+        records.push(record);
+      }
+      return record;
+    },
+    async remove(id) {
+      calls.push({ kind: "remove", id });
+      const index = records.findIndex((candidate) => candidate.id === id);
+      if (index < 0) {
+        throw new Error(`Unknown domain ${id}`);
+      }
+      records.splice(index, 1);
+    },
+    async findZone(hostname) {
+      return { id: "zone-1", name: hostname.split(".").slice(-2).join(".") };
+    }
+  };
+}
+
+function harness(overrides = {}) {
+  const wrangler = fakeWrangler();
+  const domains = overrides.domains ?? fakeDomains();
+  const deploys = [];
+  return {
+    domains,
+    deploys,
+    wrangler,
+    options: {
+      domains,
+      deployConfiguration: (input) => deploys.push(input),
+      environment: { CLOUDFLARE_API_TOKEN: "token" },
+      probe: overrides.probe ?? (async () => "https://new.example.com"),
+      retry: { attempts: 1, delayMs: 0 },
+      runCommand: wrangler.runCommand,
+      ...overrides.options
+    }
+  };
+}
+
+afterEach(() => {
+  fs.rmSync(deploymentDir(deployment), { recursive: true, force: true });
+});
+
+describe("operator domain command", () => {
+  it("attaches, verifies, cuts over, and commits the manifest only after Cloudflare confirms", async () => {
+    install();
+    const { domains, deploys, options, wrangler } = harness();
+
+    await configureDomain(
+      { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+      options
+    );
+
+    expect(domains.calls[0]).toMatchObject({ kind: "attach", hostname: "new.example.com" });
+    expect(deploys).toHaveLength(1);
+    const saved = loadManifest(deployment);
+    expect(saved.appDomain).toBe("new.example.com");
+    expect(saved.authUrl).toBe("https://new.example.com");
+    expect(saved.domainMove).toBeUndefined();
+    expect(saved.d1).toEqual(manifest().d1);
+    expect(saved.r2).toEqual(manifest().r2);
+    expect(saved.queue).toEqual(manifest().queue);
+    expect(wrangler.calls.some((call) => call.includes("d1 execute"))).toBe(true);
+  });
+
+  it("keeps the old hostname attached and records the canonical portal host", async () => {
+    install();
+    const domains = fakeDomains([
+      { id: "domain-old.example.com", hostname: "old.example.com", service: "hqbase-qa" }
+    ]);
+    const { options, wrangler } = harness({
+      domains,
+      probe: async () => "https://old.example.com"
+    });
+
+    await configureDomain(
+      { name: deployment, "app-domain": "new.example.com", "keep-service-origin": true },
+      options
+    );
+
+    const saved = loadManifest(deployment);
+    expect(saved.retiredDomains).toEqual(["old.example.com"]);
+    expect(saved.authUrl).toBe("https://old.example.com");
+    expect(domains.calls.some((call) => call.kind === "remove")).toBe(false);
+    expect(domains.records.map((record) => record.hostname).sort()).toEqual([
+      "new.example.com",
+      "old.example.com"
+    ]);
+    const redirect = wrangler.calls.find((call) => call.includes("d1 execute"));
+    expect(redirect).toMatch(/is_canonical = 1[\s\S]*new\.example\.com/);
+    expect(JSON.parse(fs.readFileSync(configPath(deployment), "utf8")).routes).toEqual([
+      { pattern: "new.example.com", custom_domain: true },
+      { pattern: "old.example.com", custom_domain: true }
     ]);
   });
 
-  it("follows the new host when a canonical auth origin was previously pinned", () => {
-    const after = updateDomainManifest(manifest({ authUrl: "https://old.example.com" }), {
-      appDomain: "new.example.com"
-    });
+  it("deletes the previous hostname only when the operator asks for it", async () => {
+    install();
+    const domains = fakeDomains([
+      { id: "domain-old.example.com", hostname: "old.example.com", service: "hqbase-qa" }
+    ]);
+    const { options } = harness({ domains });
 
-    expect(after.authUrl).toBe("https://new.example.com");
-    expect(createWranglerConfig(after).vars.BETTER_AUTH_URL).toBe("https://new.example.com");
-  });
-
-  it("honors an explicit --auth-url", () => {
-    const after = updateDomainManifest(manifest(), {
-      appDomain: "new.example.com",
-      authUrl: "https://login.example.com"
-    });
-
-    expect(after.authUrl).toBe("https://login.example.com");
-  });
-
-  it("detaches the custom domain and drops the derived auth origin", () => {
-    const after = updateDomainManifest(manifest({ authUrl: "https://old.example.com" }), {
-      detach: true
-    });
-
-    expect(after.appDomain).toBeUndefined();
-    expect(after.authUrl).toBeUndefined();
-    expect(createWranglerConfig(after).routes).toBeUndefined();
-    expect(createWranglerConfig(after).vars.BETTER_AUTH_URL).toBeUndefined();
-  });
-
-  it("keeps customer-managed OAuth valid on the new origin", () => {
-    const after = updateDomainManifest(
-      manifest({
-        authUrl: "https://old.example.com",
-        cloudflareOAuth: { mode: "customer", clientId: "customer-client" }
-      }),
-      { appDomain: "new.example.com" }
+    await configureDomain(
+      {
+        name: deployment,
+        "app-domain": "new.example.com",
+        "move-service-origin": true,
+        "detach-old": true,
+        yes: true
+      },
+      options
     );
 
-    expect(after.cloudflareOAuth).toEqual({ mode: "customer", clientId: "customer-client" });
-    expect(after.authUrl).toBe("https://new.example.com");
+    expect(domains.calls).toContainEqual({ kind: "remove", id: "domain-old.example.com" });
+    expect(domains.records.map((record) => record.hostname)).toEqual(["new.example.com"]);
+    expect(loadManifest(deployment).retiredDomains).toEqual([]);
+  });
+
+  it("really deletes the custom domain and its DNS record on detach", async () => {
+    install();
+    const domains = fakeDomains([
+      { id: "domain-old.example.com", hostname: "old.example.com", service: "hqbase-qa" }
+    ]);
+    const { deploys, options } = harness({ domains });
+
+    await configureDomain(
+      { name: deployment, detach: true, "move-service-origin": true, yes: true },
+      options
+    );
+
+    expect(domains.calls).toEqual([{ kind: "remove", id: "domain-old.example.com" }]);
+    expect(domains.records).toEqual([]);
+    const saved = loadManifest(deployment);
+    expect(saved.appDomain).toBeUndefined();
+    expect(saved.authUrl).toBeUndefined();
+    expect(deploys).toHaveLength(1);
+    const config = JSON.parse(fs.readFileSync(configPath(deployment), "utf8"));
+    expect(config.routes).toBeUndefined();
+    expect(config.vars.BETTER_AUTH_URL).toBeUndefined();
+  });
+
+  it("refuses to detach without --yes", async () => {
+    install();
+    const { domains, options } = harness();
+
+    await expect(
+      configureDomain({ name: deployment, detach: true, "move-service-origin": true }, options)
+    ).rejects.toThrowError(/requires --yes/);
+    expect(domains.calls).toEqual([]);
+  });
+
+  it("deploys the new service origin as configuration for the active release", async () => {
+    install();
+    const { deploys, options } = harness();
+
+    await configureDomain(
+      { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+      options
+    );
+
+    expect(deploys[0].configFile).toBe(configPath(deployment));
+    const config = JSON.parse(fs.readFileSync(configPath(deployment), "utf8"));
+    expect(config.vars.BETTER_AUTH_URL).toBe("https://new.example.com");
+    expect(config.routes).toEqual([
+      { pattern: "new.example.com", custom_domain: true },
+      { pattern: "old.example.com", custom_domain: true }
+    ]);
+  });
+
+  it("fails closed when the deployed service origin does not match the manifest", async () => {
+    install();
+    const { options } = harness({ probe: async () => "https://old.example.com" });
+
+    await expect(
+      configureDomain(
+        { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+        options
+      )
+    ).rejects.toThrowError(/BETTER_AUTH_URL was not deployed/);
+    expect(loadManifest(deployment).appDomain).toBe("old.example.com");
+  });
+
+  it("refuses a hostname that already routes to another Worker", async () => {
+    install();
+    const domains = fakeDomains([
+      { id: "domain-new", hostname: "new.example.com", service: "someone-else" }
+    ]);
+    const { options } = harness({ domains });
+
+    await expect(
+      configureDomain(
+        { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+        options
+      )
+    ).rejects.toThrowError(/already routes to Worker "someone-else"/);
+    expect(domains.calls).toEqual([]);
+  });
+
+  it("refuses to take over a hostname without an explicit confirmation", async () => {
+    install();
+    const domains = fakeDomains([
+      { id: "domain-new", hostname: "new.example.com", service: "someone-else" }
+    ]);
+    const { options } = harness({ domains });
+
+    await expect(
+      configureDomain(
+        {
+          name: deployment,
+          "app-domain": "new.example.com",
+          "move-service-origin": true,
+          "override-existing": true
+        },
+        options
+      )
+    ).rejects.toThrowError(/without an explicit confirmation/);
+    expect(domains.calls).toEqual([]);
+    expect(loadManifest(deployment).appDomain).toBe("old.example.com");
+  });
+
+  it("rolls back the attachment and keeps the saved record when verification fails", async () => {
+    install();
+    const domains = fakeDomains();
+    const { options } = harness({
+      domains,
+      probe: async () => {
+        throw new Error("no certificate yet");
+      }
+    });
+
+    await expect(
+      configureDomain(
+        { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+        options
+      )
+    ).rejects.toThrowError(/did not serve a healthy HQBase installation/);
+
+    expect(domains.calls.map((call) => call.kind)).toEqual(["attach", "remove"]);
+    expect(domains.records).toEqual([]);
+    const saved = loadManifest(deployment);
+    expect(saved.appDomain).toBe("old.example.com");
+    expect(saved.authUrl).toBe("https://old.example.com");
+    expect(saved.domainMove.state).toBe("rolled-back");
+    expect(JSON.parse(fs.readFileSync(configPath(deployment), "utf8")).routes).toEqual([
+      { pattern: "old.example.com", custom_domain: true }
+    ]);
+  });
+
+  it("redeploys the previous configuration when the cutover fails", async () => {
+    install();
+    const domains = fakeDomains();
+    let probes = 0;
+    const { deploys, options } = harness({
+      domains,
+      probe: async () => {
+        probes += 1;
+        if (probes === 1) {
+          return "https://old.example.com";
+        }
+        throw new Error("origin is unreachable");
+      }
+    });
+
+    await expect(
+      configureDomain(
+        { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+        options
+      )
+    ).rejects.toThrowError(/did not serve a healthy HQBase installation/);
+
+    expect(deploys).toHaveLength(2);
+    expect(loadManifest(deployment).appDomain).toBe("old.example.com");
+    expect(JSON.parse(fs.readFileSync(configPath(deployment), "utf8")).vars.BETTER_AUTH_URL).toBe(
+      "https://old.example.com"
+    );
+  });
+
+  it("does not write anything for a dry run", async () => {
+    install();
+    const { domains, deploys, options } = harness();
+    const before = fs.readFileSync(manifestPath(deployment), "utf8");
+
+    await configureDomain(
+      {
+        name: deployment,
+        "app-domain": "new.example.com",
+        "move-service-origin": true,
+        "dry-run": true
+      },
+      options
+    );
+
+    expect(fs.readFileSync(manifestPath(deployment), "utf8")).toBe(before);
+    expect(fs.existsSync(configPath(deployment))).toBe(false);
+    expect(domains.calls).toEqual([]);
+    expect(deploys).toEqual([]);
+  });
+
+  it("resumes the same move and refuses a different one", async () => {
+    const staged = install({
+      domainMove: {
+        startedAt: "2026-08-18T00:00:00.000Z",
+        state: "attached",
+        fromAppDomain: "old.example.com",
+        toAppDomain: "new.example.com",
+        fromAuthUrl: "https://old.example.com",
+        toAuthUrl: "https://new.example.com",
+        detachOld: false,
+        attachedDomainId: "domain-new.example.com",
+        attachedByThisRun: true,
+        deployed: false
+      }
+    });
+    const domains = fakeDomains([
+      { id: "domain-old.example.com", hostname: "old.example.com", service: "hqbase-qa" },
+      { id: "domain-new.example.com", hostname: "new.example.com", service: "hqbase-qa" }
+    ]);
+    const { options } = harness({ domains });
+
+    expect(() => assertUnambiguousManifest(staged)).toThrowError(/unfinished domain move/);
+    await expect(
+      configureDomain(
+        { name: deployment, "app-domain": "other.example.com", "move-service-origin": true },
+        options
+      )
+    ).rejects.toThrowError(/unfinished domain move/);
+
+    await configureDomain(
+      { name: deployment, "app-domain": "new.example.com", "move-service-origin": true },
+      options
+    );
+    const saved = loadManifest(deployment);
+    expect(saved.appDomain).toBe("new.example.com");
+    expect(saved.domainMove).toBeUndefined();
+    expect(domains.calls.filter((call) => call.kind === "attach")).toEqual([]);
+  });
+});
+
+describe("operator domain contract", () => {
+  it("never moves the service origin with the portal unless asked", () => {
+    expect(
+      resolveServiceOrigin(
+        { appDomain: "old.example.com", authUrl: "https://service.example.com" },
+        { appDomain: "new.example.com" }
+      )
+    ).toEqual({ authUrl: "https://service.example.com", moved: false });
+    expect(() =>
+      resolveServiceOrigin(
+        { appDomain: "old.example.com", authUrl: "https://old.example.com" },
+        { appDomain: "new.example.com" }
+      )
+    ).toThrowError(/--keep-service-origin|--move-service-origin/);
+  });
+
+  it("keeps the service origin hostname attached when the portal moves away from it", () => {
+    const after = updateDomainManifest(manifest(), {
+      appDomain: "new.example.com",
+      keepServiceOrigin: true
+    });
+
+    expect(after.appDomain).toBe("new.example.com");
+    expect(after.retiredDomains).toEqual(["old.example.com"]);
+    expect(createWranglerConfig(after).routes).toEqual([
+      { pattern: "new.example.com", custom_domain: true },
+      { pattern: "old.example.com", custom_domain: true }
+    ]);
+    expect(createWranglerConfig(after).vars.BETTER_AUTH_URL).toBe("https://old.example.com");
+  });
+
+  it("refuses to delete the hostname that serves the service origin", () => {
+    expect(() =>
+      updateDomainManifest(manifest(), {
+        appDomain: "new.example.com",
+        keepServiceOrigin: true,
+        detachOld: true
+      })
+    ).toThrowError(/serves the machine-facing service origin/);
   });
 
   it("refuses to detach when customer-managed OAuth needs a canonical origin", () => {
     expect(() =>
       updateDomainManifest(
-        manifest({
-          authUrl: "https://old.example.com",
-          cloudflareOAuth: { mode: "customer", clientId: "customer-client" }
-        }),
-        { detach: true }
+        manifest({ cloudflareOAuth: { mode: "customer", clientId: "customer-client" } }),
+        { detach: true, moveServiceOrigin: true }
       )
     ).toThrowError(/requires --auth-url/);
   });
@@ -99,16 +492,90 @@ describe("operator domain move", () => {
     expect(() => updateDomainManifest(manifest(), { appDomain: "localhost" })).toThrowError(
       /bare hostname/
     );
+    expect(() =>
+      updateDomainManifest(manifest(), { detach: true, authUrl: "https://a.example.com" })
+    ).toThrowError(/cannot survive --detach/);
+  });
+
+  it("refuses an unfinished move to a different hostname", () => {
+    const staged = manifest({
+      domainMove: { toAppDomain: "new.example.com", toAuthUrl: null, startedAt: "now" }
+    });
+    expect(() => assertResumable(staged, { appDomain: "other.example.com" })).toThrowError(
+      /unfinished domain move/
+    );
+    expect(() =>
+      assertResumable(staged, { appDomain: "new.example.com", authUrl: undefined })
+    ).not.toThrow();
   });
 
   it("explains the operational consequences of a move", () => {
-    const before = manifest({ authUrl: "https://old.example.com" });
-    const after = updateDomainManifest(before, { appDomain: "new.example.com" });
+    const before = manifest();
+    const after = updateDomainManifest(before, {
+      appDomain: "new.example.com",
+      moveServiceOrigin: true
+    });
     const notes = domainChangeNotes(before, after).join("\n");
 
-    expect(notes).toMatch(/detaches old.example.com/);
-    expect(notes).toMatch(/new.example.com must be a zone/);
-    expect(notes).toMatch(/sign in again/);
+    expect(notes).toMatch(/old\.example\.com stays attached and redirects/);
+    expect(notes).toMatch(/new\.example\.com must be a zone/);
+    expect(notes).toMatch(/Service origin changed to https:\/\/new\.example\.com/);
     expect(notes).toMatch(/D1, R2, and queues were not modified/);
+  });
+});
+
+describe("Cloudflare custom domain seam", () => {
+  it("never lets Cloudflare override an origin or DNS record implicitly", async () => {
+    const requests = [];
+    const client = createWorkerDomainsClient({
+      accountId,
+      token: "token",
+      fetchImpl: async (url, init) => {
+        requests.push({ url, init });
+        return {
+          ok: true,
+          async json() {
+            return { success: true, result: { id: "domain-1" } };
+          }
+        };
+      }
+    });
+
+    await client.attach({
+      hostname: "new.example.com",
+      service: "hqbase-qa",
+      zoneId: "zone-1",
+      zoneName: "example.com"
+    });
+    const body = JSON.parse(requests[0].init.body);
+    expect(requests[0].url).toBe(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/domains`
+    );
+    expect(body.override_existing_origin).toBe(false);
+    expect(body.override_existing_dns_record).toBe(false);
+
+    await client.remove("domain-1");
+    expect(requests[1].init.method).toBe("DELETE");
+    expect(requests[1].url).toMatch(/\/workers\/domains\/domain-1$/);
+  });
+
+  it("classifies an attachment before anything is changed", () => {
+    const domains = [{ id: "a", hostname: "app.example.com", service: "other-worker" }];
+    expect(planAttachment(domains, { hostname: "app.example.com", service: "hqbase-qa" })).toEqual({
+      action: "conflict",
+      existing: domains[0]
+    });
+    expect(
+      planAttachment(domains, { hostname: "app.example.com", service: "other-worker" })
+    ).toEqual({ action: "keep", existing: domains[0] });
+    expect(planAttachment(domains, { hostname: "new.example.com", service: "hqbase-qa" })).toEqual({
+      action: "attach",
+      existing: null
+    });
+  });
+
+  it("requires an explicit Cloudflare API token", () => {
+    expect(() => requireCloudflareApiToken({})).toThrowError(/CLOUDFLARE_API_TOKEN/);
+    expect(requireCloudflareApiToken({ CLOUDFLARE_API_TOKEN: " token " })).toBe("token");
   });
 });

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -35,6 +35,28 @@ describe("staging workflow lifecycle record", () => {
     expect(cleanup).toBeGreaterThan(checkpoint);
   });
 
+  it("moves the live portal to a second hostname and back", () => {
+    const lifecycle = workflow.indexOf("pnpm test:e2e:staging");
+    const move = workflow.indexOf("node scripts/test-domain-staging.mjs");
+    const recovery = workflow.indexOf("node scripts/test-domain-staging.mjs --cleanup-only");
+    const backup = workflow.indexOf("Exercise populated remote backup and restore");
+    const destroy = workflow.indexOf('pnpm hqbase destroy --name "$DEPLOYMENT_NAME"');
+
+    expect(lifecycle).toBeGreaterThan(-1);
+    expect(move).toBeGreaterThan(-1);
+    expect(recovery).toBeGreaterThan(-1);
+    expect(backup).toBeGreaterThan(-1);
+    expect(destroy).toBeGreaterThan(-1);
+    expect(move).toBeGreaterThan(lifecycle);
+    expect(recovery).toBeGreaterThan(move);
+    expect(backup).toBeGreaterThan(recovery);
+    expect(destroy).toBeGreaterThan(recovery);
+    expect(workflow).toContain("HQBASE_DOMAIN_API_TOKEN:");
+    expect(workflow).toContain("HQBASE_DOMAIN_ACCESS_CLIENT_ID:");
+    expect(workflow).toContain("HQBASE_DOMAIN_ACCESS_CLIENT_SECRET:");
+    expect(workflow).toContain("HQBASE_DOMAIN_MOVE_HOST:");
+  });
+
   it("waits for the exact live candidate version before release checks", () => {
     const waitStart = releaseWorkflow.indexOf("      - name: Wait for the signed candidate");
     const nextStep = releaseWorkflow.indexOf("\n      - name:", waitStart + 1);


### PR DESCRIPTION
## Summary
Adds `pnpm hqbase domain --name <deployment> --app-domain <host>|--detach` so an operator can move an install to another custom domain (or back to workers.dev) **non-destructively**.

Today the only way to change the domain is to hand-edit the deployment manifest, and `install --force` looks like a reconfigure but re-runs `d1 create`/`r2 bucket create` and fails on the existing names.

## How it works
- Rewrites `appDomain` in the deployment manifest and regenerates `wrangler.jsonc`.
- Applies it with `wrangler triggers deploy --config …` — routes/custom domains only, **no code upload** — so the running signed release, its vars (`HQBASE_INSTALLATION_ID`, release SHA, …), secrets, and compat flags stay exactly as they are. D1, R2, and queues are never touched.
- If a pinned `BETTER_AUTH_URL` exists it follows the new host (or `--auth-url`), which then triggers a full Worker deploy since a var can only change that way. Customer-managed OAuth is re-validated against the new origin (`--detach` is refused in that mode, since it needs a canonical origin).
- Prints the consequences: old domain detached, new host must be a zone in the account, sessions invalidated, OAuth redirect URIs to re-register.
- Supports `--dry-run` and `--skip-deploy`.

## Validation
- Unit tests in `test/unit/scripts/domain.test.mjs` (manifest/config output, auth-url resolution, detach, customer OAuth, input validation, notes).
- Ran for real on a live 1.1.2 install: `hqbase.getorchestric.com` → `hqbase.alanwizemann.com`. New host healthy, existing data intact (sign-in, not setup), old domain detached, Worker version/vars/secrets verified unchanged via the API.

## Note for maintainers
While validating I noticed `scripts/release/deploy.mjs` returns early ("already the active signed release") when the active version matches, so `hqbase oauth` may not actually apply its config change on an up-to-date install. Out of scope here; happy to open a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added domain management commands for attaching, removing, retaining, and moving portal domains.
  * Added dry-run and resumable migration support with validation and migration guidance.
  * Added automatic health checks, canonical portal updates, and recovery handling for failed moves.
  * Added configuration-only deployments that update settings without redeploying application code.
  * Added staging workflows that verify domain migrations and restoration.

* **Bug Fixes**
  * Improved safeguards against conflicting domains, invalid hostnames, unhealthy services, and incomplete migrations.
  * Retired domains are now preserved and managed consistently during configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->