### PR TITLE
Fix core Mail API reliability issues

### DIFF
--- a/api/hqbase-mail-api-v1.openapi.json
+++ b/api/hqbase-mail-api-v1.openapi.json
@@ -1023,7 +1023,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["read", "unread", "star", "unstar", "archive", "trash"]
+              "enum": ["read", "unread", "star", "unstar", "archive", "trash", "restore"]
             }
           }
         ]
@@ -1242,7 +1242,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["read", "unread", "star", "unstar", "archive", "trash"]
+              "enum": ["read", "unread", "star", "unstar", "archive", "trash", "restore"]
             }
           }
         ],
@@ -1730,6 +1730,7 @@
     "/api/v1/drafts/{id}/attachments": {
       "post": {
         "summary": "Add a draft attachment",
+        "description": "Records the file part's Content-Type, or application/octet-stream when no type is present. One file and all files in one draft can each total at most 25 MiB; larger uploads return 413 ATTACHMENTS_TOO_LARGE.",
         "security": [
           {
             "oauth2": ["mail:send"]
@@ -1789,6 +1790,16 @@
               }
             }
           },
+          "413": {
+            "description": "File or draft attachment total exceeds 25 MiB",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Rate limit exceeded",
             "content": {
@@ -1824,8 +1835,14 @@
                 "properties": {
                   "file": {
                     "type": "string",
+                    "format": "binary",
                     "contentEncoding": "binary"
                   }
+                }
+              },
+              "encoding": {
+                "file": {
+                  "contentType": "*/*"
                 }
               }
             }
@@ -2112,6 +2129,104 @@
                 "bcc": [],
                 "text": "Thanks for your message.",
                 "attachmentIds": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/forward": {
+      "post": {
+        "summary": "Forward a message",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Sent forward",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageSummary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Sending"],
+        "operationId": "forwardMessage",
+        "description": "Not idempotent. Do not retry blindly. Set includeOriginalAttachments to false to omit the source message's attachments.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ForwardInput"
+              },
+              "example": {
+                "messageId": "msg_example",
+                "from": "support@example.com",
+                "to": ["person@example.net"],
+                "cc": [],
+                "bcc": [],
+                "text": "Please review this message.",
+                "attachmentIds": [],
+                "includeOriginalAttachments": true
               }
             }
           }
@@ -2909,6 +3024,76 @@
           },
           "draftId": {
             "type": "string"
+          }
+        }
+      },
+      "ForwardInput": {
+        "type": "object",
+        "required": ["messageId", "from", "to"],
+        "properties": {
+          "messageId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "from": {
+            "type": "string",
+            "format": "email"
+          },
+          "to": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "minItems": 1,
+            "maxItems": 50
+          },
+          "cc": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "maxItems": 50,
+            "default": []
+          },
+          "bcc": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "maxItems": 50,
+            "default": []
+          },
+          "subject": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
+          "text": {
+            "type": "string",
+            "maxLength": 100000,
+            "default": ""
+          },
+          "html": {
+            "type": "string",
+            "maxLength": 200000
+          },
+          "attachmentIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            },
+            "maxItems": 20,
+            "default": []
+          },
+          "includeOriginalAttachments": {
+            "type": "boolean",
+            "default": true
           }
         }
       }

--- a/api/hqbase-mail-api-v1.openapi.json
+++ b/api/hqbase-mail-api-v1.openapi.json
@@ -1023,7 +1023,16 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["read", "unread", "star", "unstar", "archive", "trash", "restore"]
+              "enum": [
+                "read",
+                "unread",
+                "star",
+                "unstar",
+                "archive",
+                "unarchive",
+                "trash",
+                "restore"
+              ]
             }
           }
         ]
@@ -1242,7 +1251,16 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["read", "unread", "star", "unstar", "archive", "trash", "restore"]
+              "enum": [
+                "read",
+                "unread",
+                "star",
+                "unstar",
+                "archive",
+                "unarchive",
+                "trash",
+                "restore"
+              ]
             }
           }
         ],

--- a/api/hqbase-mail-api-v1.postman_collection.json
+++ b/api/hqbase-mail-api-v1.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "_postman_id": "62c6dbf4-835d-4a3f-87df-77b7ddcf2db1",
     "name": "HQBase Mail API v1",
-    "description": "Generated from api/hqbase-mail-api-v1.openapi.json. Set base_url, run Register public client, and use Postman's OAuth 2.0 Authorization Code flow with PKCE (S256). Auth URL: {{base_url}}/api/auth/oauth2/authorize. Token URL: {{base_url}}/api/auth/oauth2/token. Client ID: {{client_id}}. Scope: mail:read mail:write mail:send offline_access. Add authorization request parameter resource={{api_resource}}, then store the resulting token only in your local environment as access_token. Sending and replying are not idempotent.",
+    "description": "Generated from api/hqbase-mail-api-v1.openapi.json. Set base_url, run Register public client, and use Postman's OAuth 2.0 Authorization Code flow with PKCE (S256). Auth URL: {{base_url}}/api/auth/oauth2/authorize. Token URL: {{base_url}}/api/auth/oauth2/token. Client ID: {{client_id}}. Scope: mail:read mail:write mail:send offline_access. Add authorization request parameter resource={{api_resource}}, then store the resulting token only in your local environment as access_token. Sending, replying, and forwarding are not idempotent.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "auth": {
@@ -579,7 +579,7 @@
                 }
               ]
             },
