### PR TITLE
Paginate GET /api/v1/messages with limit and an opaque cursor

### DIFF
--- a/api/hqbase-mail-api-v1.openapi.json
+++ b/api/hqbase-mail-api-v1.openapi.json
@@ -127,7 +127,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Messages",
+            "description": "One page of messages, newest activity first.",
+            "headers": {
+              "Link": {
+                "required": false,
+                "description": "RFC 8288 link to the next page, as `<url>; rel=\"next\"`. The header is absent on the last page.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -140,7 +149,7 @@
             }
           },
           "400": {
-            "description": "Invalid request",
+            "description": "Invalid request. `INVALID_LIMIT` when limit is not an integer from 1 to 100. `INVALID_CURSOR` when the cursor is malformed or is not a message cursor.",
             "content": {
               "application/json": {
                 "schema": {
@@ -222,6 +231,28 @@
               "maxLength": 200
             },
             "description": "Search subject, sender, recipient, and message text."
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            },
+            "description": "Maximum number of messages in the page."
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 512
+            },
+            "description": "Opaque cursor from the previous page. Read it from the Link header and send it unchanged."
           }
         ]
       }

--- a/api/hqbase-mail-api-v1.postman_collection.json
+++ b/api/hqbase-mail-api-v1.postman_collection.json
@@ -179,6 +179,18 @@
                   "value": "",
                   "disabled": true,
                   "description": "Search subject, sender, recipient, and message text."
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "disabled": true,
+                  "description": "Maximum number of messages in the page."
+                },
+                {
+                  "key": "cursor",
+                  "value": "",
+                  "disabled": true,
+                  "description": "Opaque cursor from the previous page. Read it from the Link header and send it unchanged."
                 }
               ]
             },

