### PR TITLE
fix: reopen reply drafts with their conversation

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -64,6 +64,9 @@ export function App(): React.ReactElement {
     selectedDraftId === null
       ? null
       : (draftState.drafts.find((draft) => draft.id === selectedDraftId) ?? null);
+  const selectedDraftHasContext = Boolean(
+    selectedDraft?.replyToMessageId ?? selectedDraft?.forwardOfMessageId
+  );
   const contentMailboxes = React.useMemo(
     () => mailboxes.filter((mailbox) => mailbox.accessLevel !== null),
     [mailboxes]
@@ -241,6 +244,24 @@ export function App(): React.ReactElement {
                 updateProgress={updateMonitor.progress}
                 updateStatus={updateMonitor.status}
               />
+            ) : activeFolder === "drafts" && selectedDraft && selectedDraftHasContext ? (
+              <React.Suspense
+                fallback={
+                  <div className="grid h-full place-items-center text-sm text-muted-foreground">
+                    Opening draft…
+                  </div>
+                }
+              >
+                <DraftComposeDialog
+                  draft={selectedDraft}
+                  mailboxes={contentMailboxes}
+                  onDraftsChange={() => void draftState.refresh().catch(() => undefined)}
+                  onOpenChange={(open) => {
+                    if (!open) navigate({ kind: "drafts", draftId: null });
+                  }}
+                  onSent={() => void mailSync.refresh().catch(() => undefined)}
+                />
+              </React.Suspense>
             ) : activeFolder === "drafts" ? (
               <DraftsPage
                 drafts={draftState.drafts}
@@ -290,7 +311,7 @@ export function App(): React.ReactElement {
           />
         </React.Suspense>
       ) : null}
-      {selectedDraft ? (
+      {selectedDraft && !selectedDraftHasContext ? (
         <React.Suspense fallback={null}>
           <DraftComposeDialog
             draft={selectedDraft}

--- a/app/features/compose/compose-dialog.tsx
+++ b/app/features/compose/compose-dialog.tsx
@@ -15,6 +15,7 @@ import { replyToMessage, sendMessage } from "./api";
 import { ComposeForm } from "./compose-form";
 import {
   type ComposeDialogProps,
+  composeContextLabel,
   composeTitle,
   type DraftSaveState,
   defaultSendingIdentity,
@@ -69,6 +70,7 @@ export function ComposeDialog({
   const formId = React.useId();
   const replyToMessageId = mode === "reply" ? (message?.id ?? null) : null;
   const forwardOfMessageId = mode === "forward" ? (message?.id ?? null) : null;
+  const contextLabel = composeContextLabel(mode, message);
   const recoveryKey = `hqbase:compose:${mode}:${draftId ?? message?.id ?? "new"}`;
   const { initializeAutosave, resetAutosave } = useDraftAutosave({
     open,
@@ -254,6 +256,7 @@ export function ComposeDialog({
       attachments={attachments}
       bcc={bcc}
       cc={cc}
+      contextLabel={contextLabel}
       formId={formId}
       from={from}
       html={html}

--- a/app/features/compose/compose-form.tsx
+++ b/app/features/compose/compose-form.tsx
@@ -15,6 +15,7 @@ type ComposeFormProps = {
   attachments: DraftAttachment[];
   bcc: string;
   cc: string;
+  contextLabel: string | null;
   formId: string;
   from: string;
   html: string;
@@ -56,6 +57,11 @@ export function ComposeForm(props: ComposeFormProps): React.ReactElement {
           onKeyDownCapture={(event) => submitComposeOnShortcut(event, props.sendDisabled)}
           onSubmit={props.onSubmit}
         >
+          {props.contextLabel ? (
+            <div className="border-b bg-muted/30 px-5 py-2 text-xs text-muted-foreground">
+              {props.contextLabel}
+            </div>
+          ) : null}
           <ComposeFields
             identities={props.identities}
             mode={props.mode}

--- a/app/features/compose/compose-state.ts
+++ b/app/features/compose/compose-state.ts
@@ -147,6 +147,16 @@ export function composeTitle(mode: ComposeMode): string {
   return mode === "reply" ? "Reply" : mode === "forward" ? "Forward" : "New message";
 }
 
+export function composeContextLabel(
+  mode: ComposeMode,
+  message: MessageDetail | null
+): string | null {
+  if (mode === "new" || !message) return null;
+  const timestamp = message.receivedAt ?? message.sentAt ?? message.createdAt;
+  const action = mode === "reply" ? "Replying to" : "Forwarding message from";
+  return `${action} ${message.fromAddress} · ${formatDateTime(timestamp)}`;
+}
+
 export function draftStatus(state: DraftSaveState): string {
   return state === "saving"
     ? "Saving draft…"

--- a/app/features/drafts/draft-compose-dialog.tsx
+++ b/app/features/drafts/draft-compose-dialog.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
+import { PiArrowLeft } from "react-icons/pi";
 
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { ComposeDialog } from "@/features/compose/compose-dialog";
 import type { ComposeMode } from "@/features/compose/compose-state";
-import { ComposeWindow } from "@/features/compose/compose-window";
 import type { Mailbox } from "@/features/mailboxes/types";
-import { getMessage } from "@/features/messages/api";
+import { getMessageThread } from "@/features/messages/api";
+import { ConversationMessages } from "@/features/messages/conversation-messages";
 import type { MessageDetail } from "@/features/messages/types";
 
 import { deleteDraft } from "./api";
@@ -33,23 +34,26 @@ export function DraftComposeDialog({
       ? "forward"
       : "new";
   const contextMessageId = draft.replyToMessageId ?? draft.forwardOfMessageId;
-  const [message, setMessage] = React.useState<MessageDetail | null>(null);
+  const [messages, setMessages] = React.useState<MessageDetail[]>([]);
   const [error, setError] = React.useState<string | null>(null);
   const [isDiscarding, setIsDiscarding] = React.useState(false);
 
   React.useEffect(() => {
     if (!contextMessageId) {
-      setMessage(null);
+      setMessages([]);
       setError(null);
       return;
     }
 
     let active = true;
-    setMessage(null);
+    setMessages([]);
     setError(null);
-    void getMessage(contextMessageId)
-      .then((nextMessage) => {
-        if (active) setMessage(nextMessage);
+    void getMessageThread(contextMessageId)
+      .then((nextMessages) => {
+        if (!nextMessages.some((message) => message.id === contextMessageId)) {
+          throw new Error("The message this draft targets is unavailable.");
+        }
+        if (active) setMessages(nextMessages);
       })
       .catch((reason: unknown) => {
         if (active) {
@@ -61,22 +65,120 @@ export function DraftComposeDialog({
     };
   }, [contextMessageId]);
 
-  if (contextMessageId && !message) {
+  if (!contextMessageId) {
     return (
-      <ComposeWindow
+      <ComposeDialog
+        draftId={draft.id}
+        mailboxes={mailboxes}
+        mode="new"
         open
-        status={error ? "Draft unavailable" : "Loading draft"}
-        title={mode === "reply" ? "Reply" : "Forward"}
+        onDraftsChange={onDraftsChange}
         onOpenChange={onOpenChange}
-      >
-        <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
-          {error ? (
-            <>
-              <div className="space-y-1">
-                <h2 className="text-sm font-medium">Draft context is unavailable</h2>
-                <p className="max-w-sm text-xs text-muted-foreground">{error}</p>
-              </div>
-              <Button size="sm" type="button" variant="outline" onClick={() => onOpenChange(false)}>
+        onSent={onSent}
+      />
+    );
+  }
+
+  const message = messages.find((candidate) => candidate.id === contextMessageId) ?? null;
+  if (!message) {
+    return (
+      <DraftContextStatus
+        error={error}
+        isDiscarding={isDiscarding}
+        subject={draft.subject}
+        onBack={() => onOpenChange(false)}
+        onDiscard={() => {
+          setIsDiscarding(true);
+          void deleteDraft(draft.id)
+            .then(() => {
+              onOpenChange(false);
+              onDraftsChange();
+            })
+            .catch((reason: unknown) => {
+              setError(reason instanceof Error ? reason.message : "Draft could not be discarded.");
+              setIsDiscarding(false);
+            });
+        }}
+      />
+    );
+  }
+
+  return (
+    <article className="flex h-full flex-col bg-reader">
+      <DraftThreadHeader subject={message.subject} onBack={() => onOpenChange(false)} />
+      <div className="min-h-0 flex-1 overflow-auto overscroll-contain">
+        <ConversationMessages messages={messages} />
+        <div className="px-4 pb-8 pt-2 sm:px-6">
+          <ComposeDialog
+            draftId={draft.id}
+            key={`${mode}:${message.id}:${draft.id}`}
+            mailboxes={mailboxes}
+            message={message}
+            mode={mode}
+            open
+            presentation="thread"
+            threadContext={<ConversationMessages compact messages={messages} />}
+            onDraftsChange={onDraftsChange}
+            onOpenChange={onOpenChange}
+            onSent={onSent}
+          />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function DraftThreadHeader({
+  subject,
+  onBack
+}: {
+  subject: string;
+  onBack: () => void;
+}): React.ReactElement {
+  return (
+    <div className="shrink-0 border-b border-divider bg-toolbar px-3 sm:px-5">
+      <div className="flex h-11 items-center gap-2 py-2">
+        <Button
+          aria-label="Back to drafts"
+          className="size-10 min-h-10 min-w-10 shrink-0 bg-transparent text-tertiary [@media(hover:hover)]:hover:bg-selected [@media(hover:hover)]:hover:text-foreground"
+          size="icon"
+          type="button"
+          variant="ghost"
+          onClick={onBack}
+        >
+          <PiArrowLeft aria-hidden="true" className="pointer-events-none size-3.5" />
+        </Button>
+        <h1 className="min-w-0 flex-1 truncate text-sm font-medium">{subject}</h1>
+      </div>
+    </div>
+  );
+}
+
+function DraftContextStatus({
+  error,
+  isDiscarding,
+  subject,
+  onBack,
+  onDiscard
+}: {
+  error: string | null;
+  isDiscarding: boolean;
+  subject: string;
+  onBack: () => void;
+  onDiscard: () => void;
+}): React.ReactElement {
+  return (
+    <article aria-busy={!error} className="flex h-full flex-col bg-reader">
+      <DraftThreadHeader subject={subject || "Draft"} onBack={onBack} />
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+        {error ? (
+          <>
+            <div className="space-y-1">
+              <h2 className="text-sm font-medium">Draft context is unavailable</h2>
+              <p className="max-w-sm text-xs text-muted-foreground">{error}</p>
+            </div>
+            <div className="flex flex-wrap justify-center gap-2">
+              <Button size="sm" type="button" variant="outline" onClick={onBack}>
                 Back to drafts
               </Button>
               <Button
@@ -84,45 +186,19 @@ export function DraftComposeDialog({
                 size="sm"
                 type="button"
                 variant="destructive"
-                onClick={() => {
-                  setIsDiscarding(true);
-                  void deleteDraft(draft.id)
-                    .then(() => {
-                      onOpenChange(false);
-                      onDraftsChange();
-                    })
-                    .catch((reason: unknown) => {
-                      setError(
-                        reason instanceof Error ? reason.message : "Draft could not be discarded."
-                      );
-                      setIsDiscarding(false);
-                    });
-                }}
+                onClick={onDiscard}
               >
                 {isDiscarding ? "Discarding…" : "Discard draft"}
               </Button>
-            </>
-          ) : (
-            <>
-              <Spinner />
-              <span className="text-xs text-muted-foreground">Loading draft…</span>
-            </>
-          )}
-        </div>
-      </ComposeWindow>
-    );
-  }
-
-  return (
-    <ComposeDialog
-      draftId={draft.id}
-      mailboxes={mailboxes}
-      message={message}
-      mode={mode}
-      open
-      onDraftsChange={onDraftsChange}
-      onOpenChange={onOpenChange}
-      onSent={onSent}
-    />
+            </div>
+          </>
+        ) : (
+          <>
+            <Spinner />
+            <span className="text-xs text-muted-foreground">Loading conversation…</span>
+          </>
+        )}
+      </div>
+    </article>
   );
 }

--- a/test/unit/app/compose/compose-state.test.ts
+++ b/test/unit/app/compose/compose-state.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  composeContextLabel,
   defaultSendingIdentity,
   findDraftForComposer,
   forwardedMessage,
@@ -168,6 +169,13 @@ describe("composer state", () => {
 
     expect(identity).toEqual({ mailboxId: "mbx_1", address: "alias@example.com" });
     expect(replyRecipients(inboundMessage)).toEqual(["sender@example.com"]);
+    expect(composeContextLabel("reply", inboundMessage)).toContain(
+      "Replying to sender@example.com ·"
+    );
+    expect(composeContextLabel("forward", inboundMessage)).toContain(
+      "Forwarding message from sender@example.com ·"
+    );
+    expect(composeContextLabel("new", inboundMessage)).toBeNull();
     expect(
       replyRecipients({
         ...inboundMessage,

--- a/test/unit/app/drafts/draft-compose-dialog.test.tsx
+++ b/test/unit/app/drafts/draft-compose-dialog.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment happy-dom
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Draft } from "@/features/drafts/types";
+import type { MessageDetail } from "@/features/messages/types";
+
+const mocks = vi.hoisted(() => ({
+  getMessageThread: vi.fn()
+}));
+
+vi.mock("@/features/messages/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/features/messages/api")>()),
+  getMessageThread: mocks.getMessageThread
+}));
+
+vi.mock("@/features/compose/compose-dialog", () => ({
+  ComposeDialog: (props: {
+    draftId: string;
+    message: MessageDetail;
+    presentation?: string;
+    threadContext?: ReactNode;
+  }) => (
+    <div
+      data-compose-draft-id={props.draftId}
+      data-compose-message-id={props.message.id}
+      data-compose-presentation={props.presentation}
+    >
+      {props.threadContext}
+    </div>
+  )
+}));
+
+vi.mock("@/features/messages/conversation-messages", () => ({
+  ConversationMessages: ({
+    compact = false,
+    messages
+  }: {
+    compact?: boolean;
+    messages: MessageDetail[];
+  }) => (
+    <div
+      data-conversation-compact={compact ? "true" : "false"}
+      data-conversation-message-ids={messages.map((message) => message.id).join(",")}
+    />
+  )
+}));
+
+import { DraftComposeDialog } from "@/features/drafts/draft-compose-dialog";
+import { flushHookEffects, renderComponent } from "../render-hook";
+
+const targetMessage: MessageDetail = {
+  id: "msg_target",
+  threadId: "thr_1",
+  mailboxId: "mbx_1",
+  direction: "inbound",
+  folder: "inbox",
+  fromAddress: "customer@example.com",
+  to: ["support@example.com"],
+  cc: [],
+  bcc: [],
+  deliveredToAddress: "support@example.com",
+  subject: "Account access",
+  snippet: "Please help",
+  textBody: "Please help.",
+  htmlAvailable: false,
+  messageId: "<target@example.com>",
+  inReplyTo: null,
+  references: [],
+  attachments: [],
+  receivedAt: "2026-08-18T14:00:00.000Z",
+  sentAt: null,
+  readAt: "2026-08-18T14:01:00.000Z",
+  starredAt: null,
+  hasAttachments: false,
+  createdAt: "2026-08-18T14:00:00.000Z"
+};
+
+const newerMessage: MessageDetail = {
+  ...targetMessage,
+  id: "msg_newer",
+  direction: "outbound",
+  folder: "sent",
+  fromAddress: "support@example.com",
+  to: ["customer@example.com"],
+  snippet: "Following up",
+  textBody: "Following up.",
+  messageId: "<newer@example.com>",
+  inReplyTo: "<target@example.com>",
+  references: ["<target@example.com>"],
+  receivedAt: null,
+  sentAt: "2026-08-18T14:05:00.000Z",
+  createdAt: "2026-08-18T14:05:00.000Z"
+};
+
+const draft: Draft = {
+  id: "draft_reply",
+  mailboxId: "mbx_1",
+  replyToMessageId: targetMessage.id,
+  forwardOfMessageId: null,
+  from: "support@example.com",
+  to: ["customer@example.com"],
+  cc: [],
+  bcc: [],
+  subject: "Re: Account access",
+  text: "Draft response",
+  html: "<p>Draft response</p>",
+  version: 2,
+  updatedAt: "2026-08-18T14:03:00.000Z",
+  attachments: []
+};
+
+beforeEach(() => {
+  mocks.getMessageThread.mockReset();
+});
+
+describe("reopening a contextual draft", () => {
+  it("shows the current conversation but keeps the exact saved reply target", async () => {
+    mocks.getMessageThread.mockResolvedValue([targetMessage, newerMessage]);
+
+    const view = await renderComponent(
+      <DraftComposeDialog
+        draft={draft}
+        mailboxes={[]}
+        onDraftsChange={() => undefined}
+        onOpenChange={() => undefined}
+        onSent={() => undefined}
+      />
+    );
+    await flushHookEffects();
+
+    expect(mocks.getMessageThread).toHaveBeenCalledWith(targetMessage.id);
+    const composer = view.container.querySelector("[data-compose-draft-id]");
+    expect(composer?.getAttribute("data-compose-draft-id")).toBe(draft.id);
+    expect(composer?.getAttribute("data-compose-message-id")).toBe(targetMessage.id);
+    expect(composer?.getAttribute("data-compose-presentation")).toBe("thread");
+
+    const conversations = view.container.querySelectorAll("[data-conversation-message-ids]");
+    expect(conversations).toHaveLength(2);
+    for (const conversation of conversations) {
+      expect(conversation.getAttribute("data-conversation-message-ids")).toBe(
+        "msg_target,msg_newer"
+      );
+    }
+
+    await view.unmount();
+  });
+
+  it("blocks the composer when the saved target is not in the accessible thread", async () => {
+    mocks.getMessageThread.mockResolvedValue([newerMessage]);
+
+    const view = await renderComponent(
+      <DraftComposeDialog
+        draft={draft}
+        mailboxes={[]}
+        onDraftsChange={() => undefined}
+        onOpenChange={() => undefined}
+        onSent={() => undefined}
+      />
+    );
+    await flushHookEffects();
+
+    expect(view.container.textContent).toContain("Draft context is unavailable");
+    expect(view.container.textContent).toContain("The message this draft targets is unavailable.");
+    expect(view.container.querySelector("[data-compose-draft-id]")).toBeNull();
+
+    await view.unmount();
+  });
+});

--- a/test/unit/app/layout/desktop-shell.test.ts
+++ b/test/unit/app/layout/desktop-shell.test.ts
@@ -5,6 +5,7 @@ const appShell = readFileSync(
   new URL("../../../../app/components/layout/app-shell.tsx", import.meta.url),
   "utf8"
 );
+const app = readFileSync(new URL("../../../../app/app.tsx", import.meta.url), "utf8");
 const desktopLayout = readFileSync(
   new URL("../../../../app/components/layout/desktop-layout.ts", import.meta.url),
   "utf8"
@@ -64,8 +65,11 @@ describe("desktop application shell", () => {
     expect(threadComposeSurface).not.toContain("createPortal(desktop");
   });
 
-  it("reopens Reply and Forward drafts in the fixed compose window", () => {
-    expect(draftComposeDialog).not.toContain('presentation={message ? "thread" : "window"}');
-    expect(draftComposeDialog).not.toContain("threadContext=");
+  it("reopens Reply and Forward drafts with their conversation", () => {
+    expect(app).toContain("selectedDraftHasContext");
+    expect(draftComposeDialog).toContain("getMessageThread(contextMessageId)");
+    expect(draftComposeDialog).toContain('presentation="thread"');
+    expect(draftComposeDialog).toContain("threadContext=");
+    expect(draftComposeDialog).toContain("draftId={draft.id}");
   });
 });


### PR DESCRIPTION
## Summary

- Reopen saved reply and forward drafts with their accessible conversation.
- Preserve the exact saved target and show a contextual label.
- Block the composer if the target is missing or inaccessible.
- Keep standalone behavior for new-message drafts.
- Add regression tests.

## Root cause

Drafts kept `replyToMessageId` or `forwardOfMessageId`, but the Drafts route fetched one target message and reopened a fixed compose window without the thread. The backend link remained, while the user interface lost its context.

## Documentation

- HQBase/hqbase-site#17

## Validation

- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-reply-drafts-check.log pnpm check`
- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-reply-drafts-dry-run.log pnpm deploy:dry-run`