### PR TITLE
Fix draft composer placement and forward sending

### DIFF
--- a/app/features/drafts/draft-compose-dialog.tsx
+++ b/app/features/drafts/draft-compose-dialog.tsx
@@ -7,7 +7,6 @@ import type { ComposeMode } from "@/features/compose/compose-state";
 import { ComposeWindow } from "@/features/compose/compose-window";
 import type { Mailbox } from "@/features/mailboxes/types";
 import { getMessage } from "@/features/messages/api";
-import { ConversationMessages } from "@/features/messages/conversation-messages";
 import type { MessageDetail } from "@/features/messages/types";
 
 import { deleteDraft } from "./api";
@@ -121,8 +120,6 @@ export function DraftComposeDialog({
       message={message}
       mode={mode}
       open
-      presentation={message ? "thread" : "window"}
-      threadContext={message ? <ConversationMessages compact messages={[message]} /> : undefined}
       onDraftsChange={onDraftsChange}
       onOpenChange={onOpenChange}
       onSent={onSent}

--- a/test/unit/app/layout/desktop-shell.test.ts
+++ b/test/unit/app/layout/desktop-shell.test.ts
@@ -17,6 +17,10 @@ const inboxPage = readFileSync(
   new URL("../../../../app/features/inbox/inbox-page.tsx", import.meta.url),
   "utf8"
 );
+const draftComposeDialog = readFileSync(
+  new URL("../../../../app/features/drafts/draft-compose-dialog.tsx", import.meta.url),
+  "utf8"
+);
 const threadComposeSurface = readFileSync(
   new URL("../../../../app/features/compose/thread-compose-surface.tsx", import.meta.url),
   "utf8"
@@ -58,5 +62,10 @@ describe("desktop application shell", () => {
 
   it("keeps desktop Reply and Forward inside the app shell", () => {
     expect(threadComposeSurface).not.toContain("createPortal(desktop");
+  });
+
+  it("reopens Reply and Forward drafts in the fixed compose window", () => {
+    expect(draftComposeDialog).not.toContain('presentation={message ? "thread" : "window"}');
+    expect(draftComposeDialog).not.toContain("threadContext=");
   });
 });

--- a/test/unit/worker/features/send/routes.test.ts
+++ b/test/unit/worker/features/send/routes.test.ts
@@ -1,0 +1,86 @@
+import type { WorkerEnv } from "@worker/lib/env";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  enforceRateLimit: vi.fn(),
+  findMailboxForSending: vi.fn(),
+  recordAudit: vi.fn(),
+  requireDraftAttachmentIdsAccess: vi.fn(),
+  requireDraftIdAccess: vi.fn(),
+  requireMailApiContext: vi.fn(),
+  requireMailboxAccess: vi.fn(),
+  sendNewMessage: vi.fn()
+}));
+
+vi.mock("@worker/auth/mail-api", () => ({
+  requireMailApiContext: mocks.requireMailApiContext
+}));
+vi.mock("@worker/auth/mailbox-access", () => ({
+  requireMailboxAccess: mocks.requireMailboxAccess
+}));
+vi.mock("@worker/security/rate-limit", () => ({
+  enforceRateLimit: mocks.enforceRateLimit
+}));
+vi.mock("@worker/features/audit/service", () => ({
+  recordAudit: mocks.recordAudit
+}));
+vi.mock("@worker/features/drafts/access", () => ({
+  requireDraftAttachmentIdsAccess: mocks.requireDraftAttachmentIdsAccess,
+  requireDraftIdAccess: mocks.requireDraftIdAccess
+}));
+vi.mock("@worker/features/mailboxes/queries", () => ({
+  findMailboxForSending: mocks.findMailboxForSending
+}));
+vi.mock("@worker/features/send/service", () => ({
+  replyToMessage: vi.fn(),
+  sendNewMessage: mocks.sendNewMessage
+}));
+
+import { sendRoutes } from "@worker/features/send/routes";
+
+describe("send routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireMailApiContext.mockResolvedValue({
+      user: { id: "user-1", role: "member" }
+    });
+    mocks.findMailboxForSending.mockResolvedValue({ id: "mailbox-1" });
+    mocks.sendNewMessage.mockResolvedValue({ id: "sent-message-1" });
+  });
+
+  it("authorizes the selected sending mailbox before sending a draft", async () => {
+    const db = {} as D1Database;
+    const response = await sendRoutes.request(
+      "/send",
+      {
+        body: JSON.stringify({
+          from: "sender@example.com",
+          to: ["reader@example.com"],
+          cc: [],
+          bcc: [],
+          subject: "Fwd: Example",
+          text: "Forwarded message",
+          html: "<p>Forwarded message</p>",
+          attachmentIds: [],
+          draftId: "draft-forward"
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST"
+      },
+      {
+        BETTER_AUTH_SECRET: "test-secret",
+        DB: db
+      } as WorkerEnv
+    );
+
+    expect(response.status).toBe(201);
+    expect(mocks.requireMailboxAccess).toHaveBeenCalledWith(
+      db,
+      "user-1",
+      "member",
+      "mailbox-1",
+      "agent"
+    );
+    expect(mocks.sendNewMessage).toHaveBeenCalledOnce();
+  });
+});

--- a/worker/features/send/routes.ts
+++ b/worker/features/send/routes.ts
@@ -9,7 +9,6 @@ import { enforceRateLimit } from "../../security/rate-limit";
 import { recordAudit } from "../audit/service";
 import { requireDraftAttachmentIdsAccess, requireDraftIdAccess } from "../drafts/access";
 import { findMailboxForSending } from "../mailboxes/queries";
-import { requireMessageAccess } from "../messages/access";
 
 import { replyToMessage, sendNewMessage } from "./service";
 import { replyMessageSchema, sendMessageSchema } from "./validation";
@@ -27,7 +26,7 @@ sendRoutes.post("/send", async (c) => {
   const input = parseWith(sendMessageSchema, await readJson(c.req.raw));
   const mailbox = await findMailboxForSending(c.env.DB, input.from);
   if (!mailbox) throw new AppError("MAILBOX_NOT_FOUND", "Sending mailbox not found.", 404);
-  await requireMessageAccess(
+  await requireMailboxAccess(
     c.env.DB,
     authContext.user.id,
     authContext.user.role,


### PR DESCRIPTION
## Summary

- Reopen saved Reply and Forward drafts in the fixed compose window so the editor stays inside the visible application area.
- Authorize `/api/v1/send` against the selected sending mailbox instead of treating its mailbox ID as a message ID.
- Add focused regression coverage for both paths.

## Root cause

A recent interface change forced contextual drafts into the inline thread presentation even though the Drafts route mounts the editor outside the conversation workspace. On desktop, that placed the editor below the fixed-height application shell.

A separate access-control change replaced the new-message route's mailbox authorization with message authorization but continued to pass `mailbox.id`. Because that value is not a message ID, forwards sent through the shared new-message route failed with `Message not found.`

## Impact

Saved Reply and Forward drafts now open in a visible compose surface. New messages and web forwards can send after the user passes the correct live mailbox access check.

## Validation

- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-draft-forward-hotfix-check.log pnpm check`
- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-draft-forward-hotfix-dry-run.log pnpm deploy:dry-run`
