### PR TITLE
Prepare HQBase 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,41 @@
 
 ## 1.2.0
 
+### New
+
 - Refresh the app with responsive rail and drawer navigation, canonical `/mail/*` routes, Inter
   typography, full-page conversation reading, and MCP and Agent Skill settings.
-- Add cursor pagination for message listings and a durable `/api/v1/changes` feed with bounded
-  pages, deletion tombstones, and access-change records for reliable client synchronization.
+- Add opaque cursor pagination for message listings, with stable ordering and bounded pages.
+- Add a durable `/api/v1/changes` feed with deletion tombstones and access-change records for
+  reliable client synchronization.
 - Make terminal installation and removal resumable with atomic resource checkpoints, live identity
   verification, preservation of reused resources, and fail-closed recovery for ambiguous state.
-- Keep unassigned catch-all mail owner-only while making it visible through REST, MCP, unread
-  counts, notifications, and the changes feed without exposing deleted-mailbox history.
-- Add forwarding, unarchive, and restore across the app, REST, and MCP; preserve attachment media
-  types; allow safe refresh-token retries; and correct access checks for sending and replies.
+- Add forward, unarchive, and restore actions across the app, REST, and MCP, including optional
+  forwarding of the original message's attachments.
+
+### Fixed
+
+- Fix catch-all messages being absent from conversations, REST, MCP, unread counts, push
+  notifications, and the changes feed. Catch-all mail remains owner-only, and messages from a
+  deleted mailbox do not become visible as catch-all mail.
+- Return restored and unarchived messages to Inbox, Sent, or Catch-all according to their direction
+  and assignment instead of moving every message to one folder.
 - Reopen saved reply and forward drafts with their accessible conversation, preserve the exact
   target, keep the composer visible, and block sending when the target is missing or inaccessible.
-- Block direct access to Better Auth admin endpoints and show the requesting OAuth client's ID and
-  homepage on the consent page so people can verify the client before approval.
-- Clarify native OAuth registration and conversation action identifiers in the generated Agent
-  Skill, OpenAPI document, and Postman collection.
+- Correct send, reply, and forward authorization so valid mailbox sends work and source-message
+  access is checked against the correct resource.
+- Allow refresh-token retries during the configured rotation window without invalidating the token
+  family.
+- Preserve attachment media types through draft upload and forwarding, and document the attachment
+  size limits in the public API contract.
+- Block direct HTTP access to Better Auth admin endpoints so an admin cannot promote themselves to
+  owner or replace an owner's password outside HQBase's owner-only controls.
+- Show the requesting OAuth client's ID and homepage on the consent page, and clarify native PKCE
+  registration so people can verify the client before approval.
+- Prevent Reply from addressing the workspace sender, repair compact Settings navigation, and wait
+  for mail actions to finish before showing success.
+- Clarify that conversation action routes take the conversation's latest message ID, not its thread
+  ID, in the Agent Skill, OpenAPI document, and Postman collection.
 
 ## 1.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.2.0
+
+- Refresh the app with responsive rail and drawer navigation, canonical `/mail/*` routes, Inter
+  typography, full-page conversation reading, and MCP and Agent Skill settings.
+- Add cursor pagination for message listings and a durable `/api/v1/changes` feed with bounded
+  pages, deletion tombstones, and access-change records for reliable client synchronization.
+- Make terminal installation and removal resumable with atomic resource checkpoints, live identity
+  verification, preservation of reused resources, and fail-closed recovery for ambiguous state.
+- Keep unassigned catch-all mail owner-only while making it visible through REST, MCP, unread
+  counts, notifications, and the changes feed without exposing deleted-mailbox history.
+- Add forwarding, unarchive, and restore across the app, REST, and MCP; preserve attachment media
+  types; allow safe refresh-token retries; and correct access checks for sending and replies.
+- Reopen saved reply and forward drafts with their accessible conversation, preserve the exact
+  target, keep the composer visible, and block sending when the target is missing or inaccessible.
+- Block direct access to Better Auth admin endpoints and show the requesting OAuth client's ID and
+  homepage on the consent page so people can verify the client before approval.
+- Clarify native OAuth registration and conversation action identifiers in the generated Agent
+  Skill, OpenAPI document, and Postman collection.
+
 ## 1.1.2
 
 - Add secure self-service password recovery from the sign-in page. Recovery links expire after

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hqbase",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
## Summary

- bump the committed HQBase version from `1.1.2` to `1.2.0`
- keep the minimum supported upgrade version at `1.0.0`
- add public release notes for the merged interface, Mail API, provisioning, access-control, OAuth, and draft improvements

## Why

These backward-compatible features and fixes are merged and validated on `main`, but customers need a new immutable signed release before **Settings → Updates** can offer them. The minor version advances because this release adds new product and Mail API capabilities.

## User impact

After the signed release completes, HQBase owners can update through the stable channel to the new responsive interface, reliable client synchronization, resumable operator provisioning, safer catch-all and OAuth access, and complete forward, restore, unarchive, and contextual draft workflows.

## Validation

- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-release-1.2.0-check-wrangler.log pnpm check`
- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-release-1.2.0-dry-run-wrangler.log pnpm deploy:dry-run`
- [Staging E2E against exact `main` commit `5ac7a40`](https://github.com/HQBase/hqbase/actions/runs/32308638954): five rendered checks, lifecycle validation, backup and restore, and cleanup passed

This PR prepares release metadata only. After protected merge and green `main` CI, an authorized maintainer can run the signed-release workflow from `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved navigation and mail synchronization.
  - Installations can now resume after interruption.
  - Added new message actions.
  - Updated API documentation.

- **Bug Fixes**
  - Improved catch-all visibility and message restoration.
  - Fixed draft handling, authorization, token rotation, and attachments.
  - Resolved admin access, OAuth consent, settings, and mail action issues.

- **Release**
  - Updated the application to version 1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->