### PR TITLE
Fix deployment checkpoint review findings

### DIFF
--- a/scripts/hqbase/manifest.mjs
+++ b/scripts/hqbase/manifest.mjs
@@ -88,6 +88,11 @@ export function recordWorkerDeployedForConfig(configFile, workerName, options = 
 
   const manifest = (options.loadManifest ?? loadManifest)(name);
   assertCurrentManifest(manifest);
+  if (manifest.name !== name) {
+    throw new Error(
+      `Refusing to record Worker deployment: manifest name "${manifest.name}" does not match deployment "${name}".`
+    );
+  }
   if (manifest.worker.name !== workerName) {
     throw new Error(
       `Refusing to record Worker deployment: manifest Worker "${manifest.worker.name}" does not match deployed Worker "${workerName}".`

--- a/scripts/release/deploy.mjs
+++ b/scripts/release/deploy.mjs
@@ -40,12 +40,8 @@ export {
 export async function deploy(options = {}) {
   const configFile = resolve(options.configFile ?? resolve(root, "wrangler.jsonc"));
   if (process.env.HQBASE_FORCE_SOURCE_DEPLOY === "1") {
-    const sourceConfigFile = resolve(root, "wrangler.jsonc");
-    const config = JSON.parse(readFileSync(sourceConfigFile, "utf8"));
-    return sourceDeploy(root, {
-      recordWorkerDeployed: () =>
-        recordWorkerDeployedForConfig(sourceConfigFile, workerNameFromConfig(config))
-    });
+    assertSourceDeployConfig(configFile);
+    return sourceDeploy(root);
   }
   const { bytes, manifest } = await loadVerifiedRelease({
     artifactFile: options.artifactFile ?? process.env.HQBASE_RELEASE_ARTIFACT_FILE,
@@ -176,11 +172,24 @@ export async function deploy(options = {}) {
   }
 }
 
-function sourceDeploy(cwd, options = {}) {
+export function assertSourceDeployConfig(
+  configFile,
+  sourceConfigFile = resolve(root, "wrangler.jsonc")
+) {
+  const selectedConfig = resolve(configFile);
+  const repositoryConfig = resolve(sourceConfigFile);
+  if (selectedConfig !== repositoryConfig) {
+    throw new Error(
+      "HQBASE_FORCE_SOURCE_DEPLOY supports only the repository-root wrangler.jsonc. Unset it before deploying a managed installation."
+    );
+  }
+  return repositoryConfig;
+}
+
+function sourceDeploy(cwd) {
   run("pnpm", ["build"], cwd);
   run("pnpm", ["db:migrate:remote"], cwd);
   deploySource(cwd);
-  options.recordWorkerDeployed?.();
   run("pnpm", ["hqbase", "postdeploy"], cwd);
 }
 

--- a/test/unit/scripts/deploy.test.mjs
+++ b/test/unit/scripts/deploy.test.mjs
@@ -3,12 +3,14 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync 
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { configPath } from "../../../scripts/hqbase/manifest.mjs";
 import {
   inspectActiveRelease,
   isDeployButtonBootstrap,
   parseActiveRelease
 } from "../../../scripts/release/active-version.mjs";
 import {
+  assertSourceDeployConfig,
   compareVersions,
   deploySource,
   executeSql,
@@ -228,6 +230,14 @@ describe("HQBase release deployment", () => {
   it("uses the configured Worker name as the runtime automation identity", () => {
     expect(workerNameFromConfig({ name: "hqbase-deeptake-test" })).toBe("hqbase-deeptake-test");
     expect(() => workerNameFromConfig({ name: "" })).toThrow("deployed Worker name");
+  });
+  it("rejects managed configurations in forced-source mode", () => {
+    const repositoryConfig = resolve("wrangler.jsonc");
+
+    expect(assertSourceDeployConfig(repositoryConfig)).toBe(repositoryConfig);
+    expect(() => assertSourceDeployConfig(configPath("release-test"))).toThrow(
+      /HQBASE_FORCE_SOURCE_DEPLOY supports only the repository-root wrangler\.jsonc/
+    );
   });
   it("generates masked auth and Web Push secrets when the first Workers Build needs them", () => {
     let secretFile;

--- a/test/unit/scripts/destroy.test.mjs
+++ b/test/unit/scripts/destroy.test.mjs
@@ -210,6 +210,22 @@ describe("operator destroy scopes", () => {
     expect(removeQueue).toBeGreaterThan(removeWorker);
   });
 
+  it("refuses to update a manifest from another deployment directory", () => {
+    const input = manifest();
+    input.name = "other";
+    input.worker.deployed = false;
+    const checkpoints = [];
+
+    expect(() =>
+      recordWorkerDeployedForConfig(configPath("qa"), input.worker.name, {
+        loadManifest: () => input,
+        writeManifest: (next) => checkpoints.push(structuredClone(next))
+      })
+    ).toThrow(/manifest name "other" does not match deployment "qa"/);
+    expect(input.worker.deployed).toBe(false);
+    expect(checkpoints).toEqual([]);
+  });
+
   it("keeps completed cleanup checkpoints when a later deletion fails", () => {
     const input = manifest();
     input.worker.deployed = false;


### PR DESCRIPTION
## Summary

- reject manifest checkpoints whose deployment identity does not match the managed config
- reject managed installation configs in forced-source deployment mode
- add regression coverage for both review findings

Follow-up to #57.

## Validation

- CI=true pnpm exec vitest run test/unit/scripts/destroy.test.mjs test/unit/scripts/deploy.test.mjs test/unit/scripts/staging-workflow.test.mjs
- CI=true WRANGLER_LOG_PATH=/tmp/hqbase-release-cleanup-review-check.log pnpm check
- CI=true WRANGLER_LOG_PATH=/tmp/hqbase-release-cleanup-review-dry-run.log pnpm deploy:dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment validation to prevent mismatched configurations or manifests from being deployed or recorded.
  * Source deployments now require the repository’s root configuration file.
  * Prevented deployment status from being updated when deployment names do not match.

* **Tests**
  * Added coverage for valid and invalid source deployment configurations.
  * Added verification that failed validations leave deployment state unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->