### PR TITLE
Record signed staging Worker before cleanup

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -88,10 +88,14 @@ jobs:
           pnpm exec wrangler d1 migrations apply DB --remote --config "$config"
           pnpm exec wrangler deploy --config "$config" --secrets-file /tmp/hqbase-e2e-secrets.json
           node --input-type=module -e '
-            import { loadManifest, writeManifest } from "./scripts/hqbase/manifest.mjs";
-            const manifest = loadManifest(process.env.DEPLOYMENT_NAME);
-            manifest.worker.deployed = true;
-            writeManifest(manifest);
+            import {
+              configPath,
+              recordWorkerDeployedForConfig
+            } from "./scripts/hqbase/manifest.mjs";
+            recordWorkerDeployedForConfig(
+              configPath(process.env.DEPLOYMENT_NAME),
+              "hqbase-e2e-staging"
+            );
           '
       - name: Wait for the disposable custom domain
         run: |

--- a/scripts/hqbase/manifest.mjs
+++ b/scripts/hqbase/manifest.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { assertCurrentManifest } from "./lifecycle-manifest.mjs";
 import { deploymentsRoot } from "./paths.mjs";
 
 const namePattern = /^[a-z0-9][a-z0-9-]{0,40}$/;
@@ -61,4 +62,40 @@ export function writeManifest(manifest, options = {}) {
 
 export function manifestExists(name) {
   return fs.existsSync(manifestPath(name));
+}
+
+export function deploymentNameFromConfig(configFile) {
+  const resolvedConfig = path.resolve(configFile);
+  if (path.basename(resolvedConfig) !== "wrangler.jsonc") {
+    return null;
+  }
+
+  const deploymentDirectory = path.dirname(resolvedConfig);
+  if (path.dirname(deploymentDirectory) !== path.resolve(deploymentsRoot)) {
+    return null;
+  }
+
+  const name = path.basename(deploymentDirectory);
+  assertDeploymentName(name);
+  return name;
+}
+
+export function recordWorkerDeployedForConfig(configFile, workerName, options = {}) {
+  const name = deploymentNameFromConfig(configFile);
+  if (!name) {
+    return null;
+  }
+
+  const manifest = (options.loadManifest ?? loadManifest)(name);
+  assertCurrentManifest(manifest);
+  if (manifest.worker.name !== workerName) {
+    throw new Error(
+      `Refusing to record Worker deployment: manifest Worker "${manifest.worker.name}" does not match deployed Worker "${workerName}".`
+    );
+  }
+  if (!manifest.worker.deployed) {
+    manifest.worker.deployed = true;
+    (options.writeManifest ?? writeManifest)(manifest);
+  }
+  return manifest;
 }

--- a/scripts/release/deploy.mjs
+++ b/scripts/release/deploy.mjs
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
+import { recordWorkerDeployedForConfig } from "../hqbase/manifest.mjs";
 import { inspectActiveRelease } from "./active-version.mjs";
 import { capture, run } from "./command.mjs";
 import {
@@ -38,7 +39,14 @@ export {
 
 export async function deploy(options = {}) {
   const configFile = resolve(options.configFile ?? resolve(root, "wrangler.jsonc"));
-  if (process.env.HQBASE_FORCE_SOURCE_DEPLOY === "1") return sourceDeploy(root);
+  if (process.env.HQBASE_FORCE_SOURCE_DEPLOY === "1") {
+    const sourceConfigFile = resolve(root, "wrangler.jsonc");
+    const config = JSON.parse(readFileSync(sourceConfigFile, "utf8"));
+    return sourceDeploy(root, {
+      recordWorkerDeployed: () =>
+        recordWorkerDeployedForConfig(sourceConfigFile, workerNameFromConfig(config))
+    });
+  }
   const { bytes, manifest } = await loadVerifiedRelease({
     artifactFile: options.artifactFile ?? process.env.HQBASE_RELEASE_ARTIFACT_FILE,
     expectedVersion: options.expectedVersion ?? process.env.HQBASE_EXPECTED_RELEASE_VERSION,
@@ -60,6 +68,7 @@ export async function deploy(options = {}) {
       manifest.version,
       manifest.artifact.sha256
     );
+    const recordWorkerDeployed = () => recordWorkerDeployedForConfig(configFile, config.name);
     writeFileSync(resolve(source, "wrangler.jsonc"), `${JSON.stringify(config, null, 2)}\n`);
     run("pnpm", ["install", "--frozen-lockfile"], source);
     run("pnpm", ["build"], source);
@@ -68,6 +77,7 @@ export async function deploy(options = {}) {
     if (!activeRelease) {
       applyMigrations(source);
       deploySource(source, { releaseTag });
+      recordWorkerDeployed();
       executeSql(
         source,
         `UPDATE release_state SET installed_version = ${quote(manifest.version)}, installed_schema_version = ${manifest.schemaVersion}, updated_at = datetime('now') WHERE singleton = 1`
@@ -85,6 +95,7 @@ export async function deploy(options = {}) {
       );
     }
     if (activeRelease.version === manifest.version && activeRelease.tag === releaseTag) {
+      recordWorkerDeployed();
       console.log(`HQBase ${manifest.version} is already the active signed release.`);
       return;
     }
@@ -136,6 +147,7 @@ export async function deploy(options = {}) {
       ],
       source
     );
+    recordWorkerDeployed();
     capture(
       "pnpm",
       [
@@ -164,10 +176,11 @@ export async function deploy(options = {}) {
   }
 }
 
-function sourceDeploy(cwd) {
+function sourceDeploy(cwd, options = {}) {
   run("pnpm", ["build"], cwd);
   run("pnpm", ["db:migrate:remote"], cwd);
   deploySource(cwd);
+  options.recordWorkerDeployed?.();
   run("pnpm", ["hqbase", "postdeploy"], cwd);
 }
 

--- a/test/unit/scripts/destroy.test.mjs
+++ b/test/unit/scripts/destroy.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { destroyPlan, destroyResources, destroyTargets } from "../../../scripts/hqbase/destroy.mjs";
+import { configPath, recordWorkerDeployedForConfig } from "../../../scripts/hqbase/manifest.mjs";
 
 const scopes = ["worker", "data", "storage", "state", "domain", "all"];
 
@@ -176,6 +177,37 @@ describe("operator destroy scopes", () => {
     );
     expect(detach).toBeGreaterThanOrEqual(0);
     expect(removeWorker).toBeGreaterThan(detach);
+  });
+
+  it("records a direct signed deploy before deleting its bound queues", () => {
+    const input = manifest();
+    input.worker.deployed = false;
+    const checkpoints = [];
+
+    recordWorkerDeployedForConfig(configPath(input.name), input.worker.name, {
+      loadManifest: () => input,
+      writeManifest: (next) => checkpoints.push(structuredClone(next))
+    });
+
+    const commands = [];
+    destroyResources("all", input, {
+      checkpoint: () => {},
+      runCommand: (_command, args) => {
+        commands.push(args.slice(2));
+        return "";
+      }
+    });
+
+    const removeWorker = commands.findIndex(
+      (args) => args.join(" ") === "delete hqbase-qa --force"
+    );
+    const removeQueue = commands.findIndex(
+      (args) => args.join(" ") === "queues delete hqbase-jobs"
+    );
+    expect(checkpoints).toHaveLength(1);
+    expect(checkpoints[0].worker.deployed).toBe(true);
+    expect(removeWorker).toBeGreaterThanOrEqual(0);
+    expect(removeQueue).toBeGreaterThan(removeWorker);
   });
 
   it("keeps completed cleanup checkpoints when a later deletion fails", () => {

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -9,7 +9,7 @@ const workflow = readFileSync(
 describe("staging workflow lifecycle record", () => {
   it("records the reviewed Worker deploy before cleanup", () => {
     const deploy = workflow.indexOf("pnpm exec wrangler deploy --config");
-    const checkpoint = workflow.indexOf("manifest.worker.deployed = true");
+    const checkpoint = workflow.indexOf("recordWorkerDeployedForConfig");
     const cleanup = workflow.indexOf('pnpm hqbase destroy --name "$DEPLOYMENT_NAME"');
 
     expect(deploy).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary

- checkpoint managed Worker deployment immediately after a successful signed deploy
- use the same validated checkpoint helper in manual staging
- make full cleanup delete the Worker before its bound queues
- add regression coverage for the failed signed-release sequence

## Specification

- HQBase/hqbase-site#18

## Validation

- focused release and cleanup tests: 41 passed
- CI=true WRANGLER_LOG_PATH=/tmp/hqbase-release-cleanup-check.log pnpm check
- CI=true WRANGLER_LOG_PATH=/tmp/hqbase-release-cleanup-dry-run.log pnpm deploy:dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Deployment status is now recorded consistently across staging, source deployments, releases, and direct deployments.
  * Deployment configuration is validated before status updates, helping prevent incorrect worker records.
  * Resource cleanup now confirms deployment state is saved before associated resources are removed.

* **Tests**
  * Expanded automated coverage for deployment tracking and cleanup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->