### PR TITLE
Add resumable operator provisioning

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -53,6 +53,8 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ runner.arch }}-playwright-
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps chromium
+      - name: Verify resumable operator provisioning and cleanup
+        run: node scripts/test-cli-recovery.mjs "recovery-${{ github.run_id }}"
       - name: Create disposable customer resources
         run: >-
           pnpm hqbase install

--- a/scripts/hqbase/command.mjs
+++ b/scripts/hqbase/command.mjs
@@ -35,7 +35,7 @@ export function run(command, args = [], options = {}) {
     throw new Error(`Command failed (${result.status ?? "no exit code"}): ${label}${detail}`);
   }
 
-  return `${stdout}${stderr}`;
+  return options.stdoutOnly ? stdout : `${stdout}${stderr}`;
 }
 
 export function parseD1DatabaseId(output) {

--- a/scripts/hqbase/config.mjs
+++ b/scripts/hqbase/config.mjs
@@ -19,6 +19,7 @@ export function createWranglerConfig(manifest) {
   const cloudflareOAuth = manifest.cloudflareOAuth ?? { mode: "official" };
   const config = {
     $schema: `${rootFromDeployment}/node_modules/wrangler/config-schema.json`,
+    ...(manifest.accountId ? { account_id: manifest.accountId } : {}),
     name: manifest.worker.name,
     main: `${rootFromDeployment}/worker/index.ts`,
     // Matches the repository Wrangler configuration: a mail workspace should be
@@ -65,11 +66,11 @@ export function createWranglerConfig(manifest) {
       }
     ],
     queues: {
-      producers: [{ binding: "HQBASE_JOBS", queue: manifest.queue.name }],
+      producers: [{ binding: "HQBASE_JOBS", queue: manifest.queue.primary.name }],
       consumers: [
         {
-          queue: manifest.queue.name,
-          dead_letter_queue: manifest.queue.deadLetterName,
+          queue: manifest.queue.primary.name,
+          dead_letter_queue: manifest.queue.deadLetter.name,
           max_batch_size: 10,
           max_batch_timeout: 5,
           max_retries: 3

--- a/scripts/hqbase/destroy.mjs
+++ b/scripts/hqbase/destroy.mjs
@@ -2,8 +2,10 @@ import fs from "node:fs";
 
 import { optionalBoolean, requireString } from "./args.mjs";
 import { run } from "./command.mjs";
-import { deploymentDir, loadManifest } from "./manifest.mjs";
+import { assertCurrentManifest, assertUnambiguousManifest } from "./lifecycle-manifest.mjs";
+import { deploymentDir, loadManifest, writeManifest } from "./manifest.mjs";
 import { reset } from "./reset.mjs";
+import { prepareManifest, resolveCloudflareAccount, wrangler } from "./resources.mjs";
 
 const scopes = new Set(["worker", "data", "storage", "state", "domain", "all"]);
 
@@ -29,76 +31,58 @@ export function destroyPlan(scope, manifest) {
 
   return {
     ...targets,
-    data: targets.data && !manifest.d1.reused,
-    storage: targets.storage && !manifest.r2.reused,
+    worker: targets.worker && manifest.worker.deployed,
+    data: targets.data && manifest.d1.ownership === "created",
+    storage: targets.storage && manifest.r2.ownership === "created",
+    queueResources: {
+      primary: targets.queues && manifest.queue.primary.ownership === "created",
+      deadLetter: targets.queues && manifest.queue.deadLetter.ownership === "created"
+    },
     preserved: {
-      data: targets.data && manifest.d1.reused,
-      storage: targets.storage && manifest.r2.reused
+      data: targets.data && manifest.d1.ownership === "reused",
+      storage: targets.storage && manifest.r2.ownership === "reused",
+      primaryQueue: targets.queues && manifest.queue.primary.ownership === "reused",
+      deadLetterQueue: targets.queues && manifest.queue.deadLetter.ownership === "reused"
     }
   };
 }
 
-export function destroy(flags) {
+export function destroy(flags, options = {}) {
   const name = requireString(flags, "name");
   const scope = requireString(flags, "scope");
   const dryRun = optionalBoolean(flags, "dry-run");
   const yes = optionalBoolean(flags, "yes");
+  const runCommand = options.runCommand ?? run;
+  const checkpoint = options.checkpoint ?? writeManifest;
 
   if (!yes && !dryRun) {
     throw new Error("Refusing to destroy Cloudflare resources without --yes.");
   }
 
-  const manifest = loadManifest(name);
-  const targets = destroyPlan(scope, manifest);
+  let manifest = loadManifest(name);
+  if (dryRun) {
+    assertCurrentManifest(manifest);
+    assertUnambiguousManifest(manifest);
+  } else {
+    const accountId = resolveCloudflareAccount(
+      manifest.version === 3 ? manifest.accountId : undefined,
+      {
+        environment: options.environment ?? process.env,
+        runCommand
+      }
+    );
+    manifest = prepareManifest(manifest, accountId, { checkpoint, runCommand });
+  }
+
+  let targets = destroyPlan(scope, manifest);
   if (targets.domain) {
     reset({ name, scope: "domain", "dry-run": dryRun });
+    if (!dryRun) {
+      manifest = loadManifest(name);
+      targets = destroyPlan(scope, manifest);
+    }
   }
-  if (targets.queues && manifest.queue) {
-    run(
-      "pnpm",
-      [
-        "exec",
-        "wrangler",
-        "queues",
-        "consumer",
-        "worker",
-        "remove",
-        manifest.queue.name,
-        manifest.worker.name
-      ],
-      { dryRun, allowFailure: true }
-    );
-  }
-  if (targets.worker) {
-    run("pnpm", ["exec", "wrangler", "delete", manifest.worker.name, "--force"], {
-      dryRun,
-      allowFailure: true
-    });
-  }
-  if (targets.data) {
-    run("pnpm", ["exec", "wrangler", "d1", "delete", manifest.d1.name, "--skip-confirmation"], {
-      dryRun
-    });
-  }
-  if (targets.storage) {
-    run("pnpm", ["exec", "wrangler", "r2", "bucket", "delete", manifest.r2.bucket], {
-      dryRun
-    });
-  }
-  if (targets.preserved.data) {
-    console.log(`Preserved reused D1 database "${manifest.d1.name}".`);
-  }
-  if (targets.preserved.storage) {
-    console.log(`Preserved reused R2 bucket "${manifest.r2.bucket}".`);
-  }
-  if (targets.queues && manifest.queue) {
-    run("pnpm", ["exec", "wrangler", "queues", "delete", manifest.queue.name], {
-      dryRun
-    });
-    run("pnpm", ["exec", "wrangler", "queues", "delete", manifest.queue.deadLetterName], {
-      dryRun
-    });
-  }
+  destroyResources(scope, manifest, { checkpoint, dryRun, runCommand });
 
   if (scope === "all" && !dryRun) {
     fs.rmSync(deploymentDir(name), { recursive: true, force: true });
@@ -108,43 +92,88 @@ export function destroy(flags) {
   }
 }
 
+export function destroyResources(scope, manifest, options = {}) {
+  const checkpoint = options.checkpoint ?? writeManifest;
+  const dryRun = options.dryRun ?? false;
+  const runCommand = options.runCommand ?? run;
+  const targets = destroyPlan(scope, manifest);
+
+  if (targets.worker) {
+    wrangler(manifest, ["delete", manifest.worker.name, "--force"], {
+      dryRun,
+      quiet: false,
+      runCommand
+    });
+    manifest.worker.deployed = false;
+    checkpoint(manifest, { dryRun });
+  }
+
+  if (targets.queueResources.primary) {
+    wrangler(
+      manifest,
+      ["queues", "consumer", "worker", "remove", manifest.queue.primary.name, manifest.worker.name],
+      { allowFailure: true, dryRun, quiet: false, runCommand }
+    );
+  }
+  for (const [selected, queue] of [
+    [targets.queueResources.primary, manifest.queue.primary],
+    [targets.queueResources.deadLetter, manifest.queue.deadLetter]
+  ]) {
+    if (!selected) {
+      continue;
+    }
+    wrangler(manifest, ["queues", "delete", queue.name], {
+      dryRun,
+      quiet: false,
+      runCommand
+    });
+    queue.ownership = "removed";
+    checkpoint(manifest, { dryRun });
+  }
+
+  if (targets.storage) {
+    wrangler(manifest, ["r2", "bucket", "delete", manifest.r2.bucket], {
+      dryRun,
+      quiet: false,
+      runCommand
+    });
+    manifest.r2.ownership = "removed";
+    checkpoint(manifest, { dryRun });
+  }
+  if (targets.data) {
+    wrangler(manifest, ["d1", "delete", manifest.d1.id, "--skip-confirmation"], {
+      dryRun,
+      quiet: false,
+      runCommand
+    });
+    manifest.d1.ownership = "removed";
+    checkpoint(manifest, { dryRun });
+  }
+  if (targets.preserved.data) {
+    console.log(`Preserved reused D1 database "${manifest.d1.name}".`);
+  }
+  if (targets.preserved.storage) {
+    console.log(`Preserved reused R2 bucket "${manifest.r2.bucket}".`);
+  }
+  if (targets.preserved.primaryQueue) {
+    console.log(`Preserved reused queue "${manifest.queue.primary.name}".`);
+  }
+  if (targets.preserved.deadLetterQueue) {
+    console.log(`Preserved reused queue "${manifest.queue.deadLetter.name}".`);
+  }
+
+  return targets;
+}
+
 function assertDestroyManifest(manifest, targets) {
-  if (manifest?.version !== 1 && manifest?.version !== 2) {
-    throw new Error(
-      `Refusing to destroy: manifest field "version" must be a supported value. Migrate or repair the manifest from verified deployment records before retrying.`
-    );
-  }
-
-  assertOwnershipFlag(manifest, "d1");
-  assertOwnershipFlag(manifest, "r2");
-  assertRecordedName(manifest, "name");
-  assertRecordedName(manifest, "d1.name");
-  assertRecordedName(manifest, "r2.bucket");
-  if (targets.worker || targets.queues) {
-    assertRecordedName(manifest, "worker.name");
-  }
-  if (targets.queues) {
-    assertRecordedName(manifest, "queue.name");
-    assertRecordedName(manifest, "queue.deadLetterName");
-  }
+  assertCurrentManifest(manifest);
+  assertUnambiguousManifest(manifest);
   if (targets.domain && manifest.email !== null) {
-    assertRecordedName(manifest, "email.domain");
-  }
-}
-
-function assertOwnershipFlag(manifest, resource) {
-  if (typeof manifest?.[resource]?.reused !== "boolean") {
-    throw new Error(
-      `Refusing to destroy: manifest field "${resource}.reused" must be an explicit boolean. Migrate or repair the manifest from verified deployment records before retrying.`
-    );
-  }
-}
-
-function assertRecordedName(manifest, path) {
-  const value = path.split(".").reduce((current, key) => current?.[key], manifest);
-  if (typeof value !== "string" || value.trim() === "") {
-    throw new Error(
-      `Refusing to destroy: manifest field "${path}" must be a non-empty string. Migrate or repair the manifest from verified deployment records before retrying.`
-    );
+    const domain = manifest.email?.domain;
+    if (typeof domain !== "string" || domain.trim() === "") {
+      throw new Error(
+        'Refusing to destroy: manifest field "email.domain" must be a non-empty string.'
+      );
+    }
   }
 }

--- a/scripts/hqbase/doctor.mjs
+++ b/scripts/hqbase/doctor.mjs
@@ -5,41 +5,50 @@ import { configPath, loadManifest } from "./manifest.mjs";
 export function doctor(flags) {
   const name = requireString(flags, "name");
   const manifest = loadManifest(name);
+  const options = manifest.accountId ? { env: { CLOUDFLARE_ACCOUNT_ID: manifest.accountId } } : {};
 
-  run("pnpm", ["exec", "wrangler", "deploy", "--dry-run", "--config", configPath(name)]);
-  run("pnpm", ["exec", "wrangler", "d1", "info", manifest.d1.name, "--config", configPath(name)]);
-  run("pnpm", [
-    "exec",
-    "wrangler",
-    "d1",
-    "execute",
-    manifest.d1.name,
-    "--remote",
-    "--command",
-    "SELECT value FROM hqbase_schema_state WHERE key = 'product'; SELECT product, installed_version, installed_schema_version FROM release_state WHERE singleton = 1;",
-    "--config",
-    configPath(name)
-  ]);
-  run("pnpm", ["exec", "wrangler", "r2", "bucket", "info", manifest.r2.bucket, "--json"]);
+  run("pnpm", ["exec", "wrangler", "deploy", "--dry-run", "--config", configPath(name)], options);
+  run(
+    "pnpm",
+    ["exec", "wrangler", "d1", "info", manifest.d1.name, "--config", configPath(name)],
+    options
+  );
+  run(
+    "pnpm",
+    [
+      "exec",
+      "wrangler",
+      "d1",
+      "execute",
+      manifest.d1.name,
+      "--remote",
+      "--command",
+      "SELECT value FROM hqbase_schema_state WHERE key = 'product'; SELECT product, installed_version, installed_schema_version FROM release_state WHERE singleton = 1;",
+      "--config",
+      configPath(name)
+    ],
+    options
+  );
+  run("pnpm", ["exec", "wrangler", "r2", "bucket", "info", manifest.r2.bucket, "--json"], options);
   if (manifest.queue) {
-    run("pnpm", ["exec", "wrangler", "queues", "info", manifest.queue.name]);
-    run("pnpm", ["exec", "wrangler", "queues", "info", manifest.queue.deadLetterName]);
+    const primary = manifest.queue.primary?.name ?? manifest.queue.name;
+    const deadLetter = manifest.queue.deadLetter?.name ?? manifest.queue.deadLetterName;
+    run("pnpm", ["exec", "wrangler", "queues", "info", primary], options);
+    run("pnpm", ["exec", "wrangler", "queues", "info", deadLetter], options);
   }
-  run("pnpm", [
-    "exec",
-    "wrangler",
-    "deployments",
-    "status",
-    "--name",
-    manifest.worker.name,
-    "--json"
-  ]);
+  run(
+    "pnpm",
+    ["exec", "wrangler", "deployments", "status", "--name", manifest.worker.name, "--json"],
+    options
+  );
 
   if (manifest.email?.domain) {
     run("pnpm", ["exec", "wrangler", "email", "routing", "settings", manifest.email.domain], {
+      ...options,
       allowFailure: true
     });
     run("pnpm", ["exec", "wrangler", "email", "sending", "settings", manifest.email.domain], {
+      ...options,
       allowFailure: true
     });
   }

--- a/scripts/hqbase/install.mjs
+++ b/scripts/hqbase/install.mjs
@@ -1,6 +1,7 @@
 import { optionalBoolean, optionalString, requireString } from "./args.mjs";
 import { run } from "./command.mjs";
 import { writeWranglerConfig } from "./config.mjs";
+import { assertCurrentManifest, assertUnambiguousManifest } from "./lifecycle-manifest.mjs";
 import {
   configPath,
   ensureDeploymentDir,
@@ -33,6 +34,10 @@ export function install(flags, options = {}) {
   if (exists) {
     manifest = loadManifest(name);
     assertMatchingInstallFlags(manifest, flags);
+    if (dryRun) {
+      assertCurrentManifest(manifest);
+      assertUnambiguousManifest(manifest);
+    }
   } else {
     manifest = createManifest(name, {
       appDomain: optionalString(flags, "app-domain"),

--- a/scripts/hqbase/install.mjs
+++ b/scripts/hqbase/install.mjs
@@ -1,9 +1,17 @@
 import { optionalBoolean, optionalString, requireString } from "./args.mjs";
-import { parseD1DatabaseId, run } from "./command.mjs";
+import { run } from "./command.mjs";
 import { writeWranglerConfig } from "./config.mjs";
-import { configPath, ensureDeploymentDir, manifestExists, writeManifest } from "./manifest.mjs";
+import {
+  configPath,
+  ensureDeploymentDir,
+  loadManifest,
+  manifestExists,
+  writeManifest
+} from "./manifest.mjs";
+import { provisionResources } from "./provision.mjs";
+import { prepareManifest, resolveCloudflareAccount, wrangler } from "./resources.mjs";
 
-export function install(flags) {
+export function install(flags, options = {}) {
   const name = requireString(flags, "name");
   const dryRun = optionalBoolean(flags, "dry-run");
   const force = optionalBoolean(flags, "force");
@@ -11,60 +19,64 @@ export function install(flags) {
   const noEmail = flags.email === false;
   const skipDeploy = optionalBoolean(flags, "skip-deploy");
   const skipBuild = optionalBoolean(flags, "skip-build");
+  const runCommand = options.runCommand ?? run;
+  const checkpoint = options.checkpoint ?? writeManifest;
+  const exists = manifestExists(name);
 
-  if (manifestExists(name) && !force) {
-    throw new Error(`Deployment "${name}" already exists. Use --force to overwrite metadata.`);
+  if (force) {
+    throw new Error(
+      "--force is not supported because overwriting lifecycle metadata can lose resource ownership. Existing verified manifests resume automatically."
+    );
   }
 
-  const manifest = createManifest(name, {
-    appDomain: optionalString(flags, "app-domain"),
-    authUrl: optionalString(flags, "auth-url"),
-    oauthClientId: optionalString(flags, "oauth-client-id"),
-    oauthMode: optionalString(flags, "oauth-mode"),
-    domain,
-    workerName: optionalString(flags, "worker-name"),
-    d1Name: optionalString(flags, "d1-name"),
-    r2Bucket: optionalString(flags, "r2-bucket"),
-    queueName: optionalString(flags, "queue-name")
-  });
+  let manifest;
+  if (exists) {
+    manifest = loadManifest(name);
+    assertMatchingInstallFlags(manifest, flags);
+  } else {
+    manifest = createManifest(name, {
+      appDomain: optionalString(flags, "app-domain"),
+      authUrl: optionalString(flags, "auth-url"),
+      oauthClientId: optionalString(flags, "oauth-client-id"),
+      oauthMode: optionalString(flags, "oauth-mode"),
+      domain,
+      workerName: optionalString(flags, "worker-name"),
+      d1Name: optionalString(flags, "d1-name"),
+      r2Bucket: optionalString(flags, "r2-bucket"),
+      queueName: optionalString(flags, "queue-name")
+    });
+  }
 
   if (!dryRun) {
+    const accountId = resolveCloudflareAccount(
+      manifest.version === 3 ? (manifest.accountId ?? undefined) : undefined,
+      {
+        environment: options.environment ?? process.env,
+        runCommand
+      }
+    );
+    if (exists) {
+      manifest = prepareManifest(manifest, accountId, { checkpoint, runCommand });
+    } else {
+      manifest.accountId = accountId;
+      checkpoint(manifest);
+    }
     ensureDeploymentDir(name);
   }
-  writeManifest(manifest, { dryRun });
 
   if (!skipBuild) {
-    run("pnpm", ["build"], { dryRun });
+    runCommand("pnpm", ["build"], { dryRun });
   }
 
-  const d1Output = run("pnpm", ["exec", "wrangler", "d1", "create", manifest.d1.name], {
-    dryRun
-  });
-  if (!dryRun) {
-    manifest.d1.id = parseD1DatabaseId(d1Output);
-    manifest.d1.created = true;
-    writeManifest(manifest);
-  }
-
-  run("pnpm", ["exec", "wrangler", "r2", "bucket", "create", manifest.r2.bucket], {
-    dryRun
-  });
-  manifest.r2.created = true;
-  writeManifest(manifest, { dryRun });
-
-  run("pnpm", ["exec", "wrangler", "queues", "create", manifest.queue.name], { dryRun });
-  run("pnpm", ["exec", "wrangler", "queues", "create", manifest.queue.deadLetterName], {
-    dryRun
-  });
-  manifest.queue.created = true;
-  writeManifest(manifest, { dryRun });
+  provisionResources(manifest, { checkpoint, dryRun, runCommand });
 
   writeWranglerConfig(manifest, { dryRun });
 
-  if (!skipDeploy) {
-    run("node", ["scripts/release/deploy.mjs", "--config", configPath(name)], {
+  if (!skipDeploy && !manifest.worker.deployed) {
+    runCommand("node", ["scripts/release/deploy.mjs", "--config", configPath(name)], {
       dryRun,
       env: {
+        CLOUDFLARE_ACCOUNT_ID: manifest.accountId,
         WORKERS_CI: "1",
         ...((optionalString(flags, "auth-secret") ?? process.env.HQBASE_AUTH_SECRET)
           ? {
@@ -75,12 +87,16 @@ export function install(flags) {
       }
     });
     manifest.worker.deployed = true;
-    writeManifest(manifest, { dryRun });
+    checkpoint(manifest, { dryRun });
   }
 
   if (domain && !noEmail) {
-    configureEmail(manifest, { dryRun, noSending: flags.sending === false });
-    writeManifest(manifest, { dryRun });
+    configureEmail(manifest, {
+      dryRun,
+      noSending: flags.sending === false,
+      runCommand
+    });
+    checkpoint(manifest, { dryRun });
   }
 
   console.log(`HQBase deployment "${name}" is ready.`);
@@ -100,22 +116,24 @@ export function createManifest(name, input) {
   });
 
   return {
-    version: 2,
+    version: 3,
     name,
     createdAt: new Date().toISOString(),
+    accountId: null,
     worker: { name: workerName, deployed: false },
     d1: {
       name: d1Name,
-      id: "00000000-0000-0000-0000-000000000000",
-      created: false,
-      reused: false
+      id: null,
+      ownership: "unclaimed"
     },
     r2: {
       bucket: r2Bucket,
-      created: false,
-      reused: false
+      ownership: "unclaimed"
     },
-    queue: { name: queueName, deadLetterName: `${queueName}-dlq`, created: false },
+    queue: {
+      primary: { name: queueName, id: null, ownership: "unclaimed" },
+      deadLetter: { name: `${queueName}-dlq`, id: null, ownership: "unclaimed" }
+    },
     appDomain: input.appDomain,
     authUrl: input.authUrl,
     cloudflareOAuth,
@@ -129,6 +147,28 @@ export function createManifest(name, input) {
         }
       : null
   };
+}
+
+function assertMatchingInstallFlags(manifest, flags) {
+  const recorded = {
+    "app-domain": manifest.appDomain,
+    "auth-url": manifest.authUrl,
+    "d1-name": manifest.d1?.name,
+    domain: manifest.email?.domain,
+    "oauth-client-id": manifest.cloudflareOAuth?.clientId,
+    "oauth-mode": manifest.cloudflareOAuth?.mode,
+    "queue-name": manifest.queue?.primary?.name ?? manifest.queue?.name,
+    "r2-bucket": manifest.r2?.bucket,
+    "worker-name": manifest.worker?.name
+  };
+  for (const [flag, expected] of Object.entries(recorded)) {
+    const supplied = optionalString(flags, flag);
+    if (supplied !== undefined && supplied !== expected) {
+      throw new Error(
+        `Refusing to resume: --${flag} is "${supplied}", but the manifest records "${expected ?? "no value"}".`
+      );
+    }
+  }
 }
 
 export function cloudflareOAuthConfig({ authUrl, clientId, mode }) {
@@ -173,21 +213,18 @@ function validateCanonicalHttpsOrigin(value) {
 
 function configureEmail(manifest, options) {
   const { domain } = manifest.email;
-  run("pnpm", ["exec", "wrangler", "email", "routing", "enable", domain], options);
+  wrangler(manifest, ["email", "routing", "enable", domain], options);
   manifest.email.routingEnabled = true;
 
-  const previous = run(
-    "pnpm",
-    ["exec", "wrangler", "email", "routing", "rules", "get", domain, "catch-all"],
-    { ...options, allowFailure: true }
-  );
+  const previous = wrangler(manifest, ["email", "routing", "rules", "get", domain, "catch-all"], {
+    ...options,
+    allowFailure: true
+  });
   manifest.email.previousCatchAll = previous || null;
 
-  run(
-    "pnpm",
+  wrangler(
+    manifest,
     [
-      "exec",
-      "wrangler",
       "email",
       "routing",
       "rules",
@@ -206,7 +243,7 @@ function configureEmail(manifest, options) {
   manifest.email.catchAllToWorker = true;
 
   if (!options.noSending) {
-    run("pnpm", ["exec", "wrangler", "email", "sending", "enable", domain], options);
+    wrangler(manifest, ["email", "sending", "enable", domain], options);
     manifest.email.sendingEnabled = true;
   }
 }

--- a/scripts/hqbase/lifecycle-manifest.mjs
+++ b/scripts/hqbase/lifecycle-manifest.mjs
@@ -1,0 +1,141 @@
+const accountIdPattern = /^[0-9a-f]{32}$/i;
+const d1IdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const queueIdPattern = /^[0-9a-f]{32}$/i;
+const ownershipStates = new Set(["unclaimed", "creating", "created", "reused", "removed"]);
+const placeholderD1Id = "00000000-0000-0000-0000-000000000000";
+
+export function assertCurrentManifest(manifest, options = {}) {
+  if (manifest?.version !== 3) {
+    throw new Error(
+      'Refusing to continue: manifest field "version" must be 3. Version 1 and incomplete version 2 manifests require manual recovery from verified Cloudflare records.'
+    );
+  }
+  assertName(manifest, "name");
+  assertAccountId(manifest.accountId);
+  assertName(manifest, "worker.name");
+  if (typeof manifest.worker?.deployed !== "boolean") {
+    throw new Error('Refusing to continue: manifest field "worker.deployed" must be a boolean.');
+  }
+  assertName(manifest, "d1.name");
+  assertName(manifest, "r2.bucket");
+  assertName(manifest, "queue.primary.name");
+  assertName(manifest, "queue.deadLetter.name");
+  assertOwnership(manifest.d1, "d1");
+  assertOwnership(manifest.r2, "r2");
+  assertOwnership(manifest.queue.primary, "queue.primary");
+  assertOwnership(manifest.queue.deadLetter, "queue.deadLetter");
+
+  if (["created", "reused", "removed"].includes(manifest.d1.ownership)) {
+    assertD1Id(manifest.d1.id);
+  } else if (manifest.d1.id !== null) {
+    throw new Error('Refusing to continue: an unowned D1 resource must have a null "d1.id".');
+  }
+  for (const [path, resource] of [
+    ["queue.primary", manifest.queue.primary],
+    ["queue.deadLetter", manifest.queue.deadLetter]
+  ]) {
+    if (
+      ["created", "reused", "removed"].includes(resource.ownership) &&
+      !(options.allowMissingQueueIds && resource.id === null)
+    ) {
+      assertQueueId(resource.id, path);
+    } else if (resource.id !== null) {
+      throw new Error(`Refusing to continue: an unowned queue must have a null "${path}.id".`);
+    }
+  }
+}
+
+export function migrateVersion2(manifest, accountId) {
+  if (
+    typeof manifest.d1?.created !== "boolean" ||
+    typeof manifest.d1?.reused !== "boolean" ||
+    typeof manifest.r2?.created !== "boolean" ||
+    typeof manifest.r2?.reused !== "boolean" ||
+    manifest.queue?.created !== true ||
+    (!manifest.d1.created && !manifest.d1.reused) ||
+    (!manifest.r2.created && !manifest.r2.reused)
+  ) {
+    throw new Error(
+      "Refusing to continue: an incomplete version 2 manifest cannot prove independent resource ownership. Recover it from verified Cloudflare records."
+    );
+  }
+  if ((manifest.d1.created && manifest.d1.reused) || (manifest.r2.created && manifest.r2.reused)) {
+    throw new Error(
+      "Refusing to continue: a version 2 manifest cannot record a resource as both created and reused."
+    );
+  }
+  assertD1Id(manifest.d1.id);
+
+  return {
+    ...manifest,
+    version: 3,
+    accountId,
+    d1: {
+      name: manifest.d1.name,
+      id: manifest.d1.id,
+      ownership: manifest.d1.reused ? "reused" : "created"
+    },
+    r2: {
+      bucket: manifest.r2.bucket,
+      ownership: manifest.r2.reused ? "reused" : "created"
+    },
+    queue: {
+      primary: { name: manifest.queue.name, id: null, ownership: "created" },
+      deadLetter: { name: manifest.queue.deadLetterName, id: null, ownership: "created" }
+    }
+  };
+}
+
+export function assertUnambiguousManifest(manifest) {
+  for (const [path, resource] of [
+    ["d1", manifest.d1],
+    ["r2", manifest.r2],
+    ["queue.primary", manifest.queue.primary],
+    ["queue.deadLetter", manifest.queue.deadLetter]
+  ]) {
+    if (resource.ownership === "creating") {
+      throw new Error(
+        `Refusing to continue: manifest field "${path}.ownership" is "creating", so the last create request has an ambiguous result. Verify the Cloudflare resource and repair the manifest before retrying.`
+      );
+    }
+  }
+}
+
+export function assertD1Id(id) {
+  if (!d1IdPattern.test(id ?? "") || id === placeholderD1Id) {
+    throw new Error(
+      'Refusing to continue: manifest field "d1.id" must be a real D1 database UUID, not a missing, invalid, or placeholder value.'
+    );
+  }
+}
+
+export function assertAccountId(id) {
+  if (!accountIdPattern.test(id ?? "")) {
+    throw new Error(
+      "Refusing to continue: the Cloudflare account ID must be 32 hexadecimal characters."
+    );
+  }
+}
+
+function assertOwnership(resource, path) {
+  if (!ownershipStates.has(resource?.ownership)) {
+    throw new Error(
+      `Refusing to continue: manifest field "${path}.ownership" must be an explicit supported state.`
+    );
+  }
+}
+
+function assertName(manifest, path) {
+  const value = path.split(".").reduce((current, key) => current?.[key], manifest);
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Refusing to continue: manifest field "${path}" must be a non-empty string.`);
+  }
+}
+
+function assertQueueId(id, path) {
+  if (!queueIdPattern.test(id ?? "")) {
+    throw new Error(
+      `Refusing to continue: manifest field "${path}.id" must be a 32-character queue ID.`
+    );
+  }
+}

--- a/scripts/hqbase/manifest.mjs
+++ b/scripts/hqbase/manifest.mjs
@@ -47,7 +47,16 @@ export function writeManifest(manifest, options = {}) {
     return;
   }
   ensureDeploymentDir(manifest.name);
-  fs.writeFileSync(manifestPath(manifest.name), `${JSON.stringify(manifest, null, 2)}\n`);
+  const file = manifestPath(manifest.name);
+  const temporary = `${file}.${process.pid}.tmp`;
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+    fs.renameSync(temporary, file);
+  } finally {
+    if (fs.existsSync(temporary)) {
+      fs.unlinkSync(temporary);
+    }
+  }
 }
 
 export function manifestExists(name) {

--- a/scripts/hqbase/oauth.mjs
+++ b/scripts/hqbase/oauth.mjs
@@ -31,7 +31,7 @@ export function updateOAuthManifest(manifest, input) {
   const authUrl = input.authUrl ?? manifest.authUrl;
   return {
     ...manifest,
-    version: 2,
+    version: Math.max(manifest.version ?? 0, 2),
     authUrl,
     cloudflareOAuth: cloudflareOAuthConfig({
       authUrl,

--- a/scripts/hqbase/provision.mjs
+++ b/scripts/hqbase/provision.mjs
@@ -1,0 +1,81 @@
+import { parseD1DatabaseId, run } from "./command.mjs";
+import { writeManifest } from "./manifest.mjs";
+import { inspectD1, inspectQueue, inspectR2, wrangler } from "./resources.mjs";
+
+export function provisionResources(manifest, options = {}) {
+  const checkpoint = options.checkpoint ?? writeManifest;
+  const runCommand = options.runCommand ?? run;
+  const dryRun = options.dryRun ?? false;
+
+  if (dryRun) {
+    const commands = [
+      [manifest.d1, ["d1", "create", manifest.d1.name]],
+      [manifest.r2, ["r2", "bucket", "create", manifest.r2.bucket]],
+      [manifest.queue.primary, ["queues", "create", manifest.queue.primary.name]],
+      [manifest.queue.deadLetter, ["queues", "create", manifest.queue.deadLetter.name]]
+    ];
+    for (const [resource, args] of commands) {
+      if (resource.ownership === "unclaimed") {
+        wrangler(manifest, args, { dryRun, quiet: false, runCommand });
+      }
+    }
+    return;
+  }
+
+  for (const [path, resource] of [
+    ["d1", manifest.d1],
+    ["r2", manifest.r2],
+    ["queue.primary", manifest.queue.primary],
+    ["queue.deadLetter", manifest.queue.deadLetter]
+  ]) {
+    if (resource.ownership === "removed") {
+      throw new Error(
+        `Refusing to install: manifest resource "${path}" was removed. Start a new deployment name.`
+      );
+    }
+  }
+
+  if (manifest.d1.ownership === "unclaimed") {
+    beginCreate(manifest, manifest.d1, checkpoint);
+    const output = wrangler(manifest, ["d1", "create", manifest.d1.name], {
+      quiet: false,
+      runCommand,
+      stdoutOnly: false
+    });
+    const id = parseD1DatabaseId(output);
+    inspectD1(manifest, { ...manifest.d1, id, ownership: "created" }, { runCommand });
+    manifest.d1.id = id;
+    finishCreate(manifest, manifest.d1, checkpoint);
+  }
+
+  if (manifest.r2.ownership === "unclaimed") {
+    beginCreate(manifest, manifest.r2, checkpoint);
+    wrangler(manifest, ["r2", "bucket", "create", manifest.r2.bucket], {
+      quiet: false,
+      runCommand
+    });
+    inspectR2(manifest, { ...manifest.r2, ownership: "created" }, { runCommand });
+    finishCreate(manifest, manifest.r2, checkpoint);
+  }
+
+  for (const queue of [manifest.queue.primary, manifest.queue.deadLetter]) {
+    if (queue.ownership !== "unclaimed") {
+      continue;
+    }
+    beginCreate(manifest, queue, checkpoint);
+    wrangler(manifest, ["queues", "create", queue.name], { quiet: false, runCommand });
+    const identity = inspectQueue(manifest, { ...queue, ownership: "created" }, { runCommand });
+    queue.id = identity.id;
+    finishCreate(manifest, queue, checkpoint);
+  }
+}
+
+function beginCreate(manifest, resource, checkpoint) {
+  resource.ownership = "creating";
+  checkpoint(manifest);
+}
+
+function finishCreate(manifest, resource, checkpoint) {
+  resource.ownership = "created";
+  checkpoint(manifest);
+}

--- a/scripts/hqbase/reset.mjs
+++ b/scripts/hqbase/reset.mjs
@@ -16,14 +16,17 @@ export function reset(flags) {
   }
 
   const manifest = loadManifest(name);
+  const environment = manifest.accountId
+    ? { CLOUDFLARE_ACCOUNT_ID: manifest.accountId }
+    : undefined;
   if (scope === "data" || scope === "all") {
-    resetData(manifest, { dryRun });
+    resetData(manifest, { dryRun, env: environment });
   }
   if (scope === "storage" || scope === "all") {
-    resetStorage(manifest, { dryRun });
+    resetStorage(manifest, { dryRun, env: environment });
   }
   if (scope === "domain" || scope === "all") {
-    resetDomain(manifest, { dryRun });
+    resetDomain(manifest, { dryRun, env: environment });
   }
 
   writeManifest(manifest, { dryRun });

--- a/scripts/hqbase/resources.mjs
+++ b/scripts/hqbase/resources.mjs
@@ -1,0 +1,167 @@
+import { run } from "./command.mjs";
+import {
+  assertAccountId,
+  assertCurrentManifest,
+  assertD1Id,
+  assertUnambiguousManifest,
+  migrateVersion2
+} from "./lifecycle-manifest.mjs";
+
+export function resolveCloudflareAccount(expectedId, options = {}) {
+  const runCommand = options.runCommand ?? run;
+  if (expectedId != null) {
+    assertAccountId(expectedId);
+  }
+
+  const output = runCommand("pnpm", ["exec", "wrangler", "whoami", "--json"], {
+    quiet: true,
+    stdoutOnly: true
+  });
+  const identity = parseJson(output, "Wrangler account identity");
+  const accounts = Array.isArray(identity.accounts) ? identity.accounts : [];
+  const environmentId = options.environment?.CLOUDFLARE_ACCOUNT_ID;
+
+  if (environmentId !== undefined) {
+    assertAccountId(environmentId);
+  }
+  if (expectedId && environmentId && expectedId !== environmentId) {
+    throw new Error(
+      `Refusing to continue: manifest Cloudflare account ${expectedId} does not match CLOUDFLARE_ACCOUNT_ID ${environmentId}.`
+    );
+  }
+
+  const selectedId =
+    expectedId ?? environmentId ?? (accounts.length === 1 ? accounts[0]?.id : null);
+  if (!selectedId) {
+    throw new Error(
+      "Set CLOUDFLARE_ACCOUNT_ID because Wrangler has access to more than one Cloudflare account."
+    );
+  }
+  assertAccountId(selectedId);
+  if (!accounts.some((account) => account?.id === selectedId)) {
+    throw new Error(
+      `Refusing to continue: Wrangler is not authenticated for Cloudflare account ${selectedId}.`
+    );
+  }
+  return selectedId;
+}
+
+export function prepareManifest(manifest, accountId, options = {}) {
+  const runCommand = options.runCommand ?? run;
+  const isMigration = manifest?.version === 2;
+  let current = manifest;
+
+  if (isMigration) {
+    current = migrateVersion2(current, accountId);
+  }
+  assertCurrentManifest(current, { allowMissingQueueIds: isMigration });
+  if (current.accountId !== accountId) {
+    throw new Error(
+      `Refusing to continue: deployment manifest account ${current.accountId} does not match authenticated account ${accountId}.`
+    );
+  }
+
+  assertUnambiguousManifest(current);
+  const d1 = inspectD1(current, current.d1, { runCommand });
+  inspectR2(current, current.r2, { runCommand });
+  const primary = inspectQueue(current, current.queue.primary, { runCommand });
+  const deadLetter = inspectQueue(current, current.queue.deadLetter, { runCommand });
+
+  if (isMigration) {
+    current.d1.id = d1.id;
+    current.queue.primary.id = primary.id;
+    current.queue.deadLetter.id = deadLetter.id;
+    assertCurrentManifest(current);
+    options.checkpoint?.(current);
+  }
+  return current;
+}
+
+export function inspectD1(manifest, resource, options = {}) {
+  if (!needsVerification(resource)) {
+    return null;
+  }
+  assertD1Id(resource.id);
+  const output = wrangler(manifest, ["d1", "list", "--json"], options);
+  const databases = parseJson(output, "D1 database list");
+  const database = Array.isArray(databases)
+    ? databases.find((candidate) => candidate?.uuid === resource.id)
+    : null;
+  if (!database) {
+    throw new Error(`Refusing to continue: D1 database ${resource.id} is missing.`);
+  }
+  if (database.name !== resource.name) {
+    throw new Error(
+      `Refusing to continue: D1 database ${resource.id} is named "${database.name}", not "${resource.name}".`
+    );
+  }
+  return { id: database.uuid, name: database.name };
+}
+
+export function inspectR2(manifest, resource, options = {}) {
+  if (!needsVerification(resource)) {
+    return null;
+  }
+  const output = wrangler(manifest, ["r2", "bucket", "info", resource.bucket, "--json"], options);
+  const bucket = parseJson(output, "R2 bucket information");
+  if (bucket?.name !== resource.bucket) {
+    throw new Error(
+      `Refusing to continue: R2 returned "${bucket?.name ?? "no name"}" for bucket "${resource.bucket}".`
+    );
+  }
+  return { name: bucket.name };
+}
+
+export function inspectQueue(manifest, resource, options = {}) {
+  if (!needsVerification(resource)) {
+    return null;
+  }
+  const output = wrangler(manifest, ["queues", "info", resource.name], options);
+  const queue = parseQueueInfo(output);
+  if (queue.name !== resource.name) {
+    throw new Error(
+      `Refusing to continue: Queue ${resource.id ?? resource.name} is named "${queue.name}", not "${resource.name}".`
+    );
+  }
+  if (resource.id !== null && resource.id !== queue.id) {
+    throw new Error(
+      `Refusing to continue: queue "${resource.name}" has ID ${queue.id}, not ${resource.id}.`
+    );
+  }
+  return queue;
+}
+
+export function wrangler(manifest, args, options = {}) {
+  const runCommand = options.runCommand ?? run;
+  return runCommand("pnpm", ["exec", "wrangler", ...args], {
+    dryRun: options.dryRun,
+    quiet: options.quiet ?? true,
+    stdoutOnly: options.stdoutOnly ?? true,
+    allowFailure: options.allowFailure,
+    env: {
+      ...options.env,
+      CLOUDFLARE_ACCOUNT_ID: manifest.accountId
+    }
+  });
+}
+
+function needsVerification(resource) {
+  return resource.ownership === "created" || resource.ownership === "reused";
+}
+
+function parseQueueInfo(output) {
+  const name = output.match(/^Queue Name:\s*(.+)$/m)?.[1]?.trim();
+  const id = output.match(/^Queue ID:\s*([0-9a-f]{32})$/im)?.[1];
+  if (!name || !id) {
+    throw new Error("Could not parse the queue name and ID from Wrangler output.");
+  }
+  return { id, name };
+}
+
+function parseJson(output, label) {
+  try {
+    return JSON.parse(output);
+  } catch {
+    throw new Error(`Could not parse ${label} from Wrangler JSON output.`);
+  }
+}

--- a/scripts/test-cli-recovery.mjs
+++ b/scripts/test-cli-recovery.mjs
@@ -1,0 +1,228 @@
+import fs from "node:fs";
+
+import { parseD1DatabaseId, run } from "./hqbase/command.mjs";
+import { destroy } from "./hqbase/destroy.mjs";
+import { install } from "./hqbase/install.mjs";
+import {
+  assertDeploymentName,
+  deploymentDir,
+  loadManifest,
+  manifestExists,
+  writeManifest
+} from "./hqbase/manifest.mjs";
+import { prepareManifest } from "./hqbase/resources.mjs";
+
+const name = process.argv[2];
+assertDeploymentName(name);
+if (!name.startsWith("recovery-")) {
+  throw new Error('The recovery test deployment name must start with "recovery-".');
+}
+if (manifestExists(name)) {
+  throw new Error(`Recovery test manifest "${name}" already exists.`);
+}
+
+const flags = {
+  name,
+  "skip-build": true,
+  "skip-deploy": true,
+  email: false
+};
+const checkpoints = ["d1", "r2", "queue.primary", "queue.deadLetter"];
+let finished = false;
+let cleanupManifest;
+
+try {
+  for (const path of checkpoints) {
+    expectInterruption(path);
+  }
+
+  install(flags);
+  install(flags);
+  const manifest = loadManifest(name);
+  for (const path of checkpoints) {
+    if (resourceAt(manifest, path).ownership !== "created") {
+      throw new Error(`Recovery test did not finish resource "${path}".`);
+    }
+  }
+
+  expectManifestFailure((value) => {
+    value.d1.id = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+  }, /D1 database .* is missing/);
+  expectManifestFailure((value) => {
+    value.d1.name = `${value.d1.name}-conflict`;
+  }, /D1 database .* is named .* not/);
+  expectManifestFailure((value) => {
+    value.r2.bucket = `${value.r2.bucket}-missing`;
+  }, /Command failed .* r2 bucket info .* missing/);
+  expectManifestFailure((value) => {
+    value.queue.primary.id = "f".repeat(32);
+  }, /queue .* has ID .* not/);
+
+  cleanupManifest = verifyVersion2Migration(manifest);
+  const reused = structuredClone(cleanupManifest);
+  for (const path of checkpoints) {
+    resourceAt(reused, path).ownership = "reused";
+  }
+  writeManifest(reused);
+  destroy({ name, scope: "all", yes: true });
+  prepareManifest(reused, reused.accountId);
+
+  writeManifest(cleanupManifest);
+  destroy({ name, scope: "all", yes: true });
+  finished = true;
+} finally {
+  if (!finished) {
+    try {
+      if (!manifestExists(name) && cleanupManifest) {
+        writeManifest(cleanupManifest);
+      }
+      if (manifestExists(name)) {
+        destroy({ name, scope: "all", yes: true });
+      }
+    } catch (error) {
+      console.error(
+        `Automatic recovery-test cleanup stopped safely: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+}
+
+verifyAmbiguousCreate(`${name}-amb`);
+console.log(`Verified operator recovery and cleanup safety for "${name}".`);
+
+function expectInterruption(path) {
+  let interrupted = false;
+  try {
+    install(flags, {
+      checkpoint(manifest, options) {
+        writeManifest(manifest, options);
+        if (!interrupted && resourceAt(manifest, path).ownership === "created") {
+          interrupted = true;
+          throw new Error(`Expected recovery test interruption after ${path}.`);
+        }
+      }
+    });
+  } catch (error) {
+    if (!interrupted || !(error instanceof Error) || !error.message.includes("Expected recovery")) {
+      throw error;
+    }
+  }
+  if (!interrupted) {
+    throw new Error(`Recovery test did not interrupt after "${path}".`);
+  }
+}
+
+function expectManifestFailure(change, expectedError) {
+  const original = loadManifest(name);
+  const changed = structuredClone(original);
+  change(changed);
+  writeManifest(changed);
+  let failure;
+  try {
+    install(flags);
+  } catch (error) {
+    failure = error;
+  } finally {
+    writeManifest(original);
+  }
+  if (!(failure instanceof Error) || !expectedError.test(failure.message)) {
+    throw new Error(
+      `Recovery test did not get the expected fail-closed result: ${failure instanceof Error ? failure.message : "no error"}`
+    );
+  }
+}
+
+function verifyVersion2Migration(current) {
+  const legacy = {
+    ...structuredClone(current),
+    version: 2,
+    d1: { name: current.d1.name, id: current.d1.id, created: true, reused: false },
+    r2: { bucket: current.r2.bucket, created: true, reused: false },
+    queue: {
+      name: current.queue.primary.name,
+      deadLetterName: current.queue.deadLetter.name,
+      created: true
+    }
+  };
+  delete legacy.accountId;
+  writeManifest(legacy);
+  install(flags);
+
+  const migrated = loadManifest(name);
+  if (
+    migrated.version !== 3 ||
+    migrated.accountId !== current.accountId ||
+    migrated.d1.ownership !== "created" ||
+    migrated.r2.ownership !== "created" ||
+    migrated.queue.primary.id !== current.queue.primary.id ||
+    migrated.queue.deadLetter.id !== current.queue.deadLetter.id
+  ) {
+    throw new Error("Recovery test did not migrate the verified version 2 manifest.");
+  }
+  return migrated;
+}
+
+function verifyAmbiguousCreate(ambiguousName) {
+  assertDeploymentName(ambiguousName);
+  if (manifestExists(ambiguousName)) {
+    throw new Error(`Ambiguous-state test manifest "${ambiguousName}" already exists.`);
+  }
+  const ambiguousFlags = { ...flags, name: ambiguousName };
+  let databaseId;
+  let deleted = false;
+  try {
+    try {
+      install(ambiguousFlags, {
+        runCommand(command, args, options) {
+          const output = run(command, args, options);
+          if (args.slice(0, 4).join(" ") === "exec wrangler d1 create") {
+            databaseId = parseD1DatabaseId(output);
+            throw new Error("Expected interruption before the D1 ownership checkpoint.");
+          }
+          return output;
+        }
+      });
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes("Expected interruption")) {
+        throw error;
+      }
+    }
+
+    if (!databaseId || loadManifest(ambiguousName).d1.ownership !== "creating") {
+      throw new Error("Ambiguous-state test did not retain the creating state.");
+    }
+    let refused = false;
+    try {
+      install(ambiguousFlags);
+    } catch (error) {
+      refused = error instanceof Error && error.message.includes("ambiguous result");
+    }
+    if (!refused) {
+      throw new Error("Installer adopted an ambiguous D1 create result.");
+    }
+
+    const manifest = loadManifest(ambiguousName);
+    run("pnpm", ["exec", "wrangler", "d1", "delete", databaseId, "--skip-confirmation"], {
+      env: { CLOUDFLARE_ACCOUNT_ID: manifest.accountId }
+    });
+    const databases = JSON.parse(
+      run("pnpm", ["exec", "wrangler", "d1", "list", "--json"], {
+        env: { CLOUDFLARE_ACCOUNT_ID: manifest.accountId },
+        quiet: true,
+        stdoutOnly: true
+      })
+    );
+    if (databases.some((database) => database.uuid === databaseId)) {
+      throw new Error("Ambiguous-state test D1 cleanup was not confirmed.");
+    }
+    deleted = true;
+  } finally {
+    if (deleted) {
+      fs.rmSync(deploymentDir(ambiguousName), { force: true, recursive: true });
+    }
+  }
+}
+
+function resourceAt(manifest, path) {
+  return path.split(".").reduce((value, part) => value?.[part], manifest);
+}

--- a/scripts/test-cli-recovery.mjs
+++ b/scripts/test-cli-recovery.mjs
@@ -53,7 +53,7 @@ try {
   }, /D1 database .* is named .* not/);
   expectManifestFailure((value) => {
     value.r2.bucket = `${value.r2.bucket}-missing`;
-  }, /Command failed .* r2 bucket info .* missing/);
+  }, /Command failed .* r2 bucket info .*missing/);
   expectManifestFailure((value) => {
     value.queue.primary.id = "f".repeat(32);
   }, /queue .* has ID .* not/);

--- a/test/unit/scripts/destroy.test.mjs
+++ b/test/unit/scripts/destroy.test.mjs
@@ -1,17 +1,25 @@
 import { describe, expect, it } from "vitest";
 
-import { destroyPlan, destroyTargets } from "../../../scripts/hqbase/destroy.mjs";
+import { destroyPlan, destroyResources, destroyTargets } from "../../../scripts/hqbase/destroy.mjs";
 
 const scopes = ["worker", "data", "storage", "state", "domain", "all"];
 
-function manifest({ reused = false } = {}) {
+function manifest({ ownership = "created" } = {}) {
   return {
-    version: 1,
+    version: 3,
     name: "qa",
-    worker: { name: "hqbase-qa" },
-    d1: { name: "hqbase-data", reused },
-    r2: { bucket: "hqbase-mail", reused },
-    queue: { name: "hqbase-jobs", deadLetterName: "hqbase-jobs-dlq" },
+    accountId: "a".repeat(32),
+    worker: { name: "hqbase-qa", deployed: true },
+    d1: {
+      name: "hqbase-data",
+      id: "11111111-1111-4111-8111-111111111111",
+      ownership
+    },
+    r2: { bucket: "hqbase-mail", ownership },
+    queue: {
+      primary: { name: "hqbase-jobs", id: "1".repeat(32), ownership },
+      deadLetter: { name: "hqbase-jobs-dlq", id: "2".repeat(32), ownership }
+    },
     email: null
   };
 }
@@ -41,75 +49,139 @@ describe("operator destroy scopes", () => {
     expect(() => destroyTargets("ephemeral")).toThrowError(/Unknown destroy scope/);
   });
 
-  it.each(scopes)("honors the %s scope for fresh resources", (scope) => {
+  it.each(scopes)("honors the %s scope for created resources", (scope) => {
     const targets = destroyTargets(scope);
+    const plan = destroyPlan(scope, manifest());
 
-    expect(destroyPlan(scope, manifest())).toEqual({
+    expect(plan).toMatchObject({
       ...targets,
-      preserved: { data: false, storage: false }
-    });
-  });
-
-  it.each(scopes)("preserves externally owned D1 and R2 for the %s scope", (scope) => {
-    const targets = destroyTargets(scope);
-
-    expect(destroyPlan(scope, manifest({ reused: true }))).toEqual({
-      ...targets,
-      data: false,
-      storage: false,
+      worker: targets.worker,
+      data: targets.data,
+      storage: targets.storage,
+      queueResources: { primary: targets.queues, deadLetter: targets.queues },
       preserved: {
-        data: targets.data,
-        storage: targets.storage
+        data: false,
+        storage: false,
+        primaryQueue: false,
+        deadLetterQueue: false
       }
     });
   });
 
-  it("fails closed on a legacy manifest without ownership flags", () => {
-    expect(() =>
-      destroyPlan("all", {
-        version: 1,
-        d1: { name: "external-data" },
-        r2: { bucket: "external-mail", reused: true }
-      })
-    ).toThrowError(/"d1\.reused".*Migrate or repair/);
-  });
+  it.each(scopes)("preserves every reused resource for the %s scope", (scope) => {
+    const targets = destroyTargets(scope);
+    const plan = destroyPlan(scope, manifest({ ownership: "reused" }));
 
-  it("fails closed on an unsupported manifest version", () => {
-    expect(() => destroyPlan("worker", { ...manifest(), version: 0 })).toThrowError(
-      /"version".*Migrate or repair/
-    );
-  });
-
-  it("fails closed on non-boolean ownership metadata", () => {
-    expect(() =>
-      destroyPlan("all", {
-        ...manifest(),
-        r2: { bucket: "external-mail", reused: "true" }
-      })
-    ).toThrowError(/"r2\.reused".*explicit boolean/);
-  });
-
-  it.each([
-    { d1Reused: true, r2Reused: false, data: false, storage: true },
-    { d1Reused: false, r2Reused: true, data: true, storage: false }
-  ])("honors independent D1 and R2 ownership flags", ({ d1Reused, r2Reused, data, storage }) => {
-    const input = manifest();
-    input.d1.reused = d1Reused;
-    input.r2.reused = r2Reused;
-
-    expect(destroyPlan("state", input)).toMatchObject({
-      data,
-      storage,
-      preserved: { data: d1Reused, storage: r2Reused }
+    expect(plan).toMatchObject({
+      data: false,
+      storage: false,
+      queueResources: { primary: false, deadLetter: false },
+      preserved: {
+        data: targets.data,
+        storage: targets.storage,
+        primaryQueue: targets.queues,
+        deadLetterQueue: targets.queues
+      }
     });
   });
 
-  it("fails before mutation when a selected resource name is ambiguous", () => {
+  it("skips resources already removed by a partial cleanup", () => {
     const input = manifest();
-    input.queue.deadLetterName = "";
+    input.d1.ownership = "removed";
+    input.queue.primary.ownership = "removed";
 
-    expect(() => destroyPlan("state", input)).toThrowError(
-      /"queue\.deadLetterName".*Migrate or repair/
+    expect(destroyPlan("state", input)).toMatchObject({
+      data: false,
+      storage: true,
+      queueResources: { primary: false, deadLetter: true }
+    });
+  });
+
+  it("does not delete a Worker that was never recorded as deployed", () => {
+    const input = manifest();
+    input.worker.deployed = false;
+
+    expect(destroyPlan("worker", input).worker).toBe(false);
+  });
+
+  it("fails closed on a legacy manifest before planning a mutation", () => {
+    expect(() => destroyPlan("all", { ...manifest(), version: 2 })).toThrowError(
+      /version.*must be 3/
     );
+  });
+
+  it("fails closed on a placeholder D1 UUID", () => {
+    const input = manifest();
+    input.d1.id = "00000000-0000-0000-0000-000000000000";
+
+    expect(() => destroyPlan("data", input)).toThrowError(/real D1 database UUID/);
+  });
+
+  it("fails before mutation when queue ownership is ambiguous", () => {
+    const input = manifest();
+    input.queue.deadLetter.ownership = "creating";
+    input.queue.deadLetter.id = null;
+
+    expect(() => destroyPlan("state", input)).toThrowError(/ambiguous result/);
+  });
+
+  it("deletes D1 by its real UUID and checkpoints each independent resource", () => {
+    const input = manifest();
+    input.worker.deployed = false;
+    const commands = [];
+    const checkpoints = [];
+
+    destroyResources("state", input, {
+      checkpoint: (next) => checkpoints.push(structuredClone(next)),
+      runCommand: (_command, args) => {
+        commands.push(args.slice(2));
+        return "";
+      }
+    });
+
+    expect(commands).toContainEqual([
+      "d1",
+      "delete",
+      "11111111-1111-4111-8111-111111111111",
+      "--skip-confirmation"
+    ]);
+    expect(commands).not.toContainEqual(["d1", "delete", "hqbase-data", "--skip-confirmation"]);
+    expect(checkpoints).toHaveLength(4);
+    expect(checkpoints.at(-1)).toMatchObject({
+      d1: { ownership: "removed" },
+      r2: { ownership: "removed" },
+      queue: {
+        primary: { ownership: "removed" },
+        deadLetter: { ownership: "removed" }
+      }
+    });
+  });
+
+  it("keeps completed cleanup checkpoints when a later deletion fails", () => {
+    const input = manifest();
+    input.worker.deployed = false;
+    const checkpoints = [];
+
+    expect(() =>
+      destroyResources("state", input, {
+        checkpoint: (next) => checkpoints.push(structuredClone(next)),
+        runCommand: (_command, args) => {
+          if (args.slice(2, 6).join(" ") === "r2 bucket delete hqbase-mail") {
+            throw new Error("bucket is not empty");
+          }
+          return "";
+        }
+      })
+    ).toThrow(/bucket is not empty/);
+
+    expect(checkpoints).toHaveLength(2);
+    expect(input).toMatchObject({
+      d1: { ownership: "created" },
+      r2: { ownership: "created" },
+      queue: {
+        primary: { ownership: "removed" },
+        deadLetter: { ownership: "removed" }
+      }
+    });
   });
 });

--- a/test/unit/scripts/install.test.mjs
+++ b/test/unit/scripts/install.test.mjs
@@ -10,24 +10,47 @@ const repositoryWranglerConfig = JSON.parse(
 );
 
 describe("HQBase installation resources", () => {
-  it("creates a fresh, unowned manifest before provisioning", () => {
+  it("creates a fresh manifest with independent unclaimed resources", () => {
     const manifest = createManifest("qa", {});
 
     expect(manifest.d1).toEqual({
       name: "hqbase-qa",
-      id: "00000000-0000-0000-0000-000000000000",
-      created: false,
-      reused: false
+      id: null,
+      ownership: "unclaimed"
     });
     expect(manifest.r2).toEqual({
       bucket: "hqbase-qa-mail",
-      created: false,
-      reused: false
+      ownership: "unclaimed"
     });
     expect(manifest.worker.name).toBe("hqbase-qa");
-    expect(manifest.queue.name).toBe("hqbase-qa-jobs");
-    expect(manifest.version).toBe(2);
+    expect(manifest.queue).toEqual({
+      primary: { name: "hqbase-qa-jobs", id: null, ownership: "unclaimed" },
+      deadLetter: { name: "hqbase-qa-jobs-dlq", id: null, ownership: "unclaimed" }
+    });
+    expect(manifest.version).toBe(3);
+    expect(manifest.accountId).toBeNull();
     expect(manifest.cloudflareOAuth).toEqual({ mode: "official" });
+  });
+
+  it("pins generated Wrangler configuration to the recorded Cloudflare account", () => {
+    const manifest = createManifest("qa", {});
+    manifest.accountId = "a".repeat(32);
+
+    const config = createWranglerConfig(manifest);
+
+    expect(config.account_id).toBe("a".repeat(32));
+    expect(config.queues).toEqual({
+      producers: [{ binding: "HQBASE_JOBS", queue: "hqbase-qa-jobs" }],
+      consumers: [
+        {
+          queue: "hqbase-qa-jobs",
+          dead_letter_queue: "hqbase-qa-jobs-dlq",
+          max_batch_size: 10,
+          max_batch_timeout: 5,
+          max_retries: 3
+        }
+      ]
+    });
   });
 
   it("records customer-managed OAuth as non-secret deployment configuration", () => {
@@ -130,5 +153,6 @@ describe("HQBase installation resources", () => {
     });
     expect(official.cloudflareOAuth).toEqual({ mode: "official" });
     expect(official.authUrl).toBe("https://mail.example.com");
+    expect(official.version).toBe(3);
   });
 });

--- a/test/unit/scripts/install.test.mjs
+++ b/test/unit/scripts/install.test.mjs
@@ -1,8 +1,13 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { createWranglerConfig } from "../../../scripts/hqbase/config.mjs";
-import { cloudflareOAuthConfig, createManifest } from "../../../scripts/hqbase/install.mjs";
+import {
+  cloudflareOAuthConfig,
+  createManifest,
+  install
+} from "../../../scripts/hqbase/install.mjs";
+import { deploymentDir, writeManifest } from "../../../scripts/hqbase/manifest.mjs";
 import { updateOAuthManifest } from "../../../scripts/hqbase/oauth.mjs";
 
 const repositoryWranglerConfig = JSON.parse(
@@ -30,6 +35,37 @@ describe("HQBase installation resources", () => {
     expect(manifest.version).toBe(3);
     expect(manifest.accountId).toBeNull();
     expect(manifest.cloudflareOAuth).toEqual({ mode: "official" });
+  });
+
+  it("refuses a legacy manifest during an install dry run", () => {
+    const name = `legacy-dry-run-${process.pid}`;
+    const current = createManifest(name, {});
+    const legacy = {
+      ...current,
+      version: 2,
+      d1: { name: current.d1.name, id: null, created: false, reused: true },
+      r2: { bucket: current.r2.bucket, created: false, reused: true },
+      queue: {
+        name: current.queue.primary.name,
+        deadLetterName: current.queue.deadLetter.name,
+        created: false
+      }
+    };
+    delete legacy.accountId;
+    writeManifest(legacy);
+
+    try {
+      expect(() =>
+        install({
+          name,
+          "dry-run": true,
+          "skip-build": true,
+          "skip-deploy": true
+        })
+      ).toThrow(/version.*must be 3/);
+    } finally {
+      rmSync(deploymentDir(name), { force: true, recursive: true });
+    }
   });
 
   it("pins generated Wrangler configuration to the recorded Cloudflare account", () => {

--- a/test/unit/scripts/resources.test.mjs
+++ b/test/unit/scripts/resources.test.mjs
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+
+import { createManifest } from "../../../scripts/hqbase/install.mjs";
+import { provisionResources } from "../../../scripts/hqbase/provision.mjs";
+import { prepareManifest, resolveCloudflareAccount } from "../../../scripts/hqbase/resources.mjs";
+
+const accountId = "a".repeat(32);
+const d1Id = "11111111-1111-4111-8111-111111111111";
+const primaryQueueId = "1".repeat(32);
+const deadLetterQueueId = "2".repeat(32);
+
+function manifest() {
+  const value = createManifest("recovery", {});
+  value.accountId = accountId;
+  return value;
+}
+
+function markCreated(value, completed) {
+  const resources = [value.d1, value.r2, value.queue.primary, value.queue.deadLetter];
+  for (const resource of resources.slice(0, completed)) {
+    resource.ownership = "created";
+  }
+  if (completed >= 1) {
+    value.d1.id = d1Id;
+  }
+  if (completed >= 3) {
+    value.queue.primary.id = primaryQueueId;
+  }
+  if (completed >= 4) {
+    value.queue.deadLetter.id = deadLetterQueueId;
+  }
+  return value;
+}
+
+function cloudflareRunner(overrides = {}) {
+  const calls = [];
+  const runCommand = (_command, args) => {
+    const wranglerArgs = args.slice(2);
+    calls.push(wranglerArgs);
+    const operation = wranglerArgs.slice(0, 2).join(" ");
+
+    if (operation === "d1 create") {
+      return `database_id = "${d1Id}"`;
+    }
+    if (operation === "d1 list") {
+      return JSON.stringify(
+        [{ name: overrides.d1Name ?? "hqbase-recovery", uuid: d1Id }].filter(
+          () => !overrides.missingD1
+        )
+      );
+    }
+    if (wranglerArgs.slice(0, 3).join(" ") === "r2 bucket create") {
+      return "";
+    }
+    if (wranglerArgs.slice(0, 3).join(" ") === "r2 bucket info") {
+      return JSON.stringify({ name: overrides.r2Name ?? "hqbase-recovery-mail" });
+    }
+    if (operation === "queues create") {
+      return "";
+    }
+    if (operation === "queues info") {
+      const name = wranglerArgs[2];
+      const expectedId = name.endsWith("-dlq") ? deadLetterQueueId : primaryQueueId;
+      const id = overrides.queueId ?? expectedId;
+      return `Queue Name: ${overrides.queueName ?? name}\nQueue ID: ${id}\n`;
+    }
+    throw new Error(`Unexpected Wrangler operation: ${wranglerArgs.join(" ")}`);
+  };
+  return { calls, runCommand };
+}
+
+describe("operator resource recovery", () => {
+  it.each([
+    0, 1, 2, 3, 4
+  ])("resumes after %i completed provisioning steps without recreating them", (completed) => {
+    const current = markCreated(manifest(), completed);
+    const cloudflare = cloudflareRunner();
+    const checkpoints = [];
+
+    prepareManifest(current, accountId, { runCommand: cloudflare.runCommand });
+    provisionResources(current, {
+      checkpoint: (next) => checkpoints.push(structuredClone(next)),
+      runCommand: cloudflare.runCommand
+    });
+
+    const creates = cloudflare.calls.filter((args) => args.includes("create"));
+    expect(creates).toHaveLength(4 - completed);
+    expect(checkpoints).toHaveLength((4 - completed) * 2);
+    expect(current.d1).toMatchObject({ id: d1Id, ownership: "created" });
+    expect(current.r2.ownership).toBe("created");
+    expect(current.queue.primary).toMatchObject({
+      id: primaryQueueId,
+      ownership: "created"
+    });
+    expect(current.queue.deadLetter).toMatchObject({
+      id: deadLetterQueueId,
+      ownership: "created"
+    });
+  });
+
+  it("records creating before each request and created after identity verification", () => {
+    const current = manifest();
+    const cloudflare = cloudflareRunner();
+    const checkpoints = [];
+
+    provisionResources(current, {
+      checkpoint: (next) => checkpoints.push(structuredClone(next)),
+      runCommand: cloudflare.runCommand
+    });
+
+    expect(checkpoints.map((entry) => entry.d1.ownership).slice(0, 2)).toEqual([
+      "creating",
+      "created"
+    ]);
+    expect(checkpoints.at(-1).queue.deadLetter).toEqual({
+      name: "hqbase-recovery-jobs-dlq",
+      id: deadLetterQueueId,
+      ownership: "created"
+    });
+  });
+
+  it("fails closed instead of adopting an ambiguous create result", () => {
+    const current = manifest();
+    current.d1.ownership = "creating";
+    const cloudflare = cloudflareRunner();
+
+    expect(() =>
+      prepareManifest(current, accountId, { runCommand: cloudflare.runCommand })
+    ).toThrow(/ambiguous result/);
+    expect(cloudflare.calls).toEqual([]);
+  });
+
+  it.each([
+    [{ missingD1: true }, /D1 database.*missing/],
+    [{ d1Name: "other-database" }, /not "hqbase-recovery"/],
+    [{ r2Name: "other-bucket" }, /R2 returned/],
+    [{ queueId: "f".repeat(32) }, /has ID.*not/],
+    [{ queueName: "other-queue" }, /is named.*not/]
+  ])("fails closed on missing or conflicting remote identity", (overrides, error) => {
+    const current = markCreated(manifest(), 4);
+    const cloudflare = cloudflareRunner(overrides);
+
+    expect(() =>
+      prepareManifest(current, accountId, { runCommand: cloudflare.runCommand })
+    ).toThrow(error);
+  });
+
+  it("verifies and preserves reused ownership", () => {
+    const current = markCreated(manifest(), 4);
+    current.d1.ownership = "reused";
+    current.r2.ownership = "reused";
+    current.queue.primary.ownership = "reused";
+    current.queue.deadLetter.ownership = "reused";
+
+    expect(prepareManifest(current, accountId, { runCommand: cloudflareRunner().runCommand })).toBe(
+      current
+    );
+  });
+
+  it("migrates a complete version 2 manifest only after live identity checks", () => {
+    const legacy = {
+      ...manifest(),
+      version: 2,
+      accountId: undefined,
+      d1: { name: "hqbase-recovery", id: d1Id, created: true, reused: false },
+      r2: { bucket: "hqbase-recovery-mail", created: true, reused: false },
+      queue: {
+        name: "hqbase-recovery-jobs",
+        deadLetterName: "hqbase-recovery-jobs-dlq",
+        created: true
+      }
+    };
+    const checkpoints = [];
+
+    const migrated = prepareManifest(legacy, accountId, {
+      checkpoint: (next) => checkpoints.push(structuredClone(next)),
+      runCommand: cloudflareRunner().runCommand
+    });
+
+    expect(migrated.version).toBe(3);
+    expect(migrated.accountId).toBe(accountId);
+    expect(migrated.queue.primary.id).toBe(primaryQueueId);
+    expect(migrated.queue.deadLetter.id).toBe(deadLetterQueueId);
+    expect(checkpoints).toHaveLength(1);
+  });
+
+  it("refuses an incomplete version 2 manifest before a Cloudflare read", () => {
+    const legacy = {
+      ...manifest(),
+      version: 2,
+      accountId: undefined,
+      d1: { name: "hqbase-recovery", id: d1Id, created: true, reused: false },
+      r2: { bucket: "hqbase-recovery-mail", created: true, reused: false },
+      queue: {
+        name: "hqbase-recovery-jobs",
+        deadLetterName: "hqbase-recovery-jobs-dlq",
+        created: false
+      }
+    };
+    const cloudflare = cloudflareRunner();
+
+    expect(() => prepareManifest(legacy, accountId, { runCommand: cloudflare.runCommand })).toThrow(
+      /incomplete version 2/
+    );
+    expect(cloudflare.calls).toEqual([]);
+  });
+
+  it("refuses a version 1 manifest before a Cloudflare read", () => {
+    const legacy = { ...manifest(), version: 1 };
+    delete legacy.accountId;
+    const cloudflare = cloudflareRunner();
+
+    expect(() => prepareManifest(legacy, accountId, { runCommand: cloudflare.runCommand })).toThrow(
+      /version.*must be 3/
+    );
+    expect(cloudflare.calls).toEqual([]);
+  });
+
+  it("rejects a placeholder D1 UUID before a Cloudflare read", () => {
+    const current = markCreated(manifest(), 1);
+    current.d1.id = "00000000-0000-0000-0000-000000000000";
+    const cloudflare = cloudflareRunner();
+
+    expect(() =>
+      prepareManifest(current, accountId, { runCommand: cloudflare.runCommand })
+    ).toThrow(/real D1 database UUID/);
+    expect(cloudflare.calls).toEqual([]);
+  });
+});
+
+describe("Cloudflare account selection", () => {
+  it("uses the only authenticated account", () => {
+    const runCommand = () =>
+      JSON.stringify({ loggedIn: true, accounts: [{ id: accountId, name: "test" }] });
+
+    expect(resolveCloudflareAccount(undefined, { environment: {}, runCommand })).toBe(accountId);
+    expect(resolveCloudflareAccount(null, { environment: {}, runCommand })).toBe(accountId);
+  });
+
+  it("requires an explicit account when Wrangler has several", () => {
+    const runCommand = () =>
+      JSON.stringify({
+        loggedIn: true,
+        accounts: [
+          { id: accountId, name: "one" },
+          { id: "b".repeat(32), name: "two" }
+        ]
+      });
+
+    expect(() => resolveCloudflareAccount(undefined, { environment: {}, runCommand })).toThrow(
+      /Set CLOUDFLARE_ACCOUNT_ID/
+    );
+  });
+
+  it("rejects an account environment that conflicts with the manifest", () => {
+    const runCommand = () =>
+      JSON.stringify({ loggedIn: true, accounts: [{ id: accountId, name: "test" }] });
+
+    expect(() =>
+      resolveCloudflareAccount(accountId, {
+        environment: { CLOUDFLARE_ACCOUNT_ID: "b".repeat(32) },
+        runCommand
+      })
+    ).toThrow(/does not match CLOUDFLARE_ACCOUNT_ID/);
+  });
+});


### PR DESCRIPTION
## Summary

- Add independent lifecycle checkpoints for D1, R2, the primary queue, and the dead-letter queue.
- Resume only from manifests whose Cloudflare account and live resource identities can be verified.
- Refuse ambiguous, missing, conflicting, incomplete, or unsafe legacy state without adopting resources by name.
- Preserve reused resources and delete created D1 databases by their recorded UUID.
- Add recovery coverage to the staging E2E workflow.

## Scope

This changes terminal operator commands only. It does not change the Deploy to Cloudflare button, setup wizard, in-app update flow, Worker product code, or signed-release implementation.

## Safety

- Manifest writes are atomic.
- Each create and delete operation is checkpointed independently.
- A create request interrupted before identity was recorded remains ambiguous and fails closed.
- Existing legacy manifests are validated before install dry-run planning.
- Cleanup keeps the manifest when an operation fails, so the operator can correct the problem and retry.

## Validation

- 51 focused provisioning, migration, identity, retry, dry-run, and cleanup tests passed.
- `CI=true pnpm check` passed: 343 unit tests, 60 Worker integration tests, coverage, formatting, types, architecture checks, API artifacts, and production build.
- `CI=true pnpm deploy:dry-run` passed.
- The complete recovery matrix passed against an authenticated Cloudflare account at every supported interruption point, including duplicate retry, identity conflicts, legacy migration, reused-resource preservation, ambiguous creation, and partial cleanup.
- Independent final inventory confirmed that all disposable D1, R2, and Queue resources were removed.
- The `hqbase.berman.to` deployment record, Worker version, resource identities, queue topology, and health endpoint remained unchanged.

## Documentation

The contract and operator guidance are in HQBase/hqbase-site#12.

Closes #38