-            "description": "Add a draft attachment",
+            "description": "Records the file part's Content-Type, or application/octet-stream when no type is present. One file and all files in one draft can each total at most 25 MiB; larger uploads return 413 ATTACHMENTS_TOO_LARGE.",
             "body": {
               "mode": "formdata",
               "formdata": [
@@ -665,6 +665,33 @@
             "body": {
               "mode": "raw",
               "raw": "{\n  \"messageId\": \"msg_example\",\n  \"from\": \"support@example.com\",\n  \"cc\": [],\n  \"bcc\": [],\n  \"text\": \"Thanks for your message.\",\n  \"attachmentIds\": []\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Forward a message",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/v1/forward",
+              "variable": []
+            },
+            "description": "Not idempotent. Do not retry blindly. Set includeOriginalAttachments to false to omit the source message's attachments.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"messageId\": \"msg_example\",\n  \"from\": \"support@example.com\",\n  \"to\": [\n    \"person@example.net\"\n  ],\n  \"cc\": [],\n  \"bcc\": [],\n  \"text\": \"Please review this message.\",\n  \"attachmentIds\": [],\n  \"includeOriginalAttachments\": true\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/app/features/inbox/inbox-page.tsx
+++ b/app/features/inbox/inbox-page.tsx
@@ -158,6 +158,7 @@ export function InboxPage({
     if (
       action === "archive" ||
       action === "trash" ||
+      action === "restore" ||
       (activeFolder === "starred" && action === "unstar")
     ) {
       onMessageRouteChange(activeFolder, null);
@@ -199,6 +200,7 @@ export function InboxPage({
           </div>
         ) : (
           <MessageDetail
+            activeFolder={activeFolder}
             defaultFromMailboxId={defaultFromMailboxId}
             error={detailError}
             isLoading={detailLoading}

--- a/app/features/inbox/inbox-page.tsx
+++ b/app/features/inbox/inbox-page.tsx
@@ -157,6 +157,7 @@ export function InboxPage({
     void Promise.resolve(onRefresh()).catch(() => undefined);
     if (
       action === "archive" ||
+      action === "unarchive" ||
       action === "trash" ||
       action === "restore" ||
       (activeFolder === "starred" && action === "unstar")

--- a/app/features/mcp/connection-dialog.tsx
+++ b/app/features/mcp/connection-dialog.tsx
@@ -71,7 +71,7 @@ export function McpConnectionDetails({
             endpoint={fullEndpoint}
             endpointId={fullEndpointId}
             icon={<PiPaperPlaneTilt aria-hidden="true" className="pointer-events-none size-4" />}
-            permissions="Archive and trash actions, drafts, send, reply, and forward"
+            permissions="Archive, trash, and restore actions, drafts, send, reply, and forward"
             title="Read, manage & send"
           />
         </TabsContent>

--- a/app/features/mcp/connection-dialog.tsx
+++ b/app/features/mcp/connection-dialog.tsx
@@ -71,7 +71,7 @@ export function McpConnectionDetails({
             endpoint={fullEndpoint}
             endpointId={fullEndpointId}
             icon={<PiPaperPlaneTilt aria-hidden="true" className="pointer-events-none size-4" />}
-            permissions="Archive, trash, and restore actions, drafts, send, reply, and forward"
+            permissions="Archive, unarchive, trash, and restore actions, drafts, send, reply, and forward"
             title="Read, manage & send"
           />
         </TabsContent>

--- a/app/features/messages/api.ts
+++ b/app/features/messages/api.ts
@@ -53,7 +53,7 @@ export async function trustRemoteMediaSender(id: string): Promise<void> {
 
 export async function runMessageAction(
   id: string,
-  action: "read" | "unread" | "star" | "unstar" | "archive" | "trash"
+  action: "read" | "unread" | "star" | "unstar" | "archive" | "trash" | "restore"
 ): Promise<MessageSummary> {
   return apiPost<MessageSummary>(`/api/v1/messages/${id}/${action}`);
 }

--- a/app/features/messages/api.ts
+++ b/app/features/messages/api.ts
@@ -53,7 +53,7 @@ export async function trustRemoteMediaSender(id: string): Promise<void> {
 
 export async function runMessageAction(
   id: string,
-  action: "read" | "unread" | "star" | "unstar" | "archive" | "trash" | "restore"
+  action: "read" | "unread" | "star" | "unstar" | "archive" | "unarchive" | "trash" | "restore"
 ): Promise<MessageSummary> {
   return apiPost<MessageSummary>(`/api/v1/messages/${id}/${action}`);
 }

--- a/app/features/messages/message-detail.tsx
+++ b/app/features/messages/message-detail.tsx
@@ -1,11 +1,19 @@
 import * as React from "react";
-import { PiArchive, PiArrowLeft, PiEnvelopeOpen, PiStar, PiTrash } from "react-icons/pi";
+import {
+  PiArchive,
+  PiArrowCounterClockwise,
+  PiArrowLeft,
+  PiEnvelopeOpen,
+  PiStar,
+  PiTrash
+} from "react-icons/pi";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { PullToRefresh } from "@/components/ui/pull-to-refresh";
 import type { ComposeMode } from "@/features/compose/compose-state";
 import type { Mailbox } from "@/features/mailboxes/types";
+import type { MailFolderId } from "@/lib/routes";
 import { ConversationMessages } from "./conversation-messages";
 import type { MessageDetail as MessageDetailType } from "./types";
 
@@ -14,6 +22,7 @@ const ComposeDialog = React.lazy(() =>
 );
 
 type MessageDetailProps = {
+  activeFolder?: MailFolderId;
   defaultFromMailboxId: string | null;
   error?: string | null;
   isLoading?: boolean;
@@ -28,7 +37,7 @@ type MessageDetailProps = {
   onSent: () => void;
 };
 
-type MessageAction = "read" | "unread" | "star" | "unstar" | "archive" | "trash";
+type MessageAction = "read" | "unread" | "star" | "unstar" | "archive" | "trash" | "restore";
 
 type ThreadComposeMode = Extract<ComposeMode, "reply" | "forward">;
 
@@ -38,6 +47,7 @@ type ThreadComposeState = {
 };
 
 export function MessageDetail({
+  activeFolder,
   defaultFromMailboxId,
   error = null,
   isLoading = false,
@@ -70,6 +80,7 @@ export function MessageDetail({
   );
 
   const isStarred = messages.some((message) => message.starredAt !== null);
+  const isTrash = activeFolder === "trash";
 
   async function applyAction(action: MessageAction, successMessage?: string): Promise<void> {
     try {
@@ -123,18 +134,29 @@ export function MessageDetail({
                 className={`pointer-events-none ${isStarred ? "fill-star" : ""}`}
               />
             </IconButton>
-            <IconButton
-              label="Archive conversation"
-              onClick={() => void applyAction("archive", "Conversation archived.")}
-            >
-              <PiArchive aria-hidden="true" className="pointer-events-none" />
-            </IconButton>
-            <IconButton
-              label="Trash conversation"
-              onClick={() => void applyAction("trash", "Conversation moved to Trash.")}
-            >
-              <PiTrash aria-hidden="true" className="pointer-events-none" />
-            </IconButton>
+            {isTrash ? (
+              <IconButton
+                label="Restore conversation"
+                onClick={() => void applyAction("restore", "Conversation restored.")}
+              >
+                <PiArrowCounterClockwise aria-hidden="true" className="pointer-events-none" />
+              </IconButton>
+            ) : (
+              <>
+                <IconButton
+                  label="Archive conversation"
+                  onClick={() => void applyAction("archive", "Conversation archived.")}
+                >
+                  <PiArchive aria-hidden="true" className="pointer-events-none" />
+                </IconButton>
+                <IconButton
+                  label="Trash conversation"
+                  onClick={() => void applyAction("trash", "Conversation moved to Trash.")}
+                >
+                  <PiTrash aria-hidden="true" className="pointer-events-none" />
+                </IconButton>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/app/features/messages/message-detail.tsx
+++ b/app/features/messages/message-detail.tsx
@@ -37,7 +37,15 @@ type MessageDetailProps = {
   onSent: () => void;
 };
 
-type MessageAction = "read" | "unread" | "star" | "unstar" | "archive" | "trash" | "restore";
+type MessageAction =
+  | "read"
+  | "unread"
+  | "star"
+  | "unstar"
+  | "archive"
+  | "unarchive"
+  | "trash"
+  | "restore";
 
 type ThreadComposeMode = Extract<ComposeMode, "reply" | "forward">;
 
@@ -80,6 +88,7 @@ export function MessageDetail({
   );
 
   const isStarred = messages.some((message) => message.starredAt !== null);
+  const isArchived = activeFolder === "archived";
   const isTrash = activeFolder === "trash";
 
   async function applyAction(action: MessageAction, successMessage?: string): Promise<void> {
@@ -144,10 +153,19 @@ export function MessageDetail({
             ) : (
               <>
                 <IconButton
-                  label="Archive conversation"
-                  onClick={() => void applyAction("archive", "Conversation archived.")}
+                  label={isArchived ? "Unarchive conversation" : "Archive conversation"}
+                  onClick={() =>
+                    void applyAction(
+                      isArchived ? "unarchive" : "archive",
+                      isArchived ? "Conversation unarchived." : "Conversation archived."
+                    )
+                  }
                 >
-                  <PiArchive aria-hidden="true" className="pointer-events-none" />
+                  {isArchived ? (
+                    <PiArrowCounterClockwise aria-hidden="true" className="pointer-events-none" />
+                  ) : (
+                    <PiArchive aria-hidden="true" className="pointer-events-none" />
+                  )}
                 </IconButton>
                 <IconButton
                   label="Trash conversation"

--- a/app/features/messages/types.ts
+++ b/app/features/messages/types.ts
@@ -30,7 +30,14 @@ export type ConversationPage = {
   totalCount: number | null;
 };
 
-export type ConversationAction = "read" | "unread" | "star" | "unstar" | "archive" | "trash";
+export type ConversationAction =
+  | "read"
+  | "unread"
+  | "star"
+  | "unstar"
+  | "archive"
+  | "trash"
+  | "restore";
 
 export type MessageDetail = MessageSummary & {
   cc: string[];

--- a/app/features/messages/types.ts
+++ b/app/features/messages/types.ts
@@ -36,6 +36,7 @@ export type ConversationAction =
   | "star"
   | "unstar"
   | "archive"
+  | "unarchive"
   | "trash"
   | "restore";
 

--- a/app/features/messages/use-mail-sync.ts
+++ b/app/features/messages/use-mail-sync.ts
@@ -213,6 +213,7 @@ export function useMailSync({ activeFolder, mailboxId, search, userId }: MailSyn
       const removesConversation =
         action === "archive" ||
         action === "trash" ||
+        action === "restore" ||
         (activeFolder === "starred" && action === "unstar");
       if (removesConversation) {
         setTotalCount((current) => (current === null ? null : Math.max(0, current - 1)));

--- a/app/features/messages/use-mail-sync.ts
+++ b/app/features/messages/use-mail-sync.ts
@@ -212,6 +212,7 @@ export function useMailSync({ activeFolder, mailboxId, search, userId }: MailSyn
       if (affected === 0) return;
       const removesConversation =
         action === "archive" ||
+        action === "unarchive" ||
         action === "trash" ||
         action === "restore" ||
         (activeFolder === "starred" && action === "unstar");

--- a/scripts/generate-mail-api-artifacts.mjs
+++ b/scripts/generate-mail-api-artifacts.mjs
@@ -54,7 +54,7 @@ function buildCollection(document) {
       _postman_id: "62c6dbf4-835d-4a3f-87df-77b7ddcf2db1",
       name: "HQBase Mail API v1",
       description:
-        "Generated from api/hqbase-mail-api-v1.openapi.json. Set base_url, run Register public client, and use Postman's OAuth 2.0 Authorization Code flow with PKCE (S256). Auth URL: {{base_url}}/api/auth/oauth2/authorize. Token URL: {{base_url}}/api/auth/oauth2/token. Client ID: {{client_id}}. Scope: mail:read mail:write mail:send offline_access. Add authorization request parameter resource={{api_resource}}, then store the resulting token only in your local environment as access_token. Sending and replying are not idempotent.",
+        "Generated from api/hqbase-mail-api-v1.openapi.json. Set base_url, run Register public client, and use Postman's OAuth 2.0 Authorization Code flow with PKCE (S256). Auth URL: {{base_url}}/api/auth/oauth2/authorize. Token URL: {{base_url}}/api/auth/oauth2/token. Client ID: {{client_id}}. Scope: mail:read mail:write mail:send offline_access. Add authorization request parameter resource={{api_resource}}, then store the resulting token only in your local environment as access_token. Sending, replying, and forwarding are not idempotent.",
       schema: "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
     },
     auth: {
@@ -86,7 +86,8 @@ function validateOpenApi(document) {
     "/api/v1/conversations",
     "/api/v1/drafts",
     "/api/v1/send",
-    "/api/v1/reply"
+    "/api/v1/reply",
+    "/api/v1/forward"
   ];
   for (const route of requiredPaths) {
     if (!document.paths?.[route]) throw new Error(`Mail API contract is missing ${route}.`);

--- a/test/integration/worker/conversations.test.ts
+++ b/test/integration/worker/conversations.test.ts
@@ -141,6 +141,28 @@ describe("conversation persistence", () => {
         messageId: "msg_root_a"
       })
     ).resolves.toMatchObject({ affected: 1 });
+
+    await expect(
+      updateConversationAction(env.DB, {
+        action: "restore",
+        activeFolder: "trash",
+        scope: { includeUnassigned: false, mailboxIds: ["mbx_conversations"] },
+        messageId: "msg_reply_a"
+      })
+    ).resolves.toMatchObject({ affected: 1 });
+    await expect(
+      env.DB.prepare("SELECT folder, archived_at, trashed_at FROM messages WHERE id = ?")
+        .bind("msg_reply_a")
+        .first()
+    ).resolves.toEqual({ archived_at: null, folder: "sent", trashed_at: null });
+    await expect(
+      updateConversationAction(env.DB, {
+        action: "restore",
+        activeFolder: "sent",
+        scope: { includeUnassigned: false, mailboxIds: ["mbx_conversations"] },
+        messageId: "msg_reply_a"
+      })
+    ).resolves.toMatchObject({ affected: 0 });
   });
 
   it("pages conversations with a stable opaque cursor", async () => {

--- a/test/integration/worker/conversations.test.ts
+++ b/test/integration/worker/conversations.test.ts
@@ -135,6 +135,28 @@ describe("conversation persistence", () => {
 
     await expect(
       updateConversationAction(env.DB, {
+        action: "unarchive",
+        activeFolder: "archived",
+        scope: { includeUnassigned: false, mailboxIds: ["mbx_conversations"] },
+        messageId: "msg_root_a"
+      })
+    ).resolves.toMatchObject({ affected: 1 });
+    await expect(
+      env.DB.prepare("SELECT folder, archived_at, trashed_at FROM messages WHERE id = ?")
+        .bind("msg_root_a")
+        .first()
+    ).resolves.toEqual({ archived_at: null, folder: "inbox", trashed_at: null });
+    await expect(
+      updateConversationAction(env.DB, {
+        action: "unarchive",
+        activeFolder: "inbox",
+        scope: { includeUnassigned: false, mailboxIds: ["mbx_conversations"] },
+        messageId: "msg_root_a"
+      })
+    ).resolves.toMatchObject({ affected: 0 });
+
+    await expect(
+      updateConversationAction(env.DB, {
         action: "trash",
         activeFolder: "sent",
         scope: { includeUnassigned: false, mailboxIds: ["mbx_conversations"] },

--- a/test/integration/worker/mail-api.test.ts
+++ b/test/integration/worker/mail-api.test.ts
@@ -267,7 +267,7 @@ describe("HQBase Mail API v1", () => {
       "Do not open, navigate to, or interact with the verification URL in Cloud Browser"
     );
     expect(instructions).toContain("The person must open it themselves in a browser they control");
-    expect(instructions).toContain("Sending and replying are not idempotent");
+    expect(instructions).toContain("Sending, replying, and forwarding are not idempotent");
     expect(instructions).toContain(
       "get a checkpoint from `GET https://hqbase.test/api/v1/changes`"
     );
@@ -337,6 +337,79 @@ describe("HQBase Mail API v1", () => {
     const attachment = await apiFetch("/api/v1/attachments/att_api", readToken);
     expect(attachment.status).toBe(200);
     expect(await attachment.text()).toBe("hello");
+  });
+
+  it("restores trashed mail through the versioned action route", async () => {
+    const trashed = await apiFetch("/api/v1/messages/msg_api/trash", writeToken, {
+      method: "POST"
+    });
+    expect(trashed.status, await trashed.clone().text()).toBe(200);
+    await expect(trashed.json()).resolves.toMatchObject({ folder: "trash" });
+
+    const restored = await apiFetch("/api/v1/messages/msg_api/restore", writeToken, {
+      method: "POST"
+    });
+    expect(restored.status, await restored.clone().text()).toBe(200);
+    await expect(restored.json()).resolves.toMatchObject({ folder: "inbox" });
+    await expect(
+      env.DB.prepare("SELECT archived_at, trashed_at FROM messages WHERE id = 'msg_api'").first()
+    ).resolves.toEqual({ archived_at: null, trashed_at: null });
+  });
+
+  it("keeps a draft attachment's multipart MIME type", async () => {
+    const created = await apiFetch("/api/v1/drafts", fullToken, {
+      body: JSON.stringify({ mailboxId: "mbx_api", from: "support@example.com" }),
+      headers: { "content-type": "application/json" },
+      method: "POST"
+    });
+    expect(created.status, await created.clone().text()).toBe(201);
+    const draft = (await created.json()) as { id: string };
+    const form = new FormData();
+    form.set(
+      "file",
+      new File([new Uint8Array([137, 80, 78, 71])], "pixel.png", {
+        type: "image/png"
+      })
+    );
+
+    const uploaded = await apiFetch(`/api/v1/drafts/${draft.id}/attachments`, fullToken, {
+      body: form,
+      method: "POST"
+    });
+    expect(uploaded.status, await uploaded.clone().text()).toBe(201);
+    await expect(uploaded.json()).resolves.toMatchObject({
+      contentType: "image/png",
+      filename: "pixel.png",
+      sizeBytes: 4
+    });
+
+    const stored = await apiFetch(`/api/v1/drafts/${draft.id}`, fullToken);
+    await expect(stored.json()).resolves.toMatchObject({
+      attachments: [{ contentType: "image/png", filename: "pixel.png", sizeBytes: 4 }]
+    });
+  });
+
+  it("forwards an accessible message with its original attachments", async () => {
+    const response = await apiFetch("/api/v1/forward", fullToken, {
+      body: JSON.stringify({
+        messageId: "msg_api",
+        from: "support@example.com",
+        to: ["person@example.net"],
+        text: "Please review.",
+        includeOriginalAttachments: true
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST"
+    });
+    expect(response.status, await response.clone().text()).toBe(201);
+    const forwarded = (await response.json()) as { id: string };
+    const detail = await apiFetch(`/api/v1/messages/${forwarded.id}`, readToken);
+    await expect(detail.json()).resolves.toMatchObject({
+      attachments: [{ contentType: "text/plain", filename: "hello.txt", sizeBytes: 5 }],
+      folder: "sent",
+      hasAttachments: true,
+      subject: "Fwd: API message"
+    });
   });
 
   it("limits unassigned mail to authenticated owners", async () => {

--- a/test/integration/worker/mail-api.test.ts
+++ b/test/integration/worker/mail-api.test.ts
@@ -339,7 +339,22 @@ describe("HQBase Mail API v1", () => {
     expect(await attachment.text()).toBe("hello");
   });
 
-  it("restores trashed mail through the versioned action route", async () => {
+  it("unarchives and restores mail through the versioned action route", async () => {
+    const archived = await apiFetch("/api/v1/messages/msg_api/archive", writeToken, {
+      method: "POST"
+    });
+    expect(archived.status, await archived.clone().text()).toBe(200);
+    await expect(archived.json()).resolves.toMatchObject({ folder: "archived" });
+
+    const unarchived = await apiFetch("/api/v1/messages/msg_api/unarchive", writeToken, {
+      method: "POST"
+    });
+    expect(unarchived.status, await unarchived.clone().text()).toBe(200);
+    await expect(unarchived.json()).resolves.toMatchObject({ folder: "inbox" });
+    await expect(
+      env.DB.prepare("SELECT archived_at, trashed_at FROM messages WHERE id = 'msg_api'").first()
+    ).resolves.toEqual({ archived_at: null, trashed_at: null });
+
     const trashed = await apiFetch("/api/v1/messages/msg_api/trash", writeToken, {
       method: "POST"
     });

--- a/test/integration/worker/mcp.test.ts
+++ b/test/integration/worker/mcp.test.ts
@@ -483,6 +483,30 @@ describe("HQBase MCP server", () => {
         "/mcp/full"
       )
     ).resolves.toMatchObject({ affected: 1, threadId: "thr_mcp_allowed" });
+    await expect(
+      callTool(
+        "update_conversation",
+        {
+          action: "archive",
+          activeFolder: "inbox",
+          messageId: "msg_mcp_allowed"
+        },
+        fullToken,
+        "/mcp/full"
+      )
+    ).resolves.toMatchObject({ affected: 1, threadId: "thr_mcp_allowed" });
+    await expect(
+      callTool(
+        "update_conversation",
+        {
+          action: "unarchive",
+          activeFolder: "archived",
+          messageId: "msg_mcp_allowed"
+        },
+        fullToken,
+        "/mcp/full"
+      )
+    ).resolves.toMatchObject({ affected: 1, threadId: "thr_mcp_allowed" });
   });
 });
 

--- a/test/integration/worker/oauth-device.test.ts
+++ b/test/integration/worker/oauth-device.test.ts
@@ -13,6 +13,15 @@ let ownerCookie = "";
 let ownerSessionId = "";
 let otherCookie = "";
 
+type OAuthTokenResponse = {
+  access_token: string;
+  expires_at: number;
+  expires_in: number;
+  refresh_token: string;
+  scope: string;
+  token_type: string;
+};
+
 describe("OAuth Device Authorization Grant", () => {
   beforeAll(async () => {
     await applyCurrentMigrations();
@@ -103,11 +112,7 @@ describe("OAuth Device Authorization Grant", () => {
       .run();
     const tokenResponse = await pollToken(authorization.device_code);
     expect(tokenResponse.status, await tokenResponse.clone().text()).toBe(200);
-    const token = (await tokenResponse.json()) as {
-      access_token?: string;
-      refresh_token?: string;
-      scope?: string;
-    };
+    const token = (await tokenResponse.json()) as OAuthTokenResponse;
     expect(token.access_token).toMatch(/^hqb_access_/);
     expect(token.refresh_token).toMatch(/^hqb_refresh_/);
     expect(token.scope?.split(" ")).toEqual(
@@ -141,17 +146,18 @@ describe("OAuth Device Authorization Grant", () => {
     if (!token.refresh_token) throw new Error("Refresh token was not issued.");
     const rotatedResponse = await refreshToken(token.refresh_token);
     expect(rotatedResponse.status, await rotatedResponse.clone().text()).toBe(200);
-    const rotated = (await rotatedResponse.json()) as {
-      access_token?: string;
-      refresh_token?: string;
-      scope?: string;
-    };
+    const rotated = (await rotatedResponse.json()) as OAuthTokenResponse;
     expect(rotated.access_token).toMatch(/^hqb_access_/);
     expect(rotated.refresh_token).toMatch(/^hqb_refresh_/);
 
     const concurrentReplay = await refreshToken(token.refresh_token);
     expect(concurrentReplay.status, await concurrentReplay.clone().text()).toBe(200);
-    await expect(concurrentReplay.json()).resolves.toEqual(rotated);
+    const replayed = (await concurrentReplay.json()) as OAuthTokenResponse;
+    const { expires_in: rotatedExpiresIn, ...rotatedStable } = rotated;
+    const { expires_in: replayedExpiresIn, ...replayedStable } = replayed;
+    expect(replayedStable).toEqual(rotatedStable);
+    expect(replayedExpiresIn).toBeGreaterThan(0);
+    expect(replayedExpiresIn).toBeLessThanOrEqual(rotatedExpiresIn);
 
     await env.DB.prepare(
       `UPDATE oauthRefreshToken

--- a/test/integration/worker/oauth-device.test.ts
+++ b/test/integration/worker/oauth-device.test.ts
@@ -138,6 +138,36 @@ describe("OAuth Device Authorization Grant", () => {
     expect(api.status, await api.clone().text()).toBe(200);
     await expect(api.json()).resolves.toEqual([]);
 
+    if (!token.refresh_token) throw new Error("Refresh token was not issued.");
+    const rotatedResponse = await refreshToken(token.refresh_token);
+    expect(rotatedResponse.status, await rotatedResponse.clone().text()).toBe(200);
+    const rotated = (await rotatedResponse.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      scope?: string;
+    };
+    expect(rotated.access_token).toMatch(/^hqb_access_/);
+    expect(rotated.refresh_token).toMatch(/^hqb_refresh_/);
+
+    const concurrentReplay = await refreshToken(token.refresh_token);
+    expect(concurrentReplay.status, await concurrentReplay.clone().text()).toBe(200);
+    await expect(concurrentReplay.json()).resolves.toEqual(rotated);
+
+    await env.DB.prepare(
+      `UPDATE oauthRefreshToken
+       SET rotationReplayExpiresAt = ?
+       WHERE sessionId = ? AND rotatedAt IS NOT NULL`
+    )
+      .bind("2000-01-01T00:00:00.000Z", ownerSessionId)
+      .run();
+    const lateReplay = await refreshToken(token.refresh_token);
+    expect(lateReplay.status).toBe(400);
+    await expect(lateReplay.json()).resolves.toMatchObject({ error: "invalid_grant" });
+    if (!rotated.refresh_token) throw new Error("Rotated refresh token was not issued.");
+    const invalidatedFamily = await refreshToken(rotated.refresh_token);
+    expect(invalidatedFamily.status).toBe(400);
+    await expect(invalidatedFamily.json()).resolves.toMatchObject({ error: "invalid_grant" });
+
     const replay = await pollToken(authorization.device_code);
     expect(replay.status).toBe(400);
     await expect(replay.json()).resolves.toMatchObject({ error: "invalid_grant" });
@@ -273,6 +303,19 @@ function pollToken(deviceCode: string): Promise<Response> {
       client_id: clientId,
       device_code: deviceCode,
       grant_type: deviceCodeGrantType,
+      resource: apiResource
+    }),
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    method: "POST"
+  });
+}
+
+function refreshToken(token: string): Promise<Response> {
+  return SELF.fetch(`${origin}/api/auth/oauth2/token`, {
+    body: new URLSearchParams({
+      client_id: clientId,
+      grant_type: "refresh_token",
+      refresh_token: token,
       resource: apiResource
     }),
     headers: { "content-type": "application/x-www-form-urlencoded" },

--- a/test/unit/app/messages/conversation-reader.test.tsx
+++ b/test/unit/app/messages/conversation-reader.test.tsx
@@ -108,6 +108,27 @@ describe("conversation reader", () => {
     expect(html).not.toContain('aria-label="Trash conversation"');
   });
 
+  it("offers unarchive and trash in Archived", () => {
+    const html = renderToStaticMarkup(
+      <MessageDetail
+        activeFolder="archived"
+        defaultFromMailboxId="mbx_1"
+        mailboxes={[]}
+        messages={[{ ...firstMessage, folder: "archived" }]}
+        selectedId={firstMessage.id}
+        onAction={() => undefined}
+        onBack={() => undefined}
+        onRefresh={() => undefined}
+        onSent={() => undefined}
+      />
+    );
+
+    expect(html).toContain('aria-label="Unarchive conversation"');
+    expect(html).toContain('aria-label="Trash conversation"');
+    expect(html).not.toContain('aria-label="Archive conversation"');
+    expect(html).not.toContain('aria-label="Restore conversation"');
+  });
+
   it("uses list-only and conversation-only compact states", () => {
     const listHtml = renderToStaticMarkup(
       <InboxPage

--- a/test/unit/app/messages/conversation-reader.test.tsx
+++ b/test/unit/app/messages/conversation-reader.test.tsx
@@ -88,6 +88,26 @@ describe("conversation reader", () => {
     expect(html).toContain('aria-label="Archive conversation"');
   });
 
+  it("offers restore instead of archive and trash in Trash", () => {
+    const html = renderToStaticMarkup(
+      <MessageDetail
+        activeFolder="trash"
+        defaultFromMailboxId="mbx_1"
+        mailboxes={[]}
+        messages={[{ ...firstMessage, folder: "trash" }]}
+        selectedId={firstMessage.id}
+        onAction={() => undefined}
+        onBack={() => undefined}
+        onRefresh={() => undefined}
+        onSent={() => undefined}
+      />
+    );
+
+    expect(html).toContain('aria-label="Restore conversation"');
+    expect(html).not.toContain('aria-label="Archive conversation"');
+    expect(html).not.toContain('aria-label="Trash conversation"');
+  });
+
   it("uses list-only and conversation-only compact states", () => {
     const listHtml = renderToStaticMarkup(
       <InboxPage

--- a/test/unit/app/messages/use-mail-sync.test.tsx
+++ b/test/unit/app/messages/use-mail-sync.test.tsx
@@ -206,9 +206,16 @@ describe("useMailSync", () => {
   });
 
   it("reconciles conversation actions across every loaded page", async () => {
-    const conversations = ["read", "unread", "star", "unstar", "archive", "trash", "restore"].map(
-      (action, index) => conversation(`message-${action}`, `2026-07-30T1${index}:00:00.000Z`)
-    );
+    const conversations = [
+      "read",
+      "unread",
+      "star",
+      "unstar",
+      "archive",
+      "unarchive",
+      "trash",
+      "restore"
+    ].map((action, index) => conversation(`message-${action}`, `2026-07-30T1${index}:00:00.000Z`));
     mocks.listConversations.mockResolvedValueOnce({
       conversations,
       nextCursor: null,
@@ -229,6 +236,7 @@ describe("useMailSync", () => {
       hook.result.applyConversationAction("thread-message-star", "star", 1);
       hook.result.applyConversationAction("thread-message-unstar", "unstar", 1);
       hook.result.applyConversationAction("thread-message-archive", "archive", 1);
+      hook.result.applyConversationAction("thread-message-unarchive", "unarchive", 1);
       hook.result.applyConversationAction("thread-message-trash", "trash", 1);
       hook.result.applyConversationAction("thread-message-restore", "restore", 1);
       hook.result.applyConversationAction("thread-missing", "read", 0);

--- a/test/unit/app/messages/use-mail-sync.test.tsx
+++ b/test/unit/app/messages/use-mail-sync.test.tsx
@@ -206,7 +206,7 @@ describe("useMailSync", () => {
   });
 
   it("reconciles conversation actions across every loaded page", async () => {
-    const conversations = ["read", "unread", "star", "unstar", "archive", "trash"].map(
+    const conversations = ["read", "unread", "star", "unstar", "archive", "trash", "restore"].map(
       (action, index) => conversation(`message-${action}`, `2026-07-30T1${index}:00:00.000Z`)
     );
     mocks.listConversations.mockResolvedValueOnce({
@@ -230,6 +230,7 @@ describe("useMailSync", () => {
       hook.result.applyConversationAction("thread-message-unstar", "unstar", 1);
       hook.result.applyConversationAction("thread-message-archive", "archive", 1);
       hook.result.applyConversationAction("thread-message-trash", "trash", 1);
+      hook.result.applyConversationAction("thread-message-restore", "restore", 1);
       hook.result.applyConversationAction("thread-missing", "read", 0);
     });
 

--- a/test/unit/scripts/mail-api-artifacts.test.mjs
+++ b/test/unit/scripts/mail-api-artifacts.test.mjs
@@ -33,7 +33,7 @@ describe("Mail API public artifacts", () => {
       openApi.paths["/api/v1/messages/{id}/{action}"].post.parameters.find(
         (parameter) => parameter.name === "action"
       ).schema.enum
-    ).toContain("restore");
+    ).toEqual(expect.arrayContaining(["restore", "unarchive"]));
     expect(
       openApi.paths["/api/v1/drafts/{id}/attachments"].post.requestBody.content[
         "multipart/form-data"

--- a/test/unit/scripts/mail-api-artifacts.test.mjs
+++ b/test/unit/scripts/mail-api-artifacts.test.mjs
@@ -26,6 +26,19 @@ describe("Mail API public artifacts", () => {
     expect(openApi.paths["/api/v1/send"].post.security).toContainEqual({
       oauth2: ["mail:send"]
     });
+    expect(openApi.paths["/api/v1/forward"].post.security).toContainEqual({
+      oauth2: ["mail:send"]
+    });
+    expect(
+      openApi.paths["/api/v1/messages/{id}/{action}"].post.parameters.find(
+        (parameter) => parameter.name === "action"
+      ).schema.enum
+    ).toContain("restore");
+    expect(
+      openApi.paths["/api/v1/drafts/{id}/attachments"].post.requestBody.content[
+        "multipart/form-data"
+      ].encoding.file.contentType
+    ).toBe("*/*");
     expect(openApi.paths["/api/v1/users"]).toBeUndefined();
     expect(JSON.stringify(openApi)).not.toContain("r2Key");
   });

--- a/test/unit/worker/features/messages/message-actions.test.ts
+++ b/test/unit/worker/features/messages/message-actions.test.ts
@@ -17,23 +17,25 @@ describe("buildMessageActionPatch", () => {
     expect(buildMessageActionPatch("trash", "now", inbound)).toMatchObject({ folder: "trash" });
   });
 
-  it("restores each message kind to its active folder", () => {
-    expect(buildMessageActionPatch("restore", "now", inbound)).toEqual({
-      archivedAt: null,
-      folder: "inbox",
-      trashedAt: null
-    });
-    expect(
-      buildMessageActionPatch("restore", "now", {
-        direction: "outbound",
-        isUnassigned: false
-      })
-    ).toMatchObject({ folder: "sent" });
-    expect(
-      buildMessageActionPatch("restore", "now", {
-        direction: "inbound",
-        isUnassigned: true
-      })
-    ).toMatchObject({ folder: "catchall" });
+  it("returns unarchived and restored messages to their active folders", () => {
+    for (const action of ["unarchive", "restore"] as const) {
+      expect(buildMessageActionPatch(action, "now", inbound)).toEqual({
+        archivedAt: null,
+        folder: "inbox",
+        trashedAt: null
+      });
+      expect(
+        buildMessageActionPatch(action, "now", {
+          direction: "outbound",
+          isUnassigned: false
+        })
+      ).toMatchObject({ folder: "sent" });
+      expect(
+        buildMessageActionPatch(action, "now", {
+          direction: "inbound",
+          isUnassigned: true
+        })
+      ).toMatchObject({ folder: "catchall" });
+    }
   });
 });

--- a/test/unit/worker/features/messages/message-actions.test.ts
+++ b/test/unit/worker/features/messages/message-actions.test.ts
@@ -2,13 +2,38 @@ import { buildMessageActionPatch } from "@worker/features/messages/actions";
 import { describe, expect, it } from "vitest";
 
 describe("buildMessageActionPatch", () => {
+  const inbound = { direction: "inbound" as const, isUnassigned: false };
+
   it("marks messages read and unread", () => {
-    expect(buildMessageActionPatch("read", "now")).toEqual({ readAt: "now" });
-    expect(buildMessageActionPatch("unread", "now")).toEqual({ readAt: null });
+    expect(buildMessageActionPatch("read", "now", inbound)).toEqual({ readAt: "now" });
+    expect(buildMessageActionPatch("unread", "now", inbound)).toEqual({ readAt: null });
   });
 
   it("moves archive and trash folders", () => {
-    expect(buildMessageActionPatch("archive", "now")).toMatchObject({ folder: "archived" });
-    expect(buildMessageActionPatch("trash", "now")).toMatchObject({ folder: "trash" });
+    expect(buildMessageActionPatch("archive", "now", inbound)).toMatchObject({
+      folder: "archived",
+      trashedAt: null
+    });
+    expect(buildMessageActionPatch("trash", "now", inbound)).toMatchObject({ folder: "trash" });
+  });
+
+  it("restores each message kind to its active folder", () => {
+    expect(buildMessageActionPatch("restore", "now", inbound)).toEqual({
+      archivedAt: null,
+      folder: "inbox",
+      trashedAt: null
+    });
+    expect(
+      buildMessageActionPatch("restore", "now", {
+        direction: "outbound",
+        isUnassigned: false
+      })
+    ).toMatchObject({ folder: "sent" });
+    expect(
+      buildMessageActionPatch("restore", "now", {
+        direction: "inbound",
+        isUnassigned: true
+      })
+    ).toMatchObject({ folder: "catchall" });
   });
 });

--- a/worker/auth/auth.ts
+++ b/worker/auth/auth.ts
@@ -95,6 +95,7 @@ export function createAuth(
         disableJwtPlugin: true,
         grantTypes: ["authorization_code", "refresh_token"],
         loginPage: "/",
+        refreshTokenReuseInterval: 30,
         prefix: {
           clientSecret: "hqb_client_",
           opaqueAccessToken: "hqb_access_",

--- a/worker/features/mail-api/discovery.ts
+++ b/worker/features/mail-api/discovery.ts
@@ -118,8 +118,8 @@ Use this exact OAuth resource and token audience: \`${apiBase}\`. MCP uses separ
 ## Permissions
 
 - \`mail:read\` — List visible mailboxes and conversations, search and open messages, render message HTML, and download attachments.
-- \`mail:write\` — Mark mail read or unread, add or remove stars, archive mail, move mail to Trash, and trust remote images from a sender.
-- \`mail:send\` — Create and manage drafts and attachments, send new messages, and reply.
+- \`mail:write\` — Mark mail read or unread, add or remove stars, archive mail, move mail to Trash, restore mail, and trust remote images from a sender.
+- \`mail:send\` — Create and manage drafts and attachments, send new messages, reply, and forward.
 - \`offline_access\` — Request an optional refresh token. This is not an API endpoint permission.
 
 OAuth permissions do not override HQBase mailbox access. The connected person must also have the necessary Read or Agent mailbox grant. This API never grants Manager access.
@@ -140,8 +140,8 @@ The method index is an orientation aid. Consult ${openApiUrl} for exact paramete
 - Ignore response fields you do not recognize.
 - Do not log access tokens, refresh tokens, message bodies, or attachments.
 - Do not log device codes or user codes, and do not paste them into unrelated chats or tools.
-- Do not send or reply unless that external action matches the person's request.
-- Sending and replying are not idempotent. Never retry them blindly.
+- Do not send, reply, or forward unless that external action matches the person's request.
+- Sending, replying, and forwarding are not idempotent. Never retry them blindly.
 - Use the returned draft version when updating a draft so newer work is not overwritten.
 - A \`410 CHANGE_CURSOR_EXPIRED\` response requires a new full message bootstrap.
 
@@ -151,7 +151,7 @@ JSON errors contain a stable \`error.code\` and human-readable \`error.message\`
 
 ## API boundary and stability
 
-The Mail API covers mailboxes, messages, conversations, attachments, drafts, sending, and replying. It does not manage people, mailbox grants, domains, setup, updates, audits, sessions, notifications, app secrets, or Cloudflare credentials.
+The Mail API covers mailboxes, messages, conversations, attachments, drafts, sending, replying, and forwarding. It does not manage people, mailbox grants, domains, setup, updates, audits, sessions, notifications, app secrets, or Cloudflare credentials.
 
 \`/api/v1\` is HQBase's stable public Mail API. Additive fields and endpoints may appear, so ignore unknown response fields. Breaking changes use a new versioned base path such as \`/api/v2\`.
 `;

--- a/worker/features/mail-api/discovery.ts
+++ b/worker/features/mail-api/discovery.ts
@@ -118,7 +118,7 @@ Use this exact OAuth resource and token audience: \`${apiBase}\`. MCP uses separ
 ## Permissions
 
 - \`mail:read\` — List visible mailboxes and conversations, search and open messages, render message HTML, and download attachments.
-- \`mail:write\` — Mark mail read or unread, add or remove stars, archive mail, move mail to Trash, restore mail, and trust remote images from a sender.
+- \`mail:write\` — Mark mail read or unread, add or remove stars, archive or unarchive mail, move mail to Trash, restore mail, and trust remote images from a sender.
 - \`mail:send\` — Create and manage drafts and attachments, send new messages, reply, and forward.
 - \`offline_access\` — Request an optional refresh token. This is not an API endpoint permission.
 

--- a/worker/features/mcp/mail-tools.ts
+++ b/worker/features/mcp/mail-tools.ts
@@ -21,7 +21,15 @@ import { conversationFolders } from "../messages/types";
 import type { McpPrincipal } from "./route";
 import { attachmentResult, toolResult } from "./tool-result";
 
-const messageActionSchema = z.enum(["read", "unread", "star", "unstar", "archive", "trash"]);
+const messageActionSchema = z.enum([
+  "read",
+  "unread",
+  "star",
+  "unstar",
+  "archive",
+  "trash",
+  "restore"
+]);
 const conversationFolderSchema = z.enum(conversationFolders);
 
 export function registerMailTools(
@@ -172,7 +180,7 @@ function registerWriteTools(server: McpServer, env: WorkerEnv, principal: McpPri
   server.registerTool(
     "update_message",
     {
-      description: "Change read, starred, archived, or trash state for one permitted message.",
+      description: "Change read, starred, archived, trash, or restored state for one message.",
       inputSchema: {
         action: messageActionSchema,
         messageId: z.string().min(1).max(100)
@@ -192,7 +200,7 @@ function registerWriteTools(server: McpServer, env: WorkerEnv, principal: McpPri
     "update_conversation",
     {
       description:
-        "Change read, starred, archived, or trash state across one permitted conversation.",
+        "Change read, starred, archived, trash, or restored state across one conversation.",
       inputSchema: {
         action: messageActionSchema,
         activeFolder: conversationFolderSchema,

--- a/worker/features/mcp/mail-tools.ts
+++ b/worker/features/mcp/mail-tools.ts
@@ -27,6 +27,7 @@ const messageActionSchema = z.enum([
   "star",
   "unstar",
   "archive",
+  "unarchive",
   "trash",
   "restore"
 ]);
@@ -180,7 +181,8 @@ function registerWriteTools(server: McpServer, env: WorkerEnv, principal: McpPri
   server.registerTool(
     "update_message",
     {
-      description: "Change read, starred, archived, trash, or restored state for one message.",
+      description:
+        "Change read, starred, archived, unarchived, trash, or restored state for one message.",
       inputSchema: {
         action: messageActionSchema,
         messageId: z.string().min(1).max(100)
@@ -200,7 +202,7 @@ function registerWriteTools(server: McpServer, env: WorkerEnv, principal: McpPri
     "update_conversation",
     {
       description:
-        "Change read, starred, archived, trash, or restored state across one conversation.",
+        "Change read, starred, archived, unarchived, trash, or restored state across one conversation.",
       inputSchema: {
         action: messageActionSchema,
         activeFolder: conversationFolderSchema,

--- a/worker/features/messages/actions.ts
+++ b/worker/features/messages/actions.ts
@@ -1,6 +1,6 @@
-import type { MessageFolder } from "./types";
+import type { MessageDirection, MessageFolder } from "./types";
 
-export type MessageAction = "read" | "unread" | "star" | "unstar" | "archive" | "trash";
+export type MessageAction = "read" | "unread" | "star" | "unstar" | "archive" | "trash" | "restore";
 
 export type MessageActionPatch = {
   folder?: MessageFolder;
@@ -12,7 +12,8 @@ export type MessageActionPatch = {
 
 export function buildMessageActionPatch(
   action: MessageAction,
-  timestamp: string
+  timestamp: string,
+  current: { direction: MessageDirection; isUnassigned: boolean }
 ): MessageActionPatch {
   switch (action) {
     case "read":
@@ -24,8 +25,18 @@ export function buildMessageActionPatch(
     case "unstar":
       return { starredAt: null };
     case "archive":
-      return { archivedAt: timestamp, folder: "archived" };
+      return { archivedAt: timestamp, folder: "archived", trashedAt: null };
     case "trash":
       return { trashedAt: timestamp, folder: "trash" };
+    case "restore":
+      return {
+        archivedAt: null,
+        folder: current.isUnassigned
+          ? "catchall"
+          : current.direction === "outbound"
+            ? "sent"
+            : "inbox",
+        trashedAt: null
+      };
   }
 }

--- a/worker/features/messages/actions.ts
+++ b/worker/features/messages/actions.ts
@@ -1,6 +1,14 @@
 import type { MessageDirection, MessageFolder } from "./types";
 
-export type MessageAction = "read" | "unread" | "star" | "unstar" | "archive" | "trash" | "restore";
+export type MessageAction =
+  | "read"
+  | "unread"
+  | "star"
+  | "unstar"
+  | "archive"
+  | "unarchive"
+  | "trash"
+  | "restore";
 
 export type MessageActionPatch = {
   folder?: MessageFolder;
@@ -28,6 +36,7 @@ export function buildMessageActionPatch(
       return { archivedAt: timestamp, folder: "archived", trashedAt: null };
     case "trash":
       return { trashedAt: timestamp, folder: "trash" };
+    case "unarchive":
     case "restore":
       return {
         archivedAt: null,

--- a/worker/features/messages/conversation-queries.ts
+++ b/worker/features/messages/conversation-queries.ts
@@ -204,6 +204,17 @@ export async function updateConversationAction(
         bindings.push(input.activeFolder);
       }
       break;
+    case "restore":
+      set = `folder = CASE
+               WHEN mailbox_id IS NULL THEN 'catchall'
+               WHEN direction = 'outbound' THEN 'sent'
+               ELSE 'inbox'
+             END,
+             archived_at = NULL, trashed_at = NULL, updated_at = ?`;
+      bindings.unshift(timestamp);
+      where.push("folder = 'trash'");
+      if (input.activeFolder !== "trash") where.push("1 = 0");
+      break;
   }
 
   const result = await db

--- a/worker/features/messages/conversation-queries.ts
+++ b/worker/features/messages/conversation-queries.ts
@@ -194,6 +194,17 @@ export async function updateConversationAction(
       bindings.unshift(timestamp, timestamp);
       where.push("folder IN ('inbox', 'catchall')");
       break;
+    case "unarchive":
+      set = `folder = CASE
+               WHEN mailbox_id IS NULL THEN 'catchall'
+               WHEN direction = 'outbound' THEN 'sent'
+               ELSE 'inbox'
+             END,
+             archived_at = NULL, trashed_at = NULL, updated_at = ?`;
+      bindings.unshift(timestamp);
+      where.push("folder = 'archived'");
+      if (input.activeFolder !== "archived") where.push("1 = 0");
+      break;
     case "trash":
       set = "folder = 'trash', trashed_at = ?, updated_at = ?";
       bindings.unshift(timestamp, timestamp);

--- a/worker/features/messages/conversation-routes.ts
+++ b/worker/features/messages/conversation-routes.ts
@@ -11,7 +11,15 @@ import { conversationFolders } from "./types";
 
 export const conversationRoutes = new Hono<HonoApp>();
 
-const actions: readonly MessageAction[] = ["read", "unread", "star", "unstar", "archive", "trash"];
+const actions: readonly MessageAction[] = [
+  "read",
+  "unread",
+  "star",
+  "unstar",
+  "archive",
+  "trash",
+  "restore"
+];
 const folderSchema = z.enum(conversationFolders);
 const cursorSchema = z.string().min(1).max(512).optional();
 const actionBodySchema = z.object({ folder: folderSchema });

--- a/worker/features/messages/conversation-routes.ts
+++ b/worker/features/messages/conversation-routes.ts
@@ -17,6 +17,7 @@ const actions: readonly MessageAction[] = [
   "star",
   "unstar",
   "archive",
+  "unarchive",
   "trash",
   "restore"
 ];

--- a/worker/features/messages/queries.ts
+++ b/worker/features/messages/queries.ts
@@ -263,9 +263,15 @@ export async function updateMessageAction(
   if (!current) {
     throw new AppError("MESSAGE_NOT_FOUND", "Message not found.", 404);
   }
+  if (action === "restore" && current.folder !== "trash") {
+    return mapMessageSummary(current);
+  }
 
   const timestamp = nowIso();
-  const patch = buildMessageActionPatch(action, timestamp);
+  const patch = buildMessageActionPatch(action, timestamp, {
+    direction: current.direction,
+    isUnassigned: current.is_unassigned === 1
+  });
   await db
     .prepare(
       `UPDATE messages

--- a/worker/features/messages/queries.ts
+++ b/worker/features/messages/queries.ts
@@ -263,7 +263,10 @@ export async function updateMessageAction(
   if (!current) {
     throw new AppError("MESSAGE_NOT_FOUND", "Message not found.", 404);
   }
-  if (action === "restore" && current.folder !== "trash") {
+  if (
+    (action === "unarchive" && current.folder !== "archived") ||
+    (action === "restore" && current.folder !== "trash")
+  ) {
     return mapMessageSummary(current);
   }
 

--- a/worker/features/messages/routes.ts
+++ b/worker/features/messages/routes.ts
@@ -31,6 +31,7 @@ const actions: readonly MessageAction[] = [
   "star",
   "unstar",
   "archive",
+  "unarchive",
   "trash",
   "restore"
 ];

--- a/worker/features/messages/routes.ts
+++ b/worker/features/messages/routes.ts
@@ -25,7 +25,15 @@ export { isSafeInlineImage } from "./inline-media";
 
 export const messageRoutes = new Hono<HonoApp>();
 
-const actions: readonly MessageAction[] = ["read", "unread", "star", "unstar", "archive", "trash"];
+const actions: readonly MessageAction[] = [
+  "read",
+  "unread",
+  "star",
+  "unstar",
+  "archive",
+  "trash",
+  "restore"
+];
 
 messageRoutes.get("/", async (c) => {
   const auth = await requireMailApiContext(c.env, c.req.raw, "mail:read");

--- a/worker/features/send/routes.ts
+++ b/worker/features/send/routes.ts
@@ -11,8 +11,9 @@ import { requireDraftAttachmentIdsAccess, requireDraftIdAccess } from "../drafts
 import { findMailboxForSending } from "../mailboxes/queries";
 import { requireMessageAccess } from "../messages/access";
 
+import { forwardMessage } from "./forward";
 import { replyToMessage, sendNewMessage } from "./service";
-import { replyMessageSchema, sendMessageSchema } from "./validation";
+import { forwardMessageSchema, replyMessageSchema, sendMessageSchema } from "./validation";
 
 export const sendRoutes = new Hono<HonoApp>();
 
@@ -27,7 +28,7 @@ sendRoutes.post("/send", async (c) => {
   const input = parseWith(sendMessageSchema, await readJson(c.req.raw));
   const mailbox = await findMailboxForSending(c.env.DB, input.from);
   if (!mailbox) throw new AppError("MAILBOX_NOT_FOUND", "Sending mailbox not found.", 404);
-  await requireMessageAccess(
+  await requireMailboxAccess(
     c.env.DB,
     authContext.user.id,
     authContext.user.role,
@@ -59,7 +60,7 @@ sendRoutes.post("/reply", async (c) => {
     windowSeconds: 60
   });
   const input = parseWith(replyMessageSchema, await readJson(c.req.raw));
-  await requireMailboxAccess(
+  await requireMessageAccess(
     c.env.DB,
     authContext.user.id,
     authContext.user.role,
@@ -84,6 +85,46 @@ sendRoutes.post("/reply", async (c) => {
     actorType: "user",
     actorId: authContext.user.id,
     action: "message.reply",
+    resourceType: "mailbox",
+    resourceId: mailbox.id,
+    outcome: "success"
+  });
+  return c.json(sent, 201);
+});
+
+sendRoutes.post("/forward", async (c) => {
+  const authContext = await requireMailApiContext(c.env, c.req.raw, "mail:send");
+  await enforceRateLimit(c.env.DB, c.env.BETTER_AUTH_SECRET, {
+    scope: "mail.forward",
+    subject: authContext.user.id,
+    limit: 60,
+    windowSeconds: 60
+  });
+  const input = parseWith(forwardMessageSchema, await readJson(c.req.raw));
+  await requireMessageAccess(
+    c.env.DB,
+    authContext.user.id,
+    authContext.user.role,
+    input.messageId,
+    "agent"
+  );
+  const mailbox = await findMailboxForSending(c.env.DB, input.from);
+  if (!mailbox) throw new AppError("MAILBOX_NOT_FOUND", "Sending mailbox not found.", 404);
+  await requireMailboxAccess(
+    c.env.DB,
+    authContext.user.id,
+    authContext.user.role,
+    mailbox.id,
+    "agent"
+  );
+  const principal = { role: authContext.user.role, userId: authContext.user.id };
+  await requireDraftAttachmentIdsAccess(c.env, principal, input.attachmentIds);
+  const sent = await forwardMessage(c.env, input, authContext.user.id);
+  await recordAudit(c.env.DB, {
+    correlationId: c.get("correlationId"),
+    actorType: "user",
+    actorId: authContext.user.id,
+    action: "message.forward",
     resourceType: "mailbox",
     resourceId: mailbox.id,
     outcome: "success"

--- a/worker/features/send/routes.ts
+++ b/worker/features/send/routes.ts
@@ -9,6 +9,7 @@ import { enforceRateLimit } from "../../security/rate-limit";
 import { recordAudit } from "../audit/service";
 import { requireDraftAttachmentIdsAccess, requireDraftIdAccess } from "../drafts/access";
 import { findMailboxForSending } from "../mailboxes/queries";
+import { requireMessageAccess } from "../messages/access";
 
 import { forwardMessage } from "./forward";
 import { replyToMessage, sendNewMessage } from "./service";


### PR DESCRIPTION
## Summary

- allow refresh-token reuse during the configured rotation window
- restore trashed messages and conversations to their correct system mailbox
- unarchive messages and conversations through REST, MCP, and the Archived UI
- preserve attachment MIME types in the multipart API contract and round-trip handling
- add the Forward API, MCP support, UI actions, access checks, audit records, and attachment forwarding
- correct the sender and source-message authorization checks used by send and reply

## Root cause and impact

Refresh retries could invalidate a token family, restore and unarchive behavior was missing, the multipart contract did not declare arbitrary file MIME types, and forwarding was not available through the public API. The send and reply routes also checked access against the wrong resource identifiers.

These changes make the affected workflows consistent across the REST API, MCP tools, generated artifacts, UI, and tests.

## Validation

- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-mail-api-unarchive-check.log pnpm check`
- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-mail-api-unarchive-dry-run.log pnpm deploy:dry-run`
- 371 unit tests passed; 2 skipped
- 85 Worker integration tests passed

Closes #41
Closes #42
Closes #45
Closes #46
