### PR TITLE
Add a durable Mail API changes feed

### DIFF
--- a/api/hqbase-mail-api-v1.openapi.json
+++ b/api/hqbase-mail-api-v1.openapi.json
@@ -24,6 +24,9 @@
       "name": "Messages"
     },
     {
+      "name": "Changes"
+    },
+    {
       "name": "Conversations"
     },
     {
@@ -112,6 +115,108 @@
         },
         "tags": ["Mailboxes"],
         "operationId": "listMailboxes"
+      }
+    },
+    "/api/v1/changes": {
+      "get": {
+        "summary": "Read message changes",
+        "description": "Returns a bounded page of message upserts and deletion tombstones in journal order. A request without a cursor returns an empty checkpoint at the current high-water sequence.",
+        "security": [
+          {
+            "oauth2": ["mail:read"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A bounded page of message changes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageChangePage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. `INVALID_LIMIT` when limit is not an integer from 1 to 100. `INVALID_CHANGE_CURSOR` when the cursor is malformed, foreign, or beyond the current journal. `INVALID_CHANGE_FILTER` when a mailbox, folder, or search filter is supplied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "`CHANGE_CURSOR_EXPIRED` when future journal retention removes a required range. The client must start a new full bootstrap.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Changes"],
+        "operationId": "listMessageChanges",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 512
+            },
+            "description": "Opaque cursor from a checkpoint or previous changes page. Omit it only to create a new checkpoint."
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            },
+            "description": "Maximum number of journal entries read for this page."
+          }
+        ]
       }
     },
     "/api/v1/messages": {
@@ -2262,6 +2367,63 @@
           "createdAt": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "MessageChangeUpsert": {
+        "type": "object",
+        "required": ["type", "message"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "upsert"
+          },
+          "message": {
+            "$ref": "#/components/schemas/MessageSummary"
+          }
+        }
+      },
+      "MessageChangeDelete": {
+        "type": "object",
+        "required": ["type", "messageId", "mailboxId"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "delete"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "mailboxId": {
+            "type": "string"
+          }
+        }
+      },
+      "MessageChange": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/MessageChangeUpsert"
+          },
+          {
+            "$ref": "#/components/schemas/MessageChangeDelete"
+          }
+        ]
+      },
+      "MessageChangePage": {
+        "type": "object",
+        "required": ["changes", "nextCursor", "hasMore"],
+        "properties": {
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MessageChange"
+            }
+          },
+          "nextCursor": {
+            "type": "string"
+          },
+          "hasMore": {
+            "type": "boolean"
           }
         }
       },