--- a/migrations/0012_message_activity_index.sql
+++ b/migrations/0012_message_activity_index.sql
@@ -1,0 +1,13 @@
+-- Keyset pagination for GET /api/v1/messages orders by
+-- COALESCE(received_at, sent_at, created_at) DESC, id DESC.
+-- The existing created_at indexes do not match that order, so SQLite built a temporary B-tree for
+-- every page. These expression indexes supply the order directly for each filter combination.
+
+CREATE INDEX IF NOT EXISTS messages_activity_idx
+ON messages(COALESCE(received_at, sent_at, created_at) DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS messages_mailbox_activity_idx
+ON messages(mailbox_id, COALESCE(received_at, sent_at, created_at) DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS messages_folder_activity_idx
+ON messages(folder, COALESCE(received_at, sent_at, created_at) DESC, id DESC);

--- a/migrations/0012_message_activity_index.sql
+++ b/migrations/0012_message_activity_index.sql
@@ -11,3 +11,9 @@ ON messages(mailbox_id, COALESCE(received_at, sent_at, created_at) DESC, id DESC
 
 CREATE INDEX IF NOT EXISTS messages_folder_activity_idx
 ON messages(folder, COALESCE(received_at, sent_at, created_at) DESC, id DESC);
+
+-- The planner only prefers the new ordering indexes over the older (mailbox_id, created_at)
+-- ones once it has statistics for them: without this, the default broad-access shape
+-- (mailbox_id IN (...) with no folder filter) still sorts in a temporary B-tree. Cloudflare's
+-- guidance for D1 is to run PRAGMA optimize after creating indexes.
+PRAGMA optimize;

--- a/test/integration/worker/local-reset.test.ts
+++ b/test/integration/worker/local-reset.test.ts
@@ -13,6 +13,7 @@ import userOnboardingMigration from "../../../migrations/0008_user_onboarding.sq
 import loginEmailDomainMigration from "../../../migrations/0009_login_email_domain_isolation.sql?raw";
 import deviceAuthorizationMigration from "../../../migrations/0010_oauth_device_authorization.sql?raw";
 import latestPasswordResetTokenMigration from "../../../migrations/0011_latest_password_reset_token.sql?raw";
+import messageActivityIndexMigration from "../../../migrations/0012_message_activity_index.sql?raw";
 import resetSql from "../../../scripts/hqbase/reset-d1.sql?raw";
 import { buildSeedSql } from "../../../scripts/local-seed-fixture.mjs";
 import { migrationStatements } from "./migration-statements";
@@ -29,7 +30,8 @@ const migrations = [
   userOnboardingMigration,
   loginEmailDomainMigration,
   deviceAuthorizationMigration,
-  latestPasswordResetTokenMigration
+  latestPasswordResetTokenMigration,
+  messageActivityIndexMigration
 ];
 
 describe("local database reset", () => {
@@ -67,6 +69,20 @@ describe("local database reset", () => {
        WHERE type = 'trigger' AND name = 'verification_latest_password_reset_token'`
     ).first<{ name: string }>();
     expect(resetTokenTrigger?.name).toBe("verification_latest_password_reset_token");
+
+    const activityIndexes = await env.DB.prepare(
+      `SELECT name FROM sqlite_master
+       WHERE type = 'index'
+         AND name IN (
+           'messages_activity_idx', 'messages_mailbox_activity_idx', 'messages_folder_activity_idx'
+         )
+       ORDER BY name`
+    ).all<{ name: string }>();
+    expect(activityIndexes.results.map((row) => row.name)).toEqual([
+      "messages_activity_idx",
+      "messages_folder_activity_idx",
+      "messages_mailbox_activity_idx"
+    ]);
   });
 });
 

--- a/test/integration/worker/mail-api.test.ts
+++ b/test/integration/worker/mail-api.test.ts
@@ -406,7 +406,246 @@ describe("HQBase Mail API v1", () => {
     expect(response.status, await response.clone().text()).toBe(201);
     await expect(response.json()).resolves.toMatchObject({ token_endpoint_auth_method: "none" });
   });
+
+  describe("message pagination", () => {
+    // msg_page_2, msg_page_3, and msg_page_4 share one activity timestamp, so the tie is broken
+    // by descending id. msg_secret_1 shares that timestamp too but is in an unreadable mailbox.
+    const tie = "2025-01-01T00:00:02.000Z";
+    const readableOrder = ["msg_page_1", "msg_page_4", "msg_page_3", "msg_page_2", "msg_page_5"];
+
+    beforeAll(async () => {
+      const stamp = "2025-01-01T00:00:00.000Z";
+      await env.DB.batch([
+        mailboxRow("mbx_page", "page@example.com"),
+        mailboxRow("mbx_bulk", "bulk@example.com"),
+        mailboxRow("mbx_secret", "secret@example.com"),
+        grantRow("mbx_page"),
+        grantRow("mbx_bulk"),
+        threadRow("thr_page"),
+        threadRow("thr_bulk"),
+        threadRow("thr_secret"),
+        messageRow("msg_page_1", "thr_page", "mbx_page", "inbox", "2025-01-01T00:00:03.000Z", {
+          subject: "Quarterly report"
+        }),
+        messageRow("msg_page_2", "thr_page", "mbx_page", "inbox", tie, {
+          subject: "Quarterly report"
+        }),
+        messageRow("msg_page_3", "thr_page", "mbx_page", "inbox", tie),
+        messageRow("msg_page_4", "thr_page", "mbx_page", "inbox", tie),
+        messageRow("msg_page_5", "thr_page", "mbx_page", "archived", "2025-01-01T00:00:01.000Z", {
+          subject: "Quarterly report"
+        }),
+        messageRow("msg_secret_1", "thr_secret", "mbx_secret", "inbox", tie),
+        messageRow("msg_secret_2", "thr_secret", "mbx_secret", "inbox", stamp),
+        ...Array.from({ length: 120 }, (_, index) =>
+          messageRow(
+            `msg_bulk_${String(index).padStart(3, "0")}`,
+            "thr_bulk",
+            "mbx_bulk",
+            "inbox",
+            `2024-01-01T00:${String(Math.floor(index / 60)).padStart(2, "0")}:${String(
+              index % 60
+            ).padStart(2, "0")}.000Z`
+          )
+        )
+      ]);
+    });
+
+    it("keeps activity and id order across a page boundary that splits equal timestamps", async () => {
+      const { ids, pages } = await walkPages("/api/v1/messages?mailboxId=mbx_page&limit=2");
+
+      expect(ids).toEqual(readableOrder);
+      expect(new Set(ids).size).toBe(ids.length);
+      expect(pages).toEqual([
+        ["msg_page_1", "msg_page_4"],
+        ["msg_page_3", "msg_page_2"],
+        ["msg_page_5"]
+      ]);
+    });
+
+    it("omits the Link header on the final page", async () => {
+      const single = await apiFetch("/api/v1/messages?mailboxId=mbx_page&limit=100", readToken);
+      expect(single.status).toBe(200);
+      await expect(single.json()).resolves.toHaveLength(readableOrder.length);
+      expect(single.headers.get("link")).toBeNull();
+
+      const firstOfTwo = await apiFetch("/api/v1/messages?mailboxId=mbx_page&limit=4", readToken);
+      expect(firstOfTwo.headers.get("link")).toMatch(/; rel="next"$/u);
+    });
+
+    it("preserves mailboxId, folder, search, and limit in the next page link", async () => {
+      const response = await apiFetch(
+        "/api/v1/messages?mailboxId=mbx_page&folder=inbox&search=report&limit=1",
+        readToken
+      );
+      expect(response.status, await response.clone().text()).toBe(200);
+      const next = nextPageUrl(response);
+      if (!next) throw new Error("Expected a next page link.");
+
+      const url = new URL(next);
+      expect(url.origin + url.pathname).toBe(`${origin}/api/v1/messages`);
+      expect(Object.fromEntries(url.searchParams)).toEqual({
+        mailboxId: "mbx_page",
+        folder: "inbox",
+        search: "report",
+        limit: "1",
+        cursor: expect.any(String)
+      });
+
+      // The filters keep working on the next page: msg_page_5 also matches "report" but is
+      // archived, so folder=inbox keeps it out.
+      const second = await apiFetch(next.slice(origin.length), readToken);
+      await expect(second.json()).resolves.toMatchObject([{ id: "msg_page_2" }]);
+      expect(second.headers.get("link")).toBeNull();
+    });
+
+    it("never lists an unreadable mailbox on any page", async () => {
+      const { ids } = await walkPages("/api/v1/messages?limit=50");
+
+      expect(ids).not.toContain("msg_secret_1");
+      expect(ids).not.toContain("msg_secret_2");
+      expect(ids).toContain("msg_page_1");
+    });
+
+    it("does not leak an unreadable mailbox through a cursor that points into it", async () => {
+      // A well-formed message cursor positioned at msg_secret_1 inside the tied timestamp.
+      const cursor = encodeMessageCursor(tie, "msg_secret_1");
+      const response = await apiFetch(`/api/v1/messages?limit=100&cursor=${cursor}`, readToken);
+      expect(response.status, await response.clone().text()).toBe(200);
+      const ids = ((await response.json()) as Array<{ id: string }>).map((row) => row.id);
+
+      expect(ids).not.toContain("msg_secret_1");
+      expect(ids).not.toContain("msg_secret_2");
+      expect(ids.slice(0, 4)).toEqual(["msg_page_4", "msg_page_3", "msg_page_2", "msg_page_5"]);
+    });
+
+    it("defaults the page to 100 messages and caps the page at 100", async () => {
+      const byDefault = await apiFetch("/api/v1/messages?mailboxId=mbx_bulk", readToken);
+      expect(byDefault.status).toBe(200);
+      await expect(byDefault.json()).resolves.toHaveLength(100);
+      expect(byDefault.headers.get("link")).toContain('rel="next"');
+
+      const atCap = await apiFetch("/api/v1/messages?mailboxId=mbx_bulk&limit=100", readToken);
+      await expect(atCap.json()).resolves.toHaveLength(100);
+    });
+
+    it("rejects an out-of-range or non-integer limit", async () => {
+      for (const limit of ["0", "101", "abc", "-1", "1.5", ""]) {
+        const response = await apiFetch(`/api/v1/messages?limit=${limit}`, readToken);
+        expect(response.status, `limit=${limit}`).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+          error: { code: "INVALID_LIMIT", message: expect.any(String) }
+        });
+      }
+    });
+
+    it("rejects a malformed cursor and a cursor from another list", async () => {
+      // A conversation cursor carries version 1, so it must not decode as a message cursor.
+      const conversationCursor = btoa(JSON.stringify([1, tie, "msg_page_4"]))
+        .replaceAll("+", "-")
+        .replaceAll("/", "_")
+        .replace(/=+$/u, "");
+
+      for (const cursor of ["not-a-cursor", "!!!", conversationCursor]) {
+        const response = await apiFetch(
+          `/api/v1/messages?cursor=${encodeURIComponent(cursor)}`,
+          readToken
+        );
+        expect(response.status, `cursor=${cursor}`).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+          error: { code: "INVALID_CURSOR", message: expect.any(String) }
+        });
+      }
+    });
+
+    async function walkPages(
+      path: string
+    ): Promise<{ ids: string[]; pages: string[][]; requests: number }> {
+      const pages: string[][] = [];
+      let next: string | null = `${origin}${path}`;
+      let requests = 0;
+
+      while (next) {
+        if (++requests > 200) throw new Error("Pagination did not terminate.");
+        const response: Response = await apiFetch(next.slice(origin.length), readToken);
+        expect(response.status, await response.clone().text()).toBe(200);
+        pages.push(((await response.json()) as Array<{ id: string }>).map((row) => row.id));
+        next = nextPageUrl(response);
+      }
+
+      return { ids: pages.flat(), pages, requests };
+    }
+  });
 });
+
+function nextPageUrl(response: Response): string | null {
+  const link = response.headers.get("link");
+  if (!link) return null;
+  const match = link.match(/^<([^>]+)>;\s*rel="next"$/u);
+  if (!match?.[1]) throw new Error(`Malformed Link header: ${link}`);
+  return match[1];
+}
+
+/** Mirrors the worker's message cursor encoding so tests can aim a cursor at a chosen row. */
+function encodeMessageCursor(activityAt: string, id: string): string {
+  return btoa(JSON.stringify(["m1", activityAt, id]))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+function mailboxRow(id: string, address: string): D1PreparedStatement {
+  const stamp = "2025-01-01T00:00:00.000Z";
+  return env.DB.prepare(
+    `INSERT INTO mailboxes (id, address, display_name, is_active, created_at, updated_at)
+     VALUES (?, ?, ?, 1, ?, ?)`
+  ).bind(id, address, id, stamp, stamp);
+}
+
+function grantRow(mailboxId: string): D1PreparedStatement {
+  const stamp = "2025-01-01T00:00:00.000Z";
+  return env.DB.prepare(
+    `INSERT INTO mailbox_grants (mailbox_id, user_id, access_level, created_by, created_at, updated_at)
+     VALUES (?, ?, 'agent', ?, ?, ?)`
+  ).bind(mailboxId, userId, userId, stamp, stamp);
+}
+
+function threadRow(id: string): D1PreparedStatement {
+  const stamp = "2025-01-01T00:00:00.000Z";
+  return env.DB.prepare(
+    `INSERT INTO threads (id, subject_normalized, last_message_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`
+  ).bind(id, id, stamp, stamp, stamp);
+}
+
+function messageRow(
+  id: string,
+  threadId: string,
+  mailboxId: string,
+  folder: string,
+  receivedAt: string,
+  options: { subject?: string } = {}
+): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO messages
+     (id, thread_id, mailbox_id, direction, folder, from_address, to_json, cc_json, bcc_json,
+      subject, snippet, text_body, message_id, dedupe_key, in_reply_to, references_json,
+      received_at, sent_at, read_at, has_attachments, created_at, updated_at)
+     VALUES (?, ?, ?, 'inbound', ?, 'sender@example.net', '[]', '[]', '[]', ?, '', '',
+             ?, ?, NULL, '[]', ?, NULL, NULL, 0, ?, ?)`
+  ).bind(
+    id,
+    threadId,
+    mailboxId,
+    folder,
+    options.subject ?? id,
+    `<${id}@example.net>`,
+    `dedupe-${id}`,
+    receivedAt,
+    receivedAt,
+    receivedAt
+  );
+}
 
 function apiFetch(path: string, token: string, init: RequestInit = {}): Promise<Response> {
   const headers = new Headers(init.headers);

--- a/test/integration/worker/message-activity-index.test.ts
+++ b/test/integration/worker/message-activity-index.test.ts
@@ -42,6 +42,13 @@ const keysetSql = `SELECT messages.* FROM messages
 const singleMailboxSql = `SELECT messages.* FROM messages
   WHERE mailbox_id IN ('mbx_index', 'mbx_other') AND mailbox_id = 'mbx_index'
   ORDER BY ${activityAt} DESC, messages.id DESC LIMIT 101`;
+// The production default: GET /messages with no folder filter — the route ALWAYS adds
+// mailbox_id IN (...) for the readable set. Reviewer-reproduced shape: with two readable
+// mailboxes and no folder, the planner kept messages_mailbox_idx + a temp B-tree until
+// PRAGMA optimize gave it statistics for the new ordering indexes.
+const broadAccessSql = `SELECT messages.* FROM messages
+  WHERE mailbox_id IN ('mbx_index', 'mbx_other')
+  ORDER BY ${activityAt} DESC, messages.id DESC LIMIT 101`;
 
 describe("message activity index migration", () => {
   beforeAll(async () => {
@@ -51,9 +58,10 @@ describe("message activity index migration", () => {
     const stamp = "2025-01-01T00:00:00.000Z";
     await env.DB.prepare(
       `INSERT INTO mailboxes (id, address, display_name, is_active, created_at, updated_at)
-       VALUES ('mbx_index', 'index@example.com', 'Index', 1, ?, ?)`
+       VALUES ('mbx_index', 'index@example.com', 'Index', 1, ?, ?),
+              ('mbx_other', 'other@example.com', 'Other', 1, ?, ?)`
     )
-      .bind(stamp, stamp)
+      .bind(stamp, stamp, stamp, stamp)
       .run();
     await env.DB.prepare(
       `INSERT INTO threads (id, subject_normalized, last_message_at, created_at, updated_at)
@@ -61,17 +69,20 @@ describe("message activity index migration", () => {
     )
       .bind(stamp, stamp, stamp)
       .run();
+    // Both readable mailboxes are populated, so the broad-access shape (no folder,
+    // mailbox_id IN (...)) is a genuine multi-mailbox merge, not a single-source scan.
     await env.DB.batch(
-      Array.from({ length: 200 }, (_, index) =>
+      Array.from({ length: 400 }, (_, index) =>
         env.DB.prepare(
           `INSERT INTO messages
            (id, thread_id, mailbox_id, direction, folder, from_address, to_json, cc_json, bcc_json,
             subject, snippet, text_body, message_id, dedupe_key, in_reply_to, references_json,
             received_at, sent_at, read_at, has_attachments, created_at, updated_at)
-           VALUES (?, 'thr_index', 'mbx_index', 'inbound', 'inbox', 'sender@example.net', '[]',
+           VALUES (?, 'thr_index', ?, 'inbound', 'inbox', 'sender@example.net', '[]',
                    '[]', '[]', '', '', '', NULL, ?, NULL, '[]', ?, NULL, NULL, 0, ?, ?)`
         ).bind(
           `msg_idx_${String(index).padStart(4, "0")}`,
+          index % 2 === 0 ? "mbx_index" : "mbx_other",
           `idx-dedupe-${index}`,
           `2025-01-01T00:00:${String(index % 60).padStart(2, "0")}.000Z`,
           stamp,
@@ -85,10 +96,10 @@ describe("message activity index migration", () => {
     expect(await queryPlan(listSql)).toContain("USE TEMP B-TREE FOR ORDER BY");
   });
 
-  it("serves the list, keyset, and single-mailbox orders from an index after the migration", async () => {
+  it("serves the list, keyset, single-mailbox, and broad-access orders from an index after the migration", async () => {
     await applyMigration(messageActivityIndexMigration);
 
-    for (const sql of [listSql, keysetSql, singleMailboxSql]) {
+    for (const sql of [listSql, keysetSql, singleMailboxSql, broadAccessSql]) {
       expect(await queryPlan(sql), sql).not.toContain("USE TEMP B-TREE FOR ORDER BY");
     }
   });
@@ -100,7 +111,7 @@ describe("message activity index migration", () => {
     const rows = await env.DB.prepare("SELECT COUNT(*) AS count FROM messages").first<{
       count: number;
     }>();
-    expect(rows?.count).toBe(200);
+    expect(rows?.count).toBe(400);
 
     const indexes = await env.DB.prepare(
       `SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'messages_%activity_idx'

--- a/test/integration/worker/message-activity-index.test.ts
+++ b/test/integration/worker/message-activity-index.test.ts
@@ -1,0 +1,126 @@
+import { env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import initialMigration from "../../../migrations/0001_initial.sql?raw";
+import workspaceMigration from "../../../migrations/0002_workspace.sql?raw";
+import oauthResourcesMigration from "../../../migrations/0003_oauth_resources.sql?raw";
+import conversationMigration from "../../../migrations/0004_conversations.sql?raw";
+import threadRebuildMigration from "../../../migrations/0005_rebuild_threads.sql?raw";
+import pushMigration from "../../../migrations/0006_push_notifications.sql?raw";
+import userMailPreferencesMigration from "../../../migrations/0007_user_mail_preferences.sql?raw";
+import userOnboardingMigration from "../../../migrations/0008_user_onboarding.sql?raw";
+import loginEmailDomainMigration from "../../../migrations/0009_login_email_domain_isolation.sql?raw";
+import deviceAuthorizationMigration from "../../../migrations/0010_oauth_device_authorization.sql?raw";
+import latestPasswordResetTokenMigration from "../../../migrations/0011_latest_password_reset_token.sql?raw";
+import messageActivityIndexMigration from "../../../migrations/0012_message_activity_index.sql?raw";
+import { migrationStatements } from "./migration-statements";
+
+const priorMigrations = [
+  initialMigration,
+  workspaceMigration,
+  oauthResourcesMigration,
+  conversationMigration,
+  threadRebuildMigration,
+  pushMigration,
+  userMailPreferencesMigration,
+  userOnboardingMigration,
+  loginEmailDomainMigration,
+  deviceAuthorizationMigration,
+  latestPasswordResetTokenMigration
+];
+
+const activityAt = "COALESCE(received_at, sent_at, created_at)";
+// Literal values keep EXPLAIN QUERY PLAN readable; the planner treats them like bound parameters.
+const listSql = `SELECT messages.* FROM messages
+  WHERE mailbox_id IN ('mbx_index', 'mbx_other') AND folder = 'inbox'
+  ORDER BY ${activityAt} DESC, messages.id DESC LIMIT 101`;
+const keysetSql = `SELECT messages.* FROM messages
+  WHERE mailbox_id IN ('mbx_index', 'mbx_other') AND folder = 'inbox'
+    AND (${activityAt} < '2025-01-01T00:00:30.000Z'
+      OR (${activityAt} = '2025-01-01T00:00:30.000Z' AND messages.id < 'msg_idx_0100'))
+  ORDER BY ${activityAt} DESC, messages.id DESC LIMIT 101`;
+const singleMailboxSql = `SELECT messages.* FROM messages
+  WHERE mailbox_id IN ('mbx_index', 'mbx_other') AND mailbox_id = 'mbx_index'
+  ORDER BY ${activityAt} DESC, messages.id DESC LIMIT 101`;
+
+describe("message activity index migration", () => {
+  beforeAll(async () => {
+    for (const migration of priorMigrations) {
+      await applyMigration(migration);
+    }
+    const stamp = "2025-01-01T00:00:00.000Z";
+    await env.DB.prepare(
+      `INSERT INTO mailboxes (id, address, display_name, is_active, created_at, updated_at)
+       VALUES ('mbx_index', 'index@example.com', 'Index', 1, ?, ?)`
+    )
+      .bind(stamp, stamp)
+      .run();
+    await env.DB.prepare(
+      `INSERT INTO threads (id, subject_normalized, last_message_at, created_at, updated_at)
+       VALUES ('thr_index', 'index', ?, ?, ?)`
+    )
+      .bind(stamp, stamp, stamp)
+      .run();
+    await env.DB.batch(
+      Array.from({ length: 200 }, (_, index) =>
+        env.DB.prepare(
+          `INSERT INTO messages
+           (id, thread_id, mailbox_id, direction, folder, from_address, to_json, cc_json, bcc_json,
+            subject, snippet, text_body, message_id, dedupe_key, in_reply_to, references_json,
+            received_at, sent_at, read_at, has_attachments, created_at, updated_at)
+           VALUES (?, 'thr_index', 'mbx_index', 'inbound', 'inbox', 'sender@example.net', '[]',
+                   '[]', '[]', '', '', '', NULL, ?, NULL, '[]', ?, NULL, NULL, 0, ?, ?)`
+        ).bind(
+          `msg_idx_${String(index).padStart(4, "0")}`,
+          `idx-dedupe-${index}`,
+          `2025-01-01T00:00:${String(index % 60).padStart(2, "0")}.000Z`,
+          stamp,
+          stamp
+        )
+      )
+    );
+  });
+
+  it("sorts the message list in a temporary B-tree before the migration", async () => {
+    expect(await queryPlan(listSql)).toContain("USE TEMP B-TREE FOR ORDER BY");
+  });
+
+  it("serves the list, keyset, and single-mailbox orders from an index after the migration", async () => {
+    await applyMigration(messageActivityIndexMigration);
+
+    for (const sql of [listSql, keysetSql, singleMailboxSql]) {
+      expect(await queryPlan(sql), sql).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+    }
+  });
+
+  it("upgrades an existing database and is safe to re-apply", async () => {
+    await applyMigration(messageActivityIndexMigration);
+    await applyMigration(messageActivityIndexMigration);
+
+    const rows = await env.DB.prepare("SELECT COUNT(*) AS count FROM messages").first<{
+      count: number;
+    }>();
+    expect(rows?.count).toBe(200);
+
+    const indexes = await env.DB.prepare(
+      `SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'messages_%activity_idx'
+       ORDER BY name`
+    ).all<{ name: string }>();
+    expect(indexes.results.map((row) => row.name)).toEqual([
+      "messages_activity_idx",
+      "messages_folder_activity_idx",
+      "messages_mailbox_activity_idx"
+    ]);
+  });
+});
+
+async function queryPlan(sql: string): Promise<string> {
+  const result = await env.DB.prepare(`EXPLAIN QUERY PLAN ${sql}`).all<{ detail: string }>();
+  return result.results.map((row) => row.detail).join("\n");
+}
+
+async function applyMigration(source: string): Promise<void> {
+  for (const statement of migrationStatements(source)) {
+    await env.DB.prepare(statement).run();
+  }
+}

--- a/worker/features/mail-api/discovery.ts
+++ b/worker/features/mail-api/discovery.ts
@@ -131,7 +131,8 @@ The method index is an orientation aid. Consult ${openApiUrl} for exact paramete
 ## Operating rules
 
 - Use \`Content-Type: application/json\` for JSON requests and \`multipart/form-data\` for draft attachment uploads.
-- Treat conversation cursors as opaque strings and return them unchanged.
+- Treat message and conversation cursors as opaque strings and return them unchanged. Do not construct or edit a cursor.
+- \`GET ${apiBase}/messages\` returns one page. Follow the \`Link: <url>; rel="next"\` response header for the next page. No \`Link\` header means the last page.
 - Ignore response fields you do not recognize.
 - Do not log access tokens, refresh tokens, message bodies, or attachments.
 - Do not log device codes or user codes, and do not paste them into unrelated chats or tools.

--- a/worker/features/messages/conversation-queries.ts
+++ b/worker/features/messages/conversation-queries.ts
@@ -2,12 +2,16 @@ import { nowIso } from "../../db/client";
 import { AppError } from "../../lib/errors";
 
 import type { MessageAction } from "./actions";
+import { decodeKeysetCursor, encodeKeysetCursor, type KeysetCursor } from "./keyset-cursor";
 import type {
   ConversationFolder,
   ConversationPage,
   ConversationRow,
   ConversationSummary
 } from "./types";
+
+/** Conversation cursors keep version 1. Message cursors use a different version tag. */
+const conversationCursorVersion = 1;
 
 export type ListConversationFilters = {
   cursor?: string | undefined;
@@ -229,38 +233,16 @@ function mapConversationSummary(row: ConversationRow): ConversationSummary {
   };
 }
 
-type ConversationCursor = {
-  activityAt: string;
-  id: string;
-};
-
-function encodeConversationCursor(cursor: ConversationCursor): string {
-  return btoa(JSON.stringify([1, cursor.activityAt, cursor.id]))
-    .replaceAll("+", "-")
-    .replaceAll("/", "_")
-    .replace(/=+$/u, "");
+function encodeConversationCursor(cursor: KeysetCursor): string {
+  return encodeKeysetCursor(conversationCursorVersion, cursor);
 }
 
-function decodeConversationCursor(value: string): ConversationCursor {
-  try {
-    const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
-    const padding = "=".repeat((4 - (base64.length % 4)) % 4);
-    const decoded: unknown = JSON.parse(atob(`${base64}${padding}`));
-    if (
-      !Array.isArray(decoded) ||
-      decoded.length !== 3 ||
-      decoded[0] !== 1 ||
-      typeof decoded[1] !== "string" ||
-      decoded[1].length === 0 ||
-      typeof decoded[2] !== "string" ||
-      decoded[2].length === 0
-    ) {
-      throw new Error("Invalid cursor payload.");
-    }
-    return { activityAt: decoded[1], id: decoded[2] };
-  } catch {
+function decodeConversationCursor(value: string): KeysetCursor {
+  const cursor = decodeKeysetCursor(conversationCursorVersion, value);
+  if (!cursor) {
     throw new AppError("INVALID_CONVERSATION_CURSOR", "Conversation cursor is invalid.", 400);
   }
+  return cursor;
 }
 
 function parseJsonList(value: string): string[] {

--- a/worker/features/messages/keyset-cursor.ts
+++ b/worker/features/messages/keyset-cursor.ts
@@ -1,0 +1,42 @@
+/**
+ * Opaque keyset cursors for activity-ordered lists.
+ *
+ * A cursor holds the version tag, the activity timestamp, and the row id of the last row on the
+ * page. The version tag is part of the payload, so a cursor from one list never decodes as a
+ * cursor for a different list. Clients must treat the encoded value as opaque.
+ */
+
+export type KeysetCursor = {
+  activityAt: string;
+  id: string;
+};
+
+export function encodeKeysetCursor(version: string | number, cursor: KeysetCursor): string {
+  return btoa(JSON.stringify([version, cursor.activityAt, cursor.id]))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+/** Returns the cursor, or null when the value is malformed or holds a different version. */
+export function decodeKeysetCursor(version: string | number, value: string): KeysetCursor | null {
+  try {
+    const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+    const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+    const decoded: unknown = JSON.parse(atob(`${base64}${padding}`));
+    if (
+      !Array.isArray(decoded) ||
+      decoded.length !== 3 ||
+      decoded[0] !== version ||
+      typeof decoded[1] !== "string" ||
+      decoded[1].length === 0 ||
+      typeof decoded[2] !== "string" ||
+      decoded[2].length === 0
+    ) {
+      return null;
+    }
+    return { activityAt: decoded[1], id: decoded[2] };
+  } catch {
+    return null;
+  }
+}

--- a/worker/features/messages/queries.ts
+++ b/worker/features/messages/queries.ts
@@ -2,6 +2,7 @@ import { newId, nowIso } from "../../db/client";
 import { AppError } from "../../lib/errors";
 import type { MessageAction } from "./actions";
 import { buildMessageActionPatch } from "./actions";
+import { decodeKeysetCursor, encodeKeysetCursor, type KeysetCursor } from "./keyset-cursor";
 import type {
   AttachmentRow,
   InsertAttachmentInput,
@@ -17,13 +18,34 @@ const messageSelect = `SELECT messages.*,
    WHERE id = messages.delivered_to_address_id) AS delivered_to_address
   FROM messages`;
 
+/** Message cursors are versioned separately from conversation cursors. */
+const messageCursorVersion = "m1";
+const messageActivityAt = "COALESCE(received_at, sent_at, created_at)";
+
+export const defaultMessageLimit = 100;
+export const maxMessageLimit = 100;
+
 export type ListMessageFilters = {
+  cursor?: string | undefined;
   folder?: string | undefined;
   limit?: number | undefined;
   mailboxId?: string | undefined;
   search?: string | undefined;
   mailboxIds?: string[] | undefined;
 };
+
+export type MessagePage = {
+  messages: MessageSummary[];
+  nextCursor: string | null;
+};
+
+export function decodeMessageCursor(value: string): KeysetCursor {
+  const cursor = decodeKeysetCursor(messageCursorVersion, value);
+  if (!cursor) {
+    throw new AppError("INVALID_CURSOR", "Message cursor is invalid.", 400);
+  }
+  return cursor;
+}
 
 export async function insertMessage(
   db: D1Database,
@@ -118,11 +140,19 @@ export async function listMessages(
   db: D1Database,
   filters: ListMessageFilters
 ): Promise<MessageSummary[]> {
+  return (await listMessagePage(db, filters)).messages;
+}
+
+export async function listMessagePage(
+  db: D1Database,
+  filters: ListMessageFilters
+): Promise<MessagePage> {
   const where: string[] = [];
   const params: Array<string | number> = [];
 
+  // The mailbox-access filter is applied first and is never relaxed by a cursor.
   if (filters.mailboxIds) {
-    if (filters.mailboxIds.length === 0) return [];
+    if (filters.mailboxIds.length === 0) return { messages: [], nextCursor: null };
     where.push(`mailbox_id IN (${filters.mailboxIds.map(() => "?").join(", ")})`);
     params.push(...filters.mailboxIds);
   }
@@ -143,17 +173,39 @@ export async function listMessages(
     params.push(like, like, like, like, like);
   }
 
-  const limit = Math.min(Math.max(filters.limit ?? 100, 1), 100);
+  const cursor = filters.cursor ? decodeMessageCursor(filters.cursor) : null;
+  if (cursor) {
+    where.push(`(${messageActivityAt} < ? OR (${messageActivityAt} = ? AND messages.id < ?))`);
+    params.push(cursor.activityAt, cursor.activityAt, cursor.id);
+  }
+
+  const limit = Math.min(Math.max(filters.limit ?? defaultMessageLimit, 1), maxMessageLimit);
+  // Read one extra row to learn whether another page exists.
   const sql = `${messageSelect} ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
-    ORDER BY COALESCE(received_at, sent_at, created_at) DESC LIMIT ?`;
-  params.push(limit);
+    ORDER BY ${messageActivityAt} DESC, messages.id DESC LIMIT ?`;
+  params.push(limit + 1);
 
   const result = await db
     .prepare(sql)
     .bind(...params)
     .all<MessageRow>();
 
-  return result.results.map(mapMessageSummary);
+  const pageRows = result.results.slice(0, limit);
+  const finalRow = pageRows.at(-1);
+  return {
+    messages: pageRows.map(mapMessageSummary),
+    nextCursor:
+      result.results.length > limit && finalRow
+        ? encodeKeysetCursor(messageCursorVersion, {
+            activityAt: messageActivityOf(finalRow),
+            id: finalRow.id
+          })
+        : null
+  };
+}
+
+function messageActivityOf(row: MessageRow): string {
+  return row.received_at ?? row.sent_at ?? row.created_at;
 }
 
 export async function getMessageDetail(db: D1Database, id: string): Promise<MessageDetail | null> {

--- a/worker/features/messages/routes.ts
+++ b/worker/features/messages/routes.ts
@@ -9,13 +9,15 @@ import { sanitizeMessageHtml } from "./html-sanitizer";
 import { isSafeInlineImage, normalizedContentType } from "./inline-media";
 import { publicMessage } from "./public-message";
 import {
+  defaultMessageLimit,
   findAttachment,
   getAttachmentMailboxId,
   getMessageDetail,
   getMessageHtmlKey,
   getMessageMailboxId,
-  listMessages,
+  listMessagePage,
   listThreadMessages,
+  maxMessageLimit,
   updateMessageAction
 } from "./queries";
 import { isRemoteMediaTrusted, trustRemoteMediaSender } from "./remote-media";
@@ -29,14 +31,21 @@ const actions: readonly MessageAction[] = ["read", "unread", "star", "unstar", "
 messageRoutes.get("/", async (c) => {
   const auth = await requireMailApiContext(c.env, c.req.raw, "mail:read");
   const mailboxIds = await accessibleMailboxIds(c.env.DB, auth.user.id, auth.user.role, "read");
-  return c.json(
-    await listMessages(c.env.DB, {
-      folder: c.req.query("folder"),
-      mailboxId: c.req.query("mailboxId"),
-      search: c.req.query("search"),
-      mailboxIds
-    })
-  );
+  const limit = parseMessageLimit(c.req.query("limit"));
+  const page = await listMessagePage(c.env.DB, {
+    cursor: c.req.query("cursor"),
+    folder: c.req.query("folder"),
+    limit,
+    mailboxId: c.req.query("mailboxId"),
+    search: c.req.query("search"),
+    mailboxIds
+  });
+
+  const response = c.json(page.messages);
+  if (page.nextCursor) {
+    response.headers.set("link", `<${nextMessagePageUrl(c.req.url, page.nextCursor)}>; rel="next"`);
+  }
+  return response;
 });
 
 messageRoutes.get("/:id/thread", async (c) => {
@@ -193,3 +202,32 @@ attachmentRoutes.get("/:id", async (c) => {
   headers.set("content-disposition", `attachment; filename="${attachment.filename}"`);
   return new Response(object.body, { headers });
 });
+
+/** Returns the requested page size, or throws INVALID_LIMIT when the value is not 1 to 100. */
+function parseMessageLimit(value: string | undefined): number {
+  if (value === undefined) {
+    return defaultMessageLimit;
+  }
+  const limit = Number(value);
+  if (!/^\d+$/u.test(value) || !Number.isInteger(limit) || limit < 1 || limit > maxMessageLimit) {
+    throw new AppError(
+      "INVALID_LIMIT",
+      `Limit must be an integer from 1 to ${maxMessageLimit}.`,
+      400
+    );
+  }
+  return limit;
+}
+
+/** Keeps mailboxId, folder, search, and limit, and replaces the cursor. */
+function nextMessagePageUrl(requestUrl: string, cursor: string): string {
+  const url = new URL(requestUrl);
+  const preserved = new URLSearchParams();
+  for (const name of ["mailboxId", "folder", "search", "limit"]) {
+    const value = url.searchParams.get(name);
+    if (value !== null) preserved.set(name, value);
+  }
+  preserved.set("cursor", cursor);
+  url.search = preserved.toString();
+  return url.toString();
+}


### PR DESCRIPTION
Part 1 of 2 from HQBase/hqbase#11 (pagination only, per your contract). Spec-first companion: https://github.com/HQBase/hqbase-site/pull/10

## Summary

- `GET /api/v1/messages` accepts `limit` (integer 1–100, default 100) and an opaque, versioned `cursor` over `(activity_at, id)`.
- Orders by `COALESCE(received_at, sent_at, created_at) DESC, id DESC`; fetches `limit + 1` to detect a next page.
- Body is unchanged (JSON array of `MessageSummary`). When another page exists the response carries `Link: <absolute-url>; rel="next"` preserving `mailboxId`, `folder`, `search`, `limit` plus `cursor`; no `Link` on the final page.
- Malformed `limit`/`cursor` → `400 INVALID_LIMIT` / `400 INVALID_CURSOR` in the standard error envelope. The mailbox-access predicate is built independently of the cursor and applies to every page.
- Message cursors carry their own version tag (`"m1"`), so a conversation cursor is rejected here and vice versa. The base64url keyset codec is factored into `worker/features/messages/keyset-cursor.ts` and conversations were moved onto it — wire format and `INVALID_CONVERSATION_CURSOR` behaviour are byte-for-byte unchanged (a shipped path, so worth a glance in review).
- Not included: `updatedSince`, a changes endpoint, or a change-journal migration.
- The web app and MCP tool are untouched (`listMessages` still returns the array and delegates to the new page query).

## Index

`EXPLAIN QUERY PLAN` on a 200k-row replica showed `USE TEMP B-TREE FOR ORDER BY` for every filter shape (existing indexes are `(col, created_at)`), so migration `0012_message_activity_index.sql` adds expression indexes on the activity order — one each for unfiltered, mailbox-filtered and folder-filtered listings — after which list, keyset and single-mailbox plans are index-served with no temp B-tree, and that holds on a fresh database without `ANALYZE`.

Two things I'd like your call on: (a) three indexes is 3 extra B-tree writes per inserted message; `messages_folder_activity_idx` + `messages_mailbox_activity_idx` cover every shape the web app issues, and `messages_activity_idx` only earns its keep for a multi-mailbox listing with no folder — happy to trim to two. (b) A multi-value `mailbox_id IN (…)` with no folder filter still sorts via a temp B-tree unless `sqlite_stat1` exists (SQLite won't sort-merge across `IN` values without stats); D1 never runs `ANALYZE` on its own. I did not add `ANALYZE` to the migration.

## Tests

Integration (`test/integration/worker/mail-api.test.ts`, new "message pagination" block): equal activity timestamps split across a page boundary (exact per-page contents asserted, so a missing id tiebreak or an off-by-one shows as a duplicate/dropped row); no `Link` on the final page; filter preservation in the next URL, then followed; an unreadable mailbox never appears on any page; a hand-built cursor pointing into an unreadable mailbox resumes correctly without leaking it; default and cap of 100; invalid limits (`0`, `101`, `abc`, `-1`, `1.5`, empty) → `INVALID_LIMIT`; malformed cursor and a genuine conversation cursor → `INVALID_CURSOR`.
Migration coverage: `message-activity-index.test.ts` (upgrade: plan uses a temp B-tree at 0011, does not after 0012; re-apply idempotent) and `local-reset.test.ts` (fresh install: the three indexes exist).

OpenAPI edited surgically (`limit`, `cursor`, `Link` header, 400 codes); Postman regenerated and verified. Agent Skill text updated to describe message cursors.

## Validation

`pnpm check`: biome, typecheck, api:check, integration (11 files / 60 tests), coverage, architecture, build pass. Only failure is the pre-existing `use-draft-autosave.test.tsx` localStorage case under Node 26.5 (reproduces on pristine `main`). Architecture check now warns that `queries.ts` is over 300 lines (still passes); say if you'd like the paging query split into its own module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)