### PR TITLE
Wait for exact live release candidate before staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,15 +239,18 @@ jobs:
       - name: Wait for the signed candidate
         run: |
           for attempt in $(seq 1 150); do
-            if curl --fail --silent --show-error \
+            if candidate_health="$(curl --fail --silent --show-error \
               -H "CF-Access-Client-Id: $HQBASE_STAGING_ACCESS_CLIENT_ID" \
               -H "CF-Access-Client-Secret: $HQBASE_STAGING_ACCESS_CLIENT_SECRET" \
-              "$HQBASE_STAGING_URL/api/health" >/dev/null; then
+              "$HQBASE_STAGING_URL/api/health?candidate=$CANDIDATE_VERSION&attempt=$attempt")" && \
+              jq -e --arg version "$CANDIDATE_VERSION" \
+                '.ok == true and .service == "hqbase" and .version == $version' \
+                <<<"$candidate_health" >/dev/null; then
               exit 0
             fi
             sleep 2
           done
-          echo "Signed HQBase candidate was not healthy within 300 seconds"
+          echo "Signed HQBase candidate was not active within 300 seconds"
           exit 1
       - name: Verify the installed candidate release marker
         run: |

--- a/test/integration/worker/health.test.ts
+++ b/test/integration/worker/health.test.ts
@@ -8,7 +8,8 @@ describe("Worker health", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       ok: true,
-      service: "hqbase"
+      service: "hqbase",
+      version: null
     });
   });
 });

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -5,6 +5,10 @@ const workflow = readFileSync(
   new URL("../../../.github/workflows/staging-e2e.yml", import.meta.url),
   "utf8"
 );
+const releaseWorkflow = readFileSync(
+  new URL("../../../.github/workflows/release.yml", import.meta.url),
+  "utf8"
+);
 
 describe("staging workflow lifecycle record", () => {
   it("records the reviewed Worker deploy before cleanup", () => {
@@ -15,5 +19,16 @@ describe("staging workflow lifecycle record", () => {
     expect(deploy).toBeGreaterThan(-1);
     expect(checkpoint).toBeGreaterThan(deploy);
     expect(cleanup).toBeGreaterThan(checkpoint);
+  });
+
+  it("waits for the exact live candidate version before release checks", () => {
+    const waitStart = releaseWorkflow.indexOf("      - name: Wait for the signed candidate");
+    const nextStep = releaseWorkflow.indexOf("\n      - name:", waitStart + 1);
+    const waitStep = releaseWorkflow.slice(waitStart, nextStep);
+
+    expect(waitStart).toBeGreaterThan(-1);
+    expect(waitStep).toContain('jq -e --arg version "$CANDIDATE_VERSION"');
+    expect(waitStep).toContain(".version == $version");
+    expect(waitStep).toContain("candidate=$CANDIDATE_VERSION&attempt=$attempt");
   });
 });

--- a/test/unit/worker/routes/health.test.ts
+++ b/test/unit/worker/routes/health.test.ts
@@ -1,0 +1,24 @@
+import type { WorkerEnv } from "@worker/lib/env";
+import { healthRoutes } from "@worker/routes/health";
+import { describe, expect, it } from "vitest";
+
+describe("health routes", () => {
+  it("reports the release version that served the request", async () => {
+    const response = await healthRoutes.request("/", undefined, {
+      HQBASE_APP_VERSION: "1.2.0"
+    } as WorkerEnv);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      service: "hqbase",
+      version: "1.2.0"
+    });
+  });
+
+  it("reports no version when the deployment has no release binding", async () => {
+    const response = await healthRoutes.request("/", undefined, {} as WorkerEnv);
+
+    await expect(response.json()).resolves.toMatchObject({ version: null });
+  });
+});

--- a/worker/routes/health.ts
+++ b/worker/routes/health.ts
@@ -8,6 +8,7 @@ healthRoutes.get("/", (c) => {
   return c.json({
     ok: true,
     service: "hqbase",
+    version: c.env.HQBASE_APP_VERSION?.trim() || null,
     time: new Date().toISOString()
   });
 });


### PR DESCRIPTION
## Summary

- report the serving Worker version from the public health endpoint
- wait for the exact candidate version through the staging custom domain before E2E starts
- add route, integration, and workflow regression coverage

Fixes the stale-Worker failure in signed-release run 32315531746.

## Validation

- focused unit and Worker integration tests
- CI=true WRANGLER_LOG_PATH=/tmp/hqbase-release-readiness-check.log pnpm check
- CI=true WRANGLER_LOG_PATH=/tmp/hqbase-release-readiness-dry-run.log pnpm deploy:dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health checks now report the deployed application version when configured, or `null` when unavailable.
* **Bug Fixes**
  * Release validation now confirms that the deployed candidate is healthy and running the expected version before proceeding.
  * Health-check polling includes candidate version and retry details, improving accuracy during deployments.
* **Tests**
  * Added coverage for version reporting, missing version configuration, and exact-version deployment validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->