### PR TITLE
Stabilize Windows Worker integration tests

### DIFF
--- a/vitest.worker.config.ts
+++ b/vitest.worker.config.ts
@@ -36,7 +36,8 @@ export default defineConfig(async () => {
         }
       },
       hookTimeout: 30_000,
-      include: ["test/integration/worker/**/*.test.ts"]
+      include: ["test/integration/worker/**/*.test.ts"],
+      testTimeout: 15_000
     }
   };
 });


### PR DESCRIPTION
## Summary

- set the Worker integration `testTimeout` to 15 seconds
- keep the existing 30-second hook timeout unchanged
- keep the limit finite so genuine hangs still fail CI

## Root cause

Vitest applies a 5-second default timeout to each test. Windows runners intermittently exceed that limit in valid D1 and authentication integration tests. The latest `main` run at the base of PR #35 failed two existing `users.test.ts` cases, and PR #35 also pushed `local-reset.test.ts` past the same limit.

This is a test-harness change only. It does not change product behavior, the public API, or deployment configuration.

## Validation

- `CI=true pnpm check`
- `WRANGLER_LOG_PATH=/tmp/hqbase-wrangler-timeout-fix.log CI=true pnpm deploy:dry-run`