--- a/api/hqbase-mail-api-v1.postman_collection.json
+++ b/api/hqbase-mail-api-v1.postman_collection.json
@@ -151,6 +151,38 @@
       ]
     },
     {
+      "name": "Changes",
+      "item": [
+        {
+          "name": "Read message changes",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/v1/changes",
+              "variable": [],
+              "query": [
+                {
+                  "key": "cursor",
+                  "value": "",
+                  "disabled": true,
+                  "description": "Opaque cursor from a checkpoint or previous changes page. Omit it only to create a new checkpoint."
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "disabled": true,
+                  "description": "Maximum number of journal entries read for this page."
+                }
+              ]
+            },
+            "description": "Returns a bounded page of message upserts and deletion tombstones in journal order. A request without a cursor returns an empty checkpoint at the current high-water sequence."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
       "name": "Messages",
       "item": [
         {

--- a/migrations/0013_message_changes.sql
+++ b/migrations/0013_message_changes.sql
@@ -1,0 +1,31 @@
+-- Durable message change journal for GET /api/v1/changes.
+-- Journal rows have no foreign key to messages so deletion tombstones survive retention.
+
+CREATE TABLE IF NOT EXISTS message_changes (
+  sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+  message_id TEXT NOT NULL,
+  mailbox_id TEXT,
+  kind TEXT NOT NULL CHECK (kind IN ('upsert', 'delete')),
+  changed_at TEXT NOT NULL
+);
+
+CREATE TRIGGER IF NOT EXISTS message_changes_after_insert
+AFTER INSERT ON messages
+BEGIN
+  INSERT INTO message_changes (message_id, mailbox_id, kind, changed_at)
+  VALUES (NEW.id, NEW.mailbox_id, 'upsert', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+END;
+
+CREATE TRIGGER IF NOT EXISTS message_changes_after_update
+AFTER UPDATE ON messages
+BEGIN
+  INSERT INTO message_changes (message_id, mailbox_id, kind, changed_at)
+  VALUES (NEW.id, NEW.mailbox_id, 'upsert', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+END;
+
+CREATE TRIGGER IF NOT EXISTS message_changes_after_delete
+AFTER DELETE ON messages
+BEGIN
+  INSERT INTO message_changes (message_id, mailbox_id, kind, changed_at)
+  VALUES (OLD.id, OLD.mailbox_id, 'delete', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+END;

--- a/scripts/generate-mail-api-artifacts.mjs
+++ b/scripts/generate-mail-api-artifacts.mjs
@@ -82,6 +82,7 @@ function validateOpenApi(document) {
   const requiredPaths = [
     "/api/v1/mailboxes",
     "/api/v1/messages",
+    "/api/v1/changes",
     "/api/v1/conversations",
     "/api/v1/drafts",
     "/api/v1/send",

--- a/scripts/hqbase/reset-d1.sql
+++ b/scripts/hqbase/reset-d1.sql
@@ -28,6 +28,7 @@ DROP TABLE IF EXISTS rate_limits;
 DROP TABLE IF EXISTS audit_events;
 DROP TABLE IF EXISTS mailbox_grants;
 DROP TABLE IF EXISTS hqbase_schema_state;
+DROP TABLE IF EXISTS message_changes;
 DROP TABLE IF EXISTS message_attachments;
 DROP TABLE IF EXISTS messages;
 DROP TABLE IF EXISTS threads;

--- a/test/e2e/staging/lifecycle.spec.ts
+++ b/test/e2e/staging/lifecycle.spec.ts
@@ -85,6 +85,15 @@ test("HQBase web lifecycle remains healthy", async ({ page, request }) => {
     login.ok(),
     `Owner API sign-in failed (${login.status()}): ${await login.text()}`
   ).toBeTruthy();
+  if ((process.env.HQBASE_STAGING_MAIL_API_BASE_PATH ?? "/api/v1") === "/api/v1") {
+    const checkpoint = await request.get(stagingMailApiPath("/changes"));
+    expect(checkpoint.ok(), await checkpoint.text()).toBeTruthy();
+    await expect(checkpoint.json()).resolves.toMatchObject({
+      changes: [],
+      nextCursor: expect.any(String),
+      hasMore: false
+    });
+  }
   const primaryEmailAction = page.getByRole("button", {
     name: /^(?:Compose|New email)$/
   });

--- a/test/integration/worker/local-reset.test.ts
+++ b/test/integration/worker/local-reset.test.ts
@@ -14,6 +14,7 @@ import loginEmailDomainMigration from "../../../migrations/0009_login_email_doma
 import deviceAuthorizationMigration from "../../../migrations/0010_oauth_device_authorization.sql?raw";
 import latestPasswordResetTokenMigration from "../../../migrations/0011_latest_password_reset_token.sql?raw";
 import messageActivityIndexMigration from "../../../migrations/0012_message_activity_index.sql?raw";
+import messageChangesMigration from "../../../migrations/0013_message_changes.sql?raw";
 import resetSql from "../../../scripts/hqbase/reset-d1.sql?raw";
 import { buildSeedSql } from "../../../scripts/local-seed-fixture.mjs";
 import { migrationStatements } from "./migration-statements";
@@ -31,7 +32,8 @@ const migrations = [
   loginEmailDomainMigration,
   deviceAuthorizationMigration,
   latestPasswordResetTokenMigration,
-  messageActivityIndexMigration
+  messageActivityIndexMigration,
+  messageChangesMigration
 ];
 
 describe("local database reset", () => {
@@ -82,6 +84,18 @@ describe("local database reset", () => {
       "messages_activity_idx",
       "messages_folder_activity_idx",
       "messages_mailbox_activity_idx"
+    ]);
+
+    const changeJournal = await env.DB.prepare(
+      `SELECT type, name FROM sqlite_master
+       WHERE name = 'message_changes' OR name LIKE 'message_changes_after_%'
+       ORDER BY type, name`
+    ).all<{ type: string; name: string }>();
+    expect(changeJournal.results).toEqual([
+      { type: "table", name: "message_changes" },
+      { type: "trigger", name: "message_changes_after_delete" },
+      { type: "trigger", name: "message_changes_after_insert" },
+      { type: "trigger", name: "message_changes_after_update" }
     ]);
   });
 });

--- a/test/integration/worker/mail-api.test.ts
+++ b/test/integration/worker/mail-api.test.ts
@@ -237,6 +237,10 @@ describe("HQBase Mail API v1", () => {
     );
     expect(instructions).toContain("The person must open it themselves in a browser they control");
     expect(instructions).toContain("Sending and replying are not idempotent");
+    expect(instructions).toContain(
+      "get a checkpoint from `GET https://hqbase.test/api/v1/changes`"
+    );
+    expect(instructions).toContain("List mailboxes before each change cycle");
     expect(instructions).toContain("`application_type` set to `native`");
     expect(instructions).toContain("RFC 8252");
     expect(instructions).toContain("app-claimed HTTPS, loopback HTTP, and private-use schemes");

--- a/test/integration/worker/mail-changes.test.ts
+++ b/test/integration/worker/mail-changes.test.ts
@@ -1,0 +1,336 @@
+import { env, SELF } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { createAuth } from "../../../worker/auth/auth";
+import { encodeChangeCursor } from "../../../worker/features/messages/change-cursor";
+import { applyCurrentMigrations } from "./current-migrations";
+import { tokenRow } from "./mail-api-token-fixture";
+
+const origin = "https://hqbase.test";
+const apiResource = `${origin}/api/v1`;
+const readToken = "hqb_access_changes-read-token";
+const writeToken = "hqb_access_changes-write-token";
+let userId = "";
+
+describe("HQBase Mail API message changes", () => {
+  beforeAll(async () => {
+    await applyCurrentMigrations();
+    const auth = createAuth(env, new Request(`${origin}/api/auth/sign-up/email`));
+    const signUp = await auth.handler(
+      new Request(`${origin}/api/auth/sign-up/email`, {
+        body: JSON.stringify({
+          email: "changes-member@login.example",
+          name: "Changes Member",
+          password: "mail-changes-test-password",
+          rememberMe: false
+        }),
+        headers: { "content-type": "application/json", origin },
+        method: "POST"
+      })
+    );
+    expect(signUp.status, await signUp.clone().text()).toBe(200);
+
+    const user = await env.DB.prepare(
+      `SELECT u.id, s.id AS sessionId
+       FROM "user" u JOIN "session" s ON s.userId = u.id
+       WHERE u.email = ? ORDER BY s.createdAt DESC LIMIT 1`
+    )
+      .bind("changes-member@login.example")
+      .first<{ id: string; sessionId: string }>();
+    if (!user) throw new Error("Changes API test user was not created.");
+    userId = user.id;
+
+    const stamp = "2026-08-17T00:00:00.000Z";
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const tokenRows = await Promise.all([
+      tokenRow(
+        env.DB,
+        "tok_changes_read",
+        readToken,
+        "client_changes_api",
+        user.sessionId,
+        user.id,
+        future,
+        ["mail:read"],
+        apiResource
+      ),
+      tokenRow(
+        env.DB,
+        "tok_changes_write",
+        writeToken,
+        "client_changes_api",
+        user.sessionId,
+        user.id,
+        future,
+        ["mail:write"],
+        apiResource
+      )
+    ]);
+    await env.DB.batch([
+      mailboxRow("mbx_changes", "changes@example.com", stamp),
+      mailboxRow("mbx_changes_bulk", "bulk-changes@example.com", stamp),
+      mailboxRow("mbx_changes_secret", "secret-changes@example.com", stamp),
+      grantRow("mbx_changes", stamp),
+      grantRow("mbx_changes_bulk", stamp),
+      env.DB.prepare(
+        `INSERT INTO oauthClient
+         (id, clientId, disabled, redirectUris, public, requirePKCE, createdAt, updatedAt)
+         VALUES ('client_row_changes', 'client_changes_api', 0, ?, 1, 1, ?, ?)`
+      ).bind(JSON.stringify(["https://client.example/changes"]), stamp, stamp),
+      env.DB.prepare(
+        `INSERT INTO oauthConsent
+         (id, clientId, userId, scopes, resources, createdAt, updatedAt)
+         VALUES ('consent_changes', 'client_changes_api', ?, ?, ?, ?, ?)`
+      ).bind(
+        user.id,
+        JSON.stringify(["mail:read", "mail:write"]),
+        JSON.stringify([apiResource]),
+        stamp,
+        stamp
+      ),
+      ...tokenRows,
+      threadRow("thr_changes", stamp),
+      threadRow("thr_changes_bulk", stamp),
+      threadRow("thr_changes_secret", stamp),
+      messageRow("msg_changes_initial", "thr_changes", "mbx_changes", stamp)
+    ]);
+  });
+
+  it("starts with a checkpoint and does not replay historical journal rows", async () => {
+    const first = await apiFetch("/api/v1/changes", readToken);
+    expect(first.status, await first.clone().text()).toBe(200);
+    const checkpoint = await changePage(first);
+    expect(checkpoint).toMatchObject({ changes: [], hasMore: false });
+
+    const next = await apiFetch(`/api/v1/changes?cursor=${checkpoint.nextCursor}`, readToken);
+    await expect(next.json()).resolves.toMatchObject({ changes: [], hasMore: false });
+  });
+
+  it("returns every rapid update and the current public message summary", async () => {
+    const cursor = await checkpoint();
+    const stamp = "2026-08-17T00:01:00.000Z";
+    await messageRow("msg_changes_rapid", "thr_changes", "mbx_changes", stamp).run();
+    await env.DB.prepare(
+      `UPDATE messages SET read_at = ?, starred_at = ?, updated_at = ?
+       WHERE id = 'msg_changes_rapid'`
+    )
+      .bind(stamp, stamp, stamp)
+      .run();
+    await env.DB.prepare(
+      `UPDATE messages SET folder = 'archived', archived_at = ?, updated_at = ?
+       WHERE id = 'msg_changes_rapid'`
+    )
+      .bind(stamp, stamp)
+      .run();
+
+    const response = await apiFetch(`/api/v1/changes?cursor=${cursor}`, readToken);
+    const page = await changePage(response);
+    expect(page.hasMore).toBe(false);
+    expect(page.changes).toHaveLength(3);
+    for (const change of page.changes) {
+      expect(change).toMatchObject({
+        type: "upsert",
+        message: {
+          id: "msg_changes_rapid",
+          mailboxId: "mbx_changes",
+          folder: "archived",
+          readAt: stamp,
+          starredAt: stamp
+        }
+      });
+      expect(change).not.toHaveProperty("message.raw_r2_key");
+      expect(change).not.toHaveProperty("message.html_r2_key");
+      expect(change).not.toHaveProperty("message.text_body");
+    }
+  });
+
+  it("bounds a bulk cycle at its high-water sequence", async () => {
+    const stamp = "2026-08-17T00:02:00.000Z";
+    await env.DB.batch(
+      Array.from({ length: 105 }, (_, index) =>
+        messageRow(
+          `msg_changes_bulk_${String(index).padStart(3, "0")}`,
+          "thr_changes_bulk",
+          "mbx_changes_bulk",
+          stamp
+        )
+      )
+    );
+    const cursor = await checkpoint();
+    await env.DB.prepare(
+      `UPDATE messages SET read_at = ?, updated_at = ? WHERE mailbox_id = 'mbx_changes_bulk'`
+    )
+      .bind(stamp, stamp)
+      .run();
+
+    const first = await changePage(
+      await apiFetch(`/api/v1/changes?cursor=${cursor}&limit=100`, readToken)
+    );
+    expect(first.changes).toHaveLength(100);
+    expect(first.hasMore).toBe(true);
+
+    const laterStamp = "2026-08-17T00:02:01.000Z";
+    await env.DB.prepare(
+      `UPDATE messages SET starred_at = ?, updated_at = ?
+       WHERE id = 'msg_changes_bulk_000'`
+    )
+      .bind(laterStamp, laterStamp)
+      .run();
+
+    const second = await changePage(
+      await apiFetch(`/api/v1/changes?cursor=${first.nextCursor}&limit=100`, readToken)
+    );
+    expect(second.changes).toHaveLength(5);
+    expect(second.hasMore).toBe(false);
+    const cycleIds = [...first.changes, ...second.changes].map(upsertId);
+    expect(new Set(cycleIds).size).toBe(105);
+
+    const nextCycle = await changePage(
+      await apiFetch(`/api/v1/changes?cursor=${second.nextCursor}`, readToken)
+    );
+    expect(nextCycle.changes.map(upsertId)).toEqual(["msg_changes_bulk_000"]);
+  });
+
+  it("returns a durable tombstone when retention removes a message", async () => {
+    const cursor = await checkpoint();
+    const stamp = "2026-08-17T00:03:00.000Z";
+    await messageRow("msg_changes_delete", "thr_changes", "mbx_changes", stamp).run();
+    await env.DB.prepare("DELETE FROM messages WHERE id = 'msg_changes_delete'").run();
+
+    const page = await changePage(
+      await apiFetch(`/api/v1/changes?cursor=${cursor}&limit=2`, readToken)
+    );
+    expect(page).toMatchObject({ hasMore: false });
+    expect(page.changes).toEqual([
+      { type: "delete", messageId: "msg_changes_delete", mailboxId: "mbx_changes" }
+    ]);
+  });
+
+  it("applies live mailbox access and requires bootstrap after a new grant", async () => {
+    const cursor = await checkpoint();
+    const stamp = "2026-08-17T00:04:00.000Z";
+    await env.DB.batch([
+      messageRow("msg_changes_revoked", "thr_changes", "mbx_changes", stamp),
+      messageRow("msg_changes_hidden", "thr_changes_secret", "mbx_changes_secret", stamp)
+    ]);
+    await env.DB.prepare(
+      "DELETE FROM mailbox_grants WHERE mailbox_id = 'mbx_changes' AND user_id = ?"
+    )
+      .bind(userId)
+      .run();
+
+    const hidden = await changePage(await apiFetch(`/api/v1/changes?cursor=${cursor}`, readToken));
+    expect(hidden.changes).toEqual([]);
+    await grantRow("mbx_changes", stamp).run();
+
+    const afterGrant = await changePage(
+      await apiFetch(`/api/v1/changes?cursor=${hidden.nextCursor}`, readToken)
+    );
+    expect(afterGrant.changes).toEqual([]);
+    await messageRow("msg_changes_after_grant", "thr_changes", "mbx_changes", stamp).run();
+    const newChange = await changePage(
+      await apiFetch(`/api/v1/changes?cursor=${afterGrant.nextCursor}`, readToken)
+    );
+    expect(newChange.changes.map(upsertId)).toEqual(["msg_changes_after_grant"]);
+  });
+
+  it("validates scope, filters, limits, and opaque cursor bounds", async () => {
+    const noRead = await apiFetch("/api/v1/changes", writeToken);
+    expect(noRead.status).toBe(403);
+    expect(noRead.headers.get("www-authenticate")).toContain('scope="mail:read"');
+
+    for (const path of [
+      "/api/v1/changes?limit=0",
+      "/api/v1/changes?limit=101",
+      "/api/v1/changes?limit=1.5"
+    ]) {
+      const response = await apiFetch(path, readToken);
+      expect(response.status, path).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: { code: "INVALID_LIMIT" } });
+    }
+
+    const filtered = await apiFetch("/api/v1/changes?folder=inbox", readToken);
+    expect(filtered.status).toBe(400);
+    await expect(filtered.json()).resolves.toMatchObject({
+      error: { code: "INVALID_CHANGE_FILTER" }
+    });
+
+    const future = encodeChangeCursor({ after: "9223372036854775807", highWater: null });
+    for (const value of ["not-a-cursor", future]) {
+      const response = await apiFetch(
+        `/api/v1/changes?cursor=${encodeURIComponent(value)}`,
+        readToken
+      );
+      expect(response.status, value).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: { code: "INVALID_CHANGE_CURSOR" }
+      });
+    }
+  });
+});
+
+type ChangePage = {
+  changes: Array<{
+    type: "upsert" | "delete";
+    message?: { id: string };
+    messageId?: string;
+    mailboxId?: string;
+  }>;
+  nextCursor: string;
+  hasMore: boolean;
+};
+
+async function checkpoint(): Promise<string> {
+  return (await changePage(await apiFetch("/api/v1/changes", readToken))).nextCursor;
+}
+
+async function changePage(response: Response): Promise<ChangePage> {
+  expect(response.status, await response.clone().text()).toBe(200);
+  return response.json<ChangePage>();
+}
+
+function upsertId(change: ChangePage["changes"][number]): string {
+  if (change.type !== "upsert" || !change.message) throw new Error("Expected an upsert change.");
+  return change.message.id;
+}
+
+function mailboxRow(id: string, address: string, stamp: string): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO mailboxes (id, address, display_name, is_active, created_at, updated_at)
+     VALUES (?, ?, ?, 1, ?, ?)`
+  ).bind(id, address, id, stamp, stamp);
+}
+
+function grantRow(mailboxId: string, stamp: string): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO mailbox_grants (mailbox_id, user_id, access_level, created_by, created_at, updated_at)
+     VALUES (?, ?, 'agent', ?, ?, ?)`
+  ).bind(mailboxId, userId, userId, stamp, stamp);
+}
+
+function threadRow(id: string, stamp: string): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO threads (id, subject_normalized, last_message_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`
+  ).bind(id, id, stamp, stamp, stamp);
+}
+
+function messageRow(
+  id: string,
+  threadId: string,
+  mailboxId: string,
+  stamp: string
+): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO messages
+     (id, thread_id, mailbox_id, direction, folder, from_address, to_json, cc_json, bcc_json,
+      subject, snippet, text_body, message_id, dedupe_key, in_reply_to, references_json,
+      received_at, sent_at, read_at, has_attachments, created_at, updated_at)
+     VALUES (?, ?, ?, 'inbound', 'inbox', 'sender@example.net', '[]', '[]', '[]', ?, '', '',
+             NULL, ?, NULL, '[]', ?, NULL, NULL, 0, ?, ?)`
+  ).bind(id, threadId, mailboxId, id, `dedupe-${id}`, stamp, stamp, stamp);
+}
+
+function apiFetch(path: string, token: string): Promise<Response> {
+  return SELF.fetch(`${origin}${path}`, { headers: { authorization: `Bearer ${token}` } });
+}

--- a/test/integration/worker/message-changes-migration.test.ts
+++ b/test/integration/worker/message-changes-migration.test.ts
@@ -1,0 +1,122 @@
+import { env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import initialMigration from "../../../migrations/0001_initial.sql?raw";
+import workspaceMigration from "../../../migrations/0002_workspace.sql?raw";
+import oauthResourcesMigration from "../../../migrations/0003_oauth_resources.sql?raw";
+import conversationMigration from "../../../migrations/0004_conversations.sql?raw";
+import threadRebuildMigration from "../../../migrations/0005_rebuild_threads.sql?raw";
+import pushMigration from "../../../migrations/0006_push_notifications.sql?raw";
+import userMailPreferencesMigration from "../../../migrations/0007_user_mail_preferences.sql?raw";
+import userOnboardingMigration from "../../../migrations/0008_user_onboarding.sql?raw";
+import loginEmailDomainMigration from "../../../migrations/0009_login_email_domain_isolation.sql?raw";
+import deviceAuthorizationMigration from "../../../migrations/0010_oauth_device_authorization.sql?raw";
+import latestPasswordResetTokenMigration from "../../../migrations/0011_latest_password_reset_token.sql?raw";
+import messageActivityIndexMigration from "../../../migrations/0012_message_activity_index.sql?raw";
+import messageChangesMigration from "../../../migrations/0013_message_changes.sql?raw";
+import { migrationStatements } from "./migration-statements";
+
+const priorMigrations = [
+  initialMigration,
+  workspaceMigration,
+  oauthResourcesMigration,
+  conversationMigration,
+  threadRebuildMigration,
+  pushMigration,
+  userMailPreferencesMigration,
+  userOnboardingMigration,
+  loginEmailDomainMigration,
+  deviceAuthorizationMigration,
+  latestPasswordResetTokenMigration,
+  messageActivityIndexMigration
+];
+
+describe("message changes migration", () => {
+  beforeAll(async () => {
+    for (const migration of priorMigrations) await applyMigration(migration);
+    const stamp = "2026-08-17T00:00:00.000Z";
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO mailboxes (id, address, display_name, is_active, created_at, updated_at)
+         VALUES ('mbx_changes_migration', 'changes@example.com', 'Changes', 1, ?, ?)`
+      ).bind(stamp, stamp),
+      env.DB.prepare(
+        `INSERT INTO threads (id, subject_normalized, last_message_at, created_at, updated_at)
+         VALUES ('thr_changes_migration', 'changes', ?, ?, ?)`
+      ).bind(stamp, stamp, stamp),
+      messageRow("msg_before_migration", stamp)
+    ]);
+    await applyMigration(messageChangesMigration);
+  });
+
+  it("upgrades without creating false history for existing messages", async () => {
+    const count = await env.DB.prepare("SELECT COUNT(*) AS count FROM message_changes").first<{
+      count: number;
+    }>();
+    expect(count?.count).toBe(0);
+  });
+
+  it("journals inserts, updates, and durable deletion tombstones in sequence order", async () => {
+    const stamp = "2026-08-17T00:00:01.000Z";
+    await messageRow("msg_after_migration", stamp).run();
+    await env.DB.prepare(
+      "UPDATE messages SET read_at = ?, updated_at = ? WHERE id = 'msg_after_migration'"
+    )
+      .bind(stamp, stamp)
+      .run();
+    await env.DB.prepare("DELETE FROM messages WHERE id = 'msg_after_migration'").run();
+
+    const rows = await env.DB.prepare(
+      `SELECT sequence, message_id, mailbox_id, kind
+       FROM message_changes ORDER BY sequence`
+    ).all<{ sequence: number; message_id: string; mailbox_id: string; kind: string }>();
+    expect(rows.results).toEqual([
+      {
+        sequence: 1,
+        message_id: "msg_after_migration",
+        mailbox_id: "mbx_changes_migration",
+        kind: "upsert"
+      },
+      {
+        sequence: 2,
+        message_id: "msg_after_migration",
+        mailbox_id: "mbx_changes_migration",
+        kind: "upsert"
+      },
+      {
+        sequence: 3,
+        message_id: "msg_after_migration",
+        mailbox_id: "mbx_changes_migration",
+        kind: "delete"
+      }
+    ]);
+  });
+
+  it("is safe to re-apply without installing duplicate triggers", async () => {
+    await applyMigration(messageChangesMigration);
+    await messageRow("msg_after_reapply", "2026-08-17T00:00:02.000Z").run();
+
+    const rows = await env.DB.prepare(
+      "SELECT kind FROM message_changes WHERE message_id = 'msg_after_reapply'"
+    ).all<{ kind: string }>();
+    expect(rows.results).toEqual([{ kind: "upsert" }]);
+  });
+});
+
+function messageRow(id: string, stamp: string): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO messages
+     (id, thread_id, mailbox_id, direction, folder, from_address, to_json, cc_json, bcc_json,
+      subject, snippet, text_body, message_id, dedupe_key, in_reply_to, references_json,
+      received_at, sent_at, read_at, has_attachments, created_at, updated_at)
+     VALUES (?, 'thr_changes_migration', 'mbx_changes_migration', 'inbound', 'inbox',
+             'sender@example.net', '[]', '[]', '[]', ?, '', '', NULL, ?, NULL, '[]', ?, NULL,
+             NULL, 0, ?, ?)`
+  ).bind(id, id, `dedupe-${id}`, stamp, stamp, stamp);
+}
+
+async function applyMigration(source: string): Promise<void> {
+  for (const statement of migrationStatements(source)) {
+    await env.DB.prepare(statement).run();
+  }
+}

--- a/test/unit/scripts/mail-api-artifacts.test.mjs
+++ b/test/unit/scripts/mail-api-artifacts.test.mjs
@@ -12,6 +12,14 @@ describe("Mail API public artifacts", () => {
     expect(openApi.paths["/api/v1/messages"].get.security).toContainEqual({
       oauth2: ["mail:read"]
     });
+    expect(openApi.paths["/api/v1/changes"].get.security).toContainEqual({
+      oauth2: ["mail:read"]
+    });
+    expect(openApi.components.schemas.MessageChangePage.required).toEqual([
+      "changes",
+      "nextCursor",
+      "hasMore"
+    ]);
     expect(openApi.paths["/api/v1/messages/{id}/{action}"].post.security).toContainEqual({
       oauth2: ["mail:write"]
     });

--- a/test/unit/worker/features/messages/change-cursor.test.ts
+++ b/test/unit/worker/features/messages/change-cursor.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compareChangeSequences,
+  decodeChangeCursor,
+  encodeChangeCursor
+} from "../../../../../worker/features/messages/change-cursor";
+
+describe("message change cursor", () => {
+  it("round-trips a checkpoint and an active high-water cursor", () => {
+    expect(decodeChangeCursor(encodeChangeCursor({ after: "12", highWater: null }))).toEqual({
+      after: "12",
+      highWater: null
+    });
+    expect(decodeChangeCursor(encodeChangeCursor({ after: "12", highWater: "25" }))).toEqual({
+      after: "12",
+      highWater: "25"
+    });
+  });
+
+  it("compares decimal sequences without number precision loss", () => {
+    expect(compareChangeSequences("9007199254740992", "9007199254740993")).toBe(-1);
+    expect(compareChangeSequences("9007199254740993", "9007199254740993")).toBe(0);
+    expect(compareChangeSequences("9007199254740994", "9007199254740993")).toBe(1);
+  });
+
+  it("rejects malformed, foreign, reversed, and out-of-range cursors", () => {
+    const values = [
+      "not-a-cursor",
+      encode(["m1", "12", null]),
+      encode(["c1", "12", "11"]),
+      encode(["c1", "01", null]),
+      encode(["c1", "9223372036854775808", null])
+    ];
+    for (const value of values) {
+      expect(() => decodeChangeCursor(value)).toThrowError(/Change cursor is invalid/u);
+    }
+  });
+});
+
+function encode(value: unknown): string {
+  return btoa(JSON.stringify(value)).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+}

--- a/worker/features/mail-api/discovery.ts
+++ b/worker/features/mail-api/discovery.ts
@@ -133,15 +133,17 @@ The method index is an orientation aid. Consult ${openApiUrl} for exact paramete
 ## Operating rules
 
 - Use \`Content-Type: application/json\` for JSON requests and \`multipart/form-data\` for draft attachment uploads.
-- Treat message and conversation cursors as opaque strings and return them unchanged. Do not construct or edit a cursor.
+- Treat message, conversation, and change cursors as opaque strings and return them unchanged. Do not construct or edit a cursor.
 - \`GET ${apiBase}/messages\` returns one page. Follow the \`Link: <url>; rel="next"\` response header for the next page. No \`Link\` header means the last page.
+- To start message synchronization, get a checkpoint from \`GET ${apiBase}/changes\` without a cursor, paginate the full message list, then read changes after the checkpoint until \`hasMore\` is false.
+- List mailboxes before each change cycle. Remove cached mail for mailboxes that are no longer readable, and bootstrap each newly readable mailbox.
 - Ignore response fields you do not recognize.
 - Do not log access tokens, refresh tokens, message bodies, or attachments.
 - Do not log device codes or user codes, and do not paste them into unrelated chats or tools.
 - Do not send or reply unless that external action matches the person's request.
 - Sending and replying are not idempotent. Never retry them blindly.
 - Use the returned draft version when updating a draft so newer work is not overwritten.
-- HQBase does not currently expose a changes or delta feed. Refresh by listing messages or conversations again.
+- A \`410 CHANGE_CURSOR_EXPIRED\` response requires a new full message bootstrap.
 
 ## Errors
 

--- a/worker/features/mail-api/routes.ts
+++ b/worker/features/mail-api/routes.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import type { HonoApp } from "../../lib/env";
 import { draftRoutes } from "../drafts/routes";
 import { mailboxReadRoutes } from "../mailboxes/routes";
+import { changeRoutes } from "../messages/change-routes";
 import { conversationRoutes } from "../messages/conversation-routes";
 import { attachmentRoutes, messageRoutes } from "../messages/routes";
 import { sendRoutes } from "../send/routes";
@@ -11,6 +12,7 @@ export const mailApiRoutes = new Hono<HonoApp>();
 
 mailApiRoutes.route("/mailboxes", mailboxReadRoutes);
 mailApiRoutes.route("/messages", messageRoutes);
+mailApiRoutes.route("/changes", changeRoutes);
 mailApiRoutes.route("/conversations", conversationRoutes);
 mailApiRoutes.route("/attachments", attachmentRoutes);
 mailApiRoutes.route("/drafts", draftRoutes);

--- a/worker/features/messages/change-cursor.ts
+++ b/worker/features/messages/change-cursor.ts
@@ -1,0 +1,49 @@
+import { AppError } from "../../lib/errors";
+
+const changeCursorVersion = "c1";
+const maximumSqliteSequence = 9_223_372_036_854_775_807n;
+
+export type ChangeCursor = {
+  after: string;
+  highWater: string | null;
+};
+
+export function encodeChangeCursor(cursor: ChangeCursor): string {
+  return btoa(JSON.stringify([changeCursorVersion, cursor.after, cursor.highWater]))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+export function decodeChangeCursor(value: string): ChangeCursor {
+  try {
+    if (value.length === 0 || value.length > 512) throw new Error("Invalid cursor length.");
+    const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+    const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+    const decoded: unknown = JSON.parse(atob(`${base64}${padding}`));
+    if (
+      !Array.isArray(decoded) ||
+      decoded.length !== 3 ||
+      decoded[0] !== changeCursorVersion ||
+      !isChangeSequence(decoded[1]) ||
+      !(decoded[2] === null || isChangeSequence(decoded[2])) ||
+      (decoded[2] !== null && BigInt(decoded[1]) > BigInt(decoded[2]))
+    ) {
+      throw new Error("Invalid cursor payload.");
+    }
+    return { after: decoded[1], highWater: decoded[2] };
+  } catch {
+    throw new AppError("INVALID_CHANGE_CURSOR", "Change cursor is invalid.", 400);
+  }
+}
+
+export function compareChangeSequences(left: string, right: string): number {
+  const a = BigInt(left);
+  const b = BigInt(right);
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function isChangeSequence(value: unknown): value is string {
+  if (typeof value !== "string" || !/^(?:0|[1-9]\d{0,18})$/u.test(value)) return false;
+  return BigInt(value) <= maximumSqliteSequence;
+}

--- a/worker/features/messages/change-queries.ts
+++ b/worker/features/messages/change-queries.ts
@@ -1,0 +1,120 @@
+import { AppError } from "../../lib/errors";
+
+import {
+  type ChangeCursor,
+  compareChangeSequences,
+  decodeChangeCursor,
+  encodeChangeCursor
+} from "./change-cursor";
+import { mapMessageSummary } from "./queries";
+import type { MessageRow, MessageSummary } from "./types";
+
+export const defaultChangeLimit = 100;
+export const maxChangeLimit = 100;
+
+export type MessageChange =
+  | { type: "upsert"; message: MessageSummary }
+  | { type: "delete"; messageId: string; mailboxId: string };
+
+export type MessageChangePage = {
+  changes: MessageChange[];
+  nextCursor: string;
+  hasMore: boolean;
+};
+
+type JournalRow = {
+  sequence: string;
+  message_id: string;
+  mailbox_id: string;
+  kind: "upsert" | "delete";
+};
+
+const messageSelect = `SELECT messages.*,
+  (SELECT address FROM mailbox_addresses
+   WHERE id = messages.delivered_to_address_id) AS delivered_to_address
+  FROM messages`;
+
+export async function listMessageChanges(
+  db: D1Database,
+  input: { cursor?: string | undefined; limit: number; mailboxIds: string[] }
+): Promise<MessageChangePage> {
+  const currentHighWater = await getCurrentHighWater(db);
+  if (!input.cursor) {
+    return emptyPage({ after: currentHighWater, highWater: null });
+  }
+
+  const cursor = decodeChangeCursor(input.cursor);
+  validateCursorBounds(cursor, currentHighWater);
+  const highWater = cursor.highWater ?? currentHighWater;
+  if (input.mailboxIds.length === 0 || compareChangeSequences(cursor.after, highWater) === 0) {
+    return emptyPage({ after: highWater, highWater: null });
+  }
+
+  const journal = await db
+    .prepare(
+      `SELECT CAST(sequence AS TEXT) AS sequence, message_id, mailbox_id, kind
+       FROM message_changes
+       WHERE sequence > CAST(? AS INTEGER)
+         AND sequence <= CAST(? AS INTEGER)
+         AND mailbox_id IN (${input.mailboxIds.map(() => "?").join(", ")})
+       ORDER BY sequence ASC
+       LIMIT ?`
+    )
+    .bind(cursor.after, highWater, ...input.mailboxIds, input.limit + 1)
+    .all<JournalRow>();
+
+  const pageRows = journal.results.slice(0, input.limit);
+  const hasMore = journal.results.length > input.limit;
+  const messages = await currentMessages(db, pageRows);
+  const changes = pageRows.flatMap<MessageChange>((row) => {
+    if (row.kind === "delete") {
+      return [{ type: "delete", messageId: row.message_id, mailboxId: row.mailbox_id }];
+    }
+    const message = messages.get(row.message_id);
+    return message?.mailbox_id === row.mailbox_id
+      ? [{ type: "upsert", message: mapMessageSummary(message) }]
+      : [];
+  });
+
+  const finalRow = pageRows.at(-1);
+  const nextCursor =
+    hasMore && finalRow
+      ? encodeChangeCursor({ after: finalRow.sequence, highWater })
+      : encodeChangeCursor({ after: highWater, highWater: null });
+  return { changes, nextCursor, hasMore };
+}
+
+async function getCurrentHighWater(db: D1Database): Promise<string> {
+  const row = await db
+    .prepare("SELECT CAST(COALESCE(MAX(sequence), 0) AS TEXT) AS sequence FROM message_changes")
+    .first<{ sequence: string }>();
+  return row?.sequence ?? "0";
+}
+
+async function currentMessages(
+  db: D1Database,
+  rows: JournalRow[]
+): Promise<Map<string, MessageRow>> {
+  const ids = [
+    ...new Set(rows.filter((row) => row.kind === "upsert").map((row) => row.message_id))
+  ];
+  if (ids.length === 0) return new Map();
+  const result = await db
+    .prepare(`${messageSelect} WHERE messages.id IN (${ids.map(() => "?").join(", ")})`)
+    .bind(...ids)
+    .all<MessageRow>();
+  return new Map(result.results.map((row) => [row.id, row]));
+}
+
+function validateCursorBounds(cursor: ChangeCursor, currentHighWater: string): void {
+  if (
+    compareChangeSequences(cursor.after, currentHighWater) > 0 ||
+    (cursor.highWater !== null && compareChangeSequences(cursor.highWater, currentHighWater) > 0)
+  ) {
+    throw new AppError("INVALID_CHANGE_CURSOR", "Change cursor is invalid.", 400);
+  }
+}
+
+function emptyPage(cursor: ChangeCursor): MessageChangePage {
+  return { changes: [], nextCursor: encodeChangeCursor(cursor), hasMore: false };
+}

--- a/worker/features/messages/change-routes.ts
+++ b/worker/features/messages/change-routes.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono";
+
+import { requireMailApiContext } from "../../auth/mail-api";
+import { accessibleMailboxIds } from "../../auth/mailbox-access";
+import type { HonoApp } from "../../lib/env";
+import { AppError } from "../../lib/errors";
+
+import { defaultChangeLimit, listMessageChanges, maxChangeLimit } from "./change-queries";
+
+export const changeRoutes = new Hono<HonoApp>();
+
+changeRoutes.get("/", async (c) => {
+  const auth = await requireMailApiContext(c.env, c.req.raw, "mail:read");
+  for (const name of ["mailboxId", "folder", "search"]) {
+    if (c.req.query(name) !== undefined) {
+      throw new AppError(
+        "INVALID_CHANGE_FILTER",
+        "The changes feed does not accept mailbox, folder, or search filters.",
+        400
+      );
+    }
+  }
+  const mailboxIds = await accessibleMailboxIds(c.env.DB, auth.user.id, auth.user.role, "read");
+  return c.json(
+    await listMessageChanges(c.env.DB, {
+      cursor: c.req.query("cursor"),
+      limit: parseChangeLimit(c.req.query("limit")),
+      mailboxIds
+    })
+  );
+});
+
+function parseChangeLimit(value: string | undefined): number {
+  if (value === undefined) return defaultChangeLimit;
+  const limit = Number(value);
+  if (!/^\d+$/u.test(value) || !Number.isInteger(limit) || limit < 1 || limit > maxChangeLimit) {
+    throw new AppError(
+      "INVALID_LIMIT",
+      `Limit must be an integer from 1 to ${maxChangeLimit}.`,
+      400
+    );
+  }
+  return limit;
+}

--- a/worker/features/messages/conversation-queries.ts
+++ b/worker/features/messages/conversation-queries.ts
@@ -204,10 +204,10 @@ export async function updateConversationAction(
   }
 
   const result = await db
-    .prepare(`UPDATE messages SET ${set} WHERE ${where.join(" AND ")}`)
+    .prepare(`UPDATE messages SET ${set} WHERE ${where.join(" AND ")} RETURNING id`)
     .bind(...bindings)
-    .run();
-  return { affected: result.meta.changes, threadId: selected.thread_id };
+    .all<{ id: string }>();
+  return { affected: result.results.length, threadId: selected.thread_id };
 }
 
 function mapConversationSummary(row: ConversationRow): ConversationSummary {


### PR DESCRIPTION
## Summary

- Add the net-new `GET /api/v1/changes` endpoint with `mail:read` authorization.
- Record message upserts and durable deletion tombstones in an additive D1 journal.
- Use opaque, 64-bit-safe cursors and bounded high-water pagination.
- Update OpenAPI, Postman, Agent Skill discovery, reset support, and staging coverage.
- Preserve existing route payloads and conversation-action `affected` counts.

## Contract

- Specification: HQBase/hqbase-site#11
- No existing endpoint or web UI behavior changes.

## Verification

- [x] `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-mail-changes-check-3.log pnpm check`
- [x] `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-mail-changes-dry-run.log pnpm deploy:dry-run`
- [x] Fresh-install, upgrade, cursor, authorization, pagination, tombstone, and access-change tests

Closes #11.
