### PR TITLE
feat: support receive-only workspaces

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -12,6 +12,7 @@ import {
   TemporaryPasswordSetupPage
 } from "@/features/auth/password-setup-page";
 import type { CurrentUser } from "@/features/auth/types";
+import { sendingIdentities } from "@/features/compose/compose-state";
 import { DraftsPage } from "@/features/drafts/drafts-page";
 import { useDrafts } from "@/features/drafts/use-drafts";
 import { InboxPage } from "@/features/inbox/inbox-page";
@@ -70,6 +71,10 @@ export function App(): React.ReactElement {
   const contentMailboxes = React.useMemo(
     () => mailboxes.filter((mailbox) => mailbox.accessLevel !== null),
     [mailboxes]
+  );
+  const canSend = React.useMemo(
+    () => sendingIdentities(contentMailboxes).length > 0,
+    [contentMailboxes]
   );
   const canManageUpdates =
     !user?.passwordSetupRequired && (user?.role === "owner" || user?.role === "admin");
@@ -204,9 +209,7 @@ export function App(): React.ReactElement {
         onOpenUpdates={() => {
           navigate({ kind: "settings", tab: "updates" });
         }}
-        onCompose={() => {
-          setComposeOpen(true);
-        }}
+        {...(canSend ? { onCompose: () => setComposeOpen(true) } : {})}
         onFolderChange={(folder) => {
           navigate(
             folder === "settings"

--- a/app/components/layout/app-shell.tsx
+++ b/app/components/layout/app-shell.tsx
@@ -25,7 +25,7 @@ type AppShellProps = {
   updateStatus: UpdateStatus | null;
   unread: UnreadCounts;
   draftCount: number;
-  onCompose: () => void;
+  onCompose?: (() => void) | undefined;
   onFolderChange: (folder: FolderId) => void;
   onSettingsTabChange?: ((tab: import("@/lib/routes").SettingsTabId) => void) | undefined;
   onMailboxChange: (mailboxId: string) => void;
@@ -60,7 +60,7 @@ export function AppShell(props: AppShellProps): React.ReactElement {
               sidebarCollapsed={sidebarCollapsed}
               unread={props.unread}
               user={props.user}
-              onCompose={props.onCompose}
+              {...(props.onCompose ? { onCompose: props.onCompose } : {})}
               onFolderChange={props.onFolderChange}
               onSettingsTabChange={props.onSettingsTabChange}
               onSignedOut={props.onSignedOut}
@@ -88,7 +88,7 @@ export function AppShell(props: AppShellProps): React.ReactElement {
             mailboxId={props.mailboxId}
             unread={props.unread}
             user={props.user}
-            onCompose={props.onCompose}
+            {...(props.onCompose ? { onCompose: props.onCompose } : {})}
             onFolderChange={props.onFolderChange}
             onSettingsTabChange={props.onSettingsTabChange}
             onSignedOut={props.onSignedOut}
@@ -157,7 +157,7 @@ function ShellContent({
         unread={unread}
         user={user}
         sidebarCollapsed={sidebarCollapsed}
-        onCompose={onCompose}
+        {...(onCompose ? { onCompose } : {})}
         onFolderChange={onFolderChange}
         onMailboxChange={onMailboxChange}
         onSearchChange={onSearchChange}

--- a/app/components/layout/top-bar.tsx
+++ b/app/components/layout/top-bar.tsx
@@ -28,7 +28,7 @@ type TopBarProps = {
   mailboxId: string;
   search: string;
   unread: UnreadCounts;
-  onCompose: () => void;
+  onCompose?: (() => void) | undefined;
   onFolderChange: (folder: FolderId) => void;
   onMailboxChange: (mailboxId: string) => void;
   onSearchChange: (search: string) => void;
@@ -81,7 +81,7 @@ export function TopBar({
         mailboxes={mailboxes}
         unread={unread}
         user={user}
-        onCompose={onCompose}
+        {...(onCompose ? { onCompose } : {})}
         onFolderChange={onFolderChange}
         onMailboxChange={onMailboxChange}
         onSettingsTabChange={onSettingsTabChange}

--- a/app/features/compose/compose-state.ts
+++ b/app/features/compose/compose-state.ts
@@ -81,8 +81,8 @@ export function defaultSendingIdentity(
 ): SendingIdentity | null {
   const mailbox = mailboxes.find((candidate) => candidate.id === defaultFromMailboxId);
   const primaryAddress =
-    mailbox?.addresses.find((address) => address.isPrimary && address.sendEnabled)?.address ??
-    (mailbox?.addresses.length === 0 ? mailbox.address : null);
+    mailbox?.addresses.find((address) => address.isPrimary && address.sendAvailable)?.address ??
+    null;
   return (
     identities.find(
       (identity) =>
@@ -100,11 +100,9 @@ export function sendingIdentities(mailboxes: Mailbox[]): SendingIdentity[] {
         mailbox.isActive && (mailbox.accessLevel === "agent" || mailbox.accessLevel === "manager")
     )
     .flatMap((mailbox) =>
-      mailbox.addresses?.length
-        ? mailbox.addresses
-            .filter((address) => address.sendEnabled)
-            .map((address) => ({ mailboxId: mailbox.id, address: address.address }))
-        : [{ mailboxId: mailbox.id, address: mailbox.address }]
+      mailbox.addresses
+        .filter((address) => address.sendAvailable)
+        .map((address) => ({ mailboxId: mailbox.id, address: address.address }))
     );
 }
 

--- a/app/features/domains/connect-domain-dialog.tsx
+++ b/app/features/domains/connect-domain-dialog.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { PiPlus } from "react-icons/pi";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogClose,
@@ -12,7 +13,7 @@ import {
   DialogTitle,
   DialogTrigger
 } from "@/components/ui/dialog";
-import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/components/ui/field";
 import {
   Select,
   SelectContent,
@@ -44,6 +45,7 @@ export function ConnectDomainDialog({
   const [zones, setZones] = React.useState<CloudflareZone[]>([]);
   const [zoneId, setZoneId] = React.useState("");
   const [name, setName] = React.useState("");
+  const [enableSending, setEnableSending] = React.useState(true);
   const [pending, setPending] = React.useState(false);
 
   const loadZones = React.useCallback(async () => {
@@ -82,7 +84,7 @@ export function ConnectDomainDialog({
     event.preventDefault();
     setPending(true);
     try {
-      await provisionDomain({ zoneId, name, enableSending: true });
+      await provisionDomain({ zoneId, name, enableSending });
       reset();
       onConnected();
       toast.success("Domain connected.");
@@ -95,6 +97,7 @@ export function ConnectDomainDialog({
 
   function reset() {
     setName("");
+    setEnableSending(true);
     setZoneId("");
     setZones([]);
   }
@@ -139,6 +142,21 @@ export function ConnectDomainDialog({
                     </SelectGroup>
                   </SelectContent>
                 </Select>
+              </Field>
+              <Field className="grid grid-cols-[auto_1fr] items-start gap-x-2.5 gap-y-1">
+                <Checkbox
+                  checked={enableSending}
+                  id="connect-domain-enable-sending"
+                  onCheckedChange={(checked) => setEnableSending(checked === true)}
+                />
+                <div className="grid gap-1 leading-none">
+                  <FieldLabel htmlFor="connect-domain-enable-sending">
+                    Enable outbound sending
+                  </FieldLabel>
+                  <FieldDescription>
+                    Requires Workers Paid. Clear this option for receive-only mail.
+                  </FieldDescription>
+                </div>
               </Field>
             </FieldGroup>
             <DialogFooter>

--- a/app/features/domains/domain-settings.tsx
+++ b/app/features/domains/domain-settings.tsx
@@ -6,7 +6,13 @@ import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { CloudflareAuthorizationDialog } from "@/features/settings/cloudflare-authorization-dialog";
 import { SettingsSection } from "@/features/settings/settings-section";
-import { changePortal, listDomains, revokeCloudflareAuthorization, updateDomain } from "./api";
+import {
+  changePortal,
+  listDomains,
+  provisionDomain,
+  revokeCloudflareAuthorization,
+  updateDomain
+} from "./api";
 import { ConnectDomainDialog } from "./connect-domain-dialog";
 import { DomainTable } from "./domain-table";
 import type { MailDomain } from "./types";
@@ -15,7 +21,8 @@ const PENDING_OPERATION_KEY = "hqb_cloudflare_operation_v1";
 
 type PendingCloudflareOperation =
   | { action: "connect" }
-  | { action: "portal"; hostname: string; zoneId: string };
+  | { action: "portal"; hostname: string; zoneId: string }
+  | { action: "sending"; domainId: string; name: string; zoneId: string };
 
 export function DomainSettings({
   portalHostname,
@@ -55,7 +62,7 @@ export function DomainSettings({
       const pending = readPendingOperation();
       if (pending?.action === "connect") {
         setConnectOpen(true);
-      } else if (pending?.action === "portal") {
+      } else if (pending?.action === "portal" || pending?.action === "sending") {
         setAuthorizationOperation(pending);
       } else {
         toast.error("Sign in again, then restart the Cloudflare change.");
@@ -87,6 +94,28 @@ export function DomainSettings({
     }
 
     setChangePending(true);
+    if (pending.action === "sending") {
+      setPendingDomainId(pending.domainId);
+      void provisionDomain({ zoneId: pending.zoneId, name: pending.name, enableSending: true })
+        .then(({ domain }) => {
+          if (domain.sendingStatus !== "ready") {
+            throw new Error("Cloudflare has not reported Email Sending as ready.");
+          }
+          refresh();
+          onChanged();
+          toast.success(`Sending enabled for ${domain.name}.`);
+        })
+        .catch((error: unknown) => {
+          toast.error(error instanceof Error ? error.message : "Cloudflare change failed.");
+        })
+        .finally(() => {
+          sessionStorage.removeItem(PENDING_OPERATION_KEY);
+          setChangePending(false);
+          setPendingDomainId(null);
+        });
+      return;
+    }
+
     void changePortal({ zoneId: pending.zoneId, hostname: pending.hostname })
       .then(() => {
         onChanged();
@@ -99,7 +128,7 @@ export function DomainSettings({
         sessionStorage.removeItem(PENDING_OPERATION_KEY);
         setChangePending(false);
       });
-  }, [onChanged]);
+  }, [onChanged, refresh]);
 
   function portal(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -122,6 +151,19 @@ export function DomainSettings({
     } finally {
       setPendingDomainId(null);
     }
+  }
+
+  function enableSending(domain: MailDomain) {
+    if (!domain.zoneId) {
+      toast.error("Reconnect this domain to its Cloudflare zone before enabling sending.");
+      return;
+    }
+    setAuthorizationOperation({
+      action: "sending",
+      domainId: domain.id,
+      name: domain.name,
+      zoneId: domain.zoneId
+    });
   }
 
   return (
@@ -155,6 +197,7 @@ export function DomainSettings({
       <DomainTable
         domains={domains}
         pendingDomainId={pendingDomainId}
+        onEnableSending={enableSending}
         onToggle={(domain) => void toggleDomain(domain)}
       />
 
@@ -187,8 +230,15 @@ export function DomainSettings({
       </div>
       <CloudflareAuthorizationDialog
         authorizeHref="/api/domains/cloudflare/oauth/start"
-        description="To save this change, HQBase needs temporary access to your Cloudflare account. You’ll return to Domains automatically, and HQBase will update the workspace portal."
-        open={authorizationOperation?.action === "portal"}
+        description={
+          authorizationOperation?.action === "sending"
+            ? "HQBase needs temporary Cloudflare access to enable Email Sending. You will return to Domains automatically."
+            : "To save this change, HQBase needs temporary access to your Cloudflare account. You’ll return to Domains automatically, and HQBase will update the workspace portal."
+        }
+        open={
+          authorizationOperation?.action === "portal" ||
+          authorizationOperation?.action === "sending"
+        }
         onAuthorize={() => {
           if (authorizationOperation) {
             sessionStorage.setItem(PENDING_OPERATION_KEY, JSON.stringify(authorizationOperation));
@@ -214,6 +264,19 @@ function readPendingOperation(): PendingCloudflareOperation | null {
       typeof value.zoneId === "string"
     ) {
       return { action: "portal", hostname: value.hostname, zoneId: value.zoneId };
+    }
+    if (
+      value?.action === "sending" &&
+      typeof value.domainId === "string" &&
+      typeof value.name === "string" &&
+      typeof value.zoneId === "string"
+    ) {
+      return {
+        action: "sending",
+        domainId: value.domainId,
+        name: value.name,
+        zoneId: value.zoneId
+      };
     }
   } catch {
     // Ignore malformed, non-secret browser draft state.

--- a/app/features/domains/domain-table.tsx
+++ b/app/features/domains/domain-table.tsx
@@ -15,10 +15,12 @@ import type { MailDomain } from "./types";
 export function DomainTable({
   domains,
   pendingDomainId,
+  onEnableSending,
   onToggle
 }: {
   domains: MailDomain[];
   pendingDomainId: string | null;
+  onEnableSending: (domain: MailDomain) => void;
   onToggle: (domain: MailDomain) => void;
 }): React.ReactElement {
   return (
@@ -67,20 +69,34 @@ export function DomainTable({
               </Badge>
             </TableCell>
             <TableCell className="text-right">
-              <Button
-                aria-label={`${domain.isEnabled ? "Disable" : "Enable"} ${domain.name}`}
-                disabled={pendingDomainId === domain.id}
-                size="sm"
-                type="button"
-                variant="outline"
-                onClick={() => onToggle(domain)}
-              >
-                {pendingDomainId === domain.id
-                  ? "Updating…"
-                  : domain.isEnabled
-                    ? "Disable"
-                    : "Enable"}
-              </Button>
+              <div className="flex justify-end gap-2">
+                {domain.isEnabled && domain.sendingStatus !== "ready" && domain.zoneId ? (
+                  <Button
+                    aria-label={`Enable sending for ${domain.name}`}
+                    disabled={pendingDomainId === domain.id}
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                    onClick={() => onEnableSending(domain)}
+                  >
+                    Enable sending
+                  </Button>
+                ) : null}
+                <Button
+                  aria-label={`${domain.isEnabled ? "Disable" : "Enable"} ${domain.name}`}
+                  disabled={pendingDomainId === domain.id}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                  onClick={() => onToggle(domain)}
+                >
+                  {pendingDomainId === domain.id
+                    ? "Updating…"
+                    : domain.isEnabled
+                      ? "Disable"
+                      : "Enable"}
+                </Button>
+              </div>
             </TableCell>
           </TableRow>
         ))}

--- a/app/features/mailboxes/default-from-mailbox-control.tsx
+++ b/app/features/mailboxes/default-from-mailbox-control.tsx
@@ -79,7 +79,6 @@ function defaultFromMailboxOptions(mailboxes: Mailbox[]): Mailbox[] {
     (mailbox) =>
       mailbox.isActive &&
       (mailbox.accessLevel === "agent" || mailbox.accessLevel === "manager") &&
-      (mailbox.addresses.length === 0 ||
-        mailbox.addresses.some((address) => address.isPrimary && address.sendEnabled))
+      mailbox.addresses.some((address) => address.isPrimary && address.sendAvailable)
   );
 }

--- a/app/features/mailboxes/types.ts
+++ b/app/features/mailboxes/types.ts
@@ -9,6 +9,7 @@ export type Mailbox = {
     displayName: string;
     receiveEnabled: boolean;
     sendEnabled: boolean;
+    sendAvailable: boolean;
     isPrimary: boolean;
   }>;
   displayName: string;

--- a/app/features/messages/message-detail.tsx
+++ b/app/features/messages/message-detail.tsx
@@ -11,7 +11,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { PullToRefresh } from "@/components/ui/pull-to-refresh";
-import type { ComposeMode } from "@/features/compose/compose-state";
+import { type ComposeMode, sendingIdentities } from "@/features/compose/compose-state";
 import type { Mailbox } from "@/features/mailboxes/types";
 import type { MailFolderId } from "@/lib/routes";
 import { ConversationMessages } from "./conversation-messages";
@@ -70,6 +70,7 @@ export function MessageDetail({
   onSent
 }: MessageDetailProps): React.ReactElement {
   const [composeState, setComposeState] = React.useState<ThreadComposeState | null>(null);
+  const canSend = sendingIdentities(mailboxes).length > 0;
 
   if (isLoading) {
     return <MessageReaderStatus label="Loading conversation" />;
@@ -181,7 +182,12 @@ export function MessageDetail({
       <PullToRefresh className="min-h-0 flex-1" onRefresh={onRefresh}>
         <ConversationMessages
           messages={messages}
-          onCompose={(message, mode) => setComposeState({ message, mode })}
+          {...(canSend
+            ? {
+                onCompose: (message: MessageDetailType, mode: ThreadComposeMode) =>
+                  setComposeState({ message, mode })
+              }
+            : {})}
         />
         {composeState ? (
           <div className="px-4 pb-8 pt-2 sm:px-6">

--- a/app/features/setup/api.ts
+++ b/app/features/setup/api.ts
@@ -26,6 +26,7 @@ export async function listCloudflareZones(): Promise<CloudflareZone[]> {
 }
 
 export async function inspectCloudflareDomain(input: {
+  requireSending?: boolean;
   workerName: string;
   zoneId: string;
 }): Promise<CloudflareDomainStatus> {

--- a/app/features/setup/setup-domain-screen.tsx
+++ b/app/features/setup/setup-domain-screen.tsx
@@ -27,6 +27,7 @@ export function DomainStep(props: {
   appHostname: string;
   appSubdomain: string;
   connectionError: string | null;
+  enableSending: boolean;
   errors: DomainErrors;
   isLoading: boolean;
   onBack: () => void;
@@ -38,6 +39,7 @@ export function DomainStep(props: {
   selectedZoneIds: string[];
   selectedZones: CloudflareZone[];
   setAppSubdomain: (value: string) => void;
+  setEnableSending: (value: boolean) => void;
   setPortalZoneId: (value: string) => void;
   zones: CloudflareZone[];
 }): React.ReactElement {
@@ -105,6 +107,20 @@ export function DomainStep(props: {
               </div>
             );
           })}
+        </div>
+      </Field>
+
+      <Field className="grid grid-cols-[auto_1fr] items-start gap-x-2.5 gap-y-1">
+        <Checkbox
+          checked={props.enableSending}
+          id="setup-enable-sending"
+          onCheckedChange={(checked) => props.setEnableSending(checked === true)}
+        />
+        <div className="grid gap-1 leading-none">
+          <FieldLabel htmlFor="setup-enable-sending">Enable outbound sending</FieldLabel>
+          <FieldDescription>
+            Requires Workers Paid. Clear this option to create a receive-only workspace.
+          </FieldDescription>
         </div>
       </Field>
 
@@ -250,7 +266,7 @@ function describeReadinessFailure(status: CloudflareConfigureResult["status"]): 
   if (!status.catchAll.enabled || !status.catchAll.configuredForWorker) {
     issues.push(status.catchAll.error ?? "Catch-all is not routing to this HQBase Worker.");
   }
-  if (!status.sending.enabled) {
+  if (status.sendingRequired && !status.sending.enabled) {
     issues.push(status.sending.error ?? "Email Sending is not enabled.");
   }
   return issues.join(" ") || "Cloudflare has not reported this domain as ready yet.";

--- a/app/features/setup/setup-preview-fixtures.tsx
+++ b/app/features/setup/setup-preview-fixtures.tsx
@@ -115,7 +115,7 @@ export function renderPreviewFixture(input: FixtureInput): React.ReactNode {
         connectionError={
           readinessError ? "Cloudflare needs attention on one or more checks below." : null
         }
-        enableSending
+        enableSending={true}
         errors={{}}
         isLoading={false}
         onBack={() => undefined}
@@ -166,7 +166,7 @@ export function renderPreviewFixture(input: FixtureInput): React.ReactNode {
       errors={{ rows: input.mailboxes.map(() => ({})) }}
       isPending={input.state === "submitting"}
       mailboxes={input.mailboxes}
-      sendingEnabled
+      sendingEnabled={true}
       onAdd={() => input.setMailboxes((current) => [...current, { address: "", displayName: "" }])}
       onBack={() => undefined}
       onComplete={() => undefined}

--- a/app/features/setup/setup-preview-fixtures.tsx
+++ b/app/features/setup/setup-preview-fixtures.tsx
@@ -115,6 +115,7 @@ export function renderPreviewFixture(input: FixtureInput): React.ReactNode {
         connectionError={
           readinessError ? "Cloudflare needs attention on one or more checks below." : null
         }
+        enableSending
         errors={{}}
         isLoading={false}
         onBack={() => undefined}
@@ -130,6 +131,7 @@ export function renderPreviewFixture(input: FixtureInput): React.ReactNode {
         selectedZoneIds={input.selectedZoneIds}
         selectedZones={input.selectedZones}
         setAppSubdomain={input.setAppSubdomain}
+        setEnableSending={() => undefined}
         setPortalZoneId={input.setPortalZoneId}
         zones={zones}
       />
@@ -164,6 +166,7 @@ export function renderPreviewFixture(input: FixtureInput): React.ReactNode {
       errors={{ rows: input.mailboxes.map(() => ({})) }}
       isPending={input.state === "submitting"}
       mailboxes={input.mailboxes}
+      sendingEnabled
       onAdd={() => input.setMailboxes((current) => [...current, { address: "", displayName: "" }])}
       onBack={() => undefined}
       onComplete={() => undefined}
@@ -227,6 +230,7 @@ function readinessFailureFixture(): ConfiguredDomain[] {
         status: {
           zone,
           workerName: "hqbase-preview",
+          sendingRequired: true,
           routing: {
             enabled: true,
             status: "active",

--- a/app/features/setup/setup-workspace-screens.tsx
+++ b/app/features/setup/setup-workspace-screens.tsx
@@ -142,6 +142,7 @@ export function MailboxStep({
   errors,
   isPending,
   mailboxes,
+  sendingEnabled,
   onAdd,
   onBack,
   onComplete,
@@ -154,6 +155,7 @@ export function MailboxStep({
   errors: MailboxErrors;
   isPending: boolean;
   mailboxes: MailboxDraft[];
+  sendingEnabled: boolean;
   onAdd: () => void;
   onBack: () => void;
   onComplete: () => void;
@@ -248,29 +250,35 @@ export function MailboxStep({
         Add mailbox
       </Button>
 
-      <Field className="max-w-md">
-        <FieldLabel htmlFor="setup-default-from-mailbox">Default From mailbox</FieldLabel>
-        <Select value={defaultFromMailboxAddress} onValueChange={onSetDefaultFromMailboxAddress}>
-          <SelectTrigger id="setup-default-from-mailbox" className="w-full shadow-none">
-            <SelectValue placeholder="Choose a mailbox" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectGroup>
-              {mailboxes
-                .filter((mailbox) => mailbox.address)
-                .map((mailbox, index) => (
-                  <SelectItem key={`${index}:${mailbox.address}`} value={mailbox.address}>
-                    {mailbox.displayName || "Mailbox"} — {mailbox.address}
-                  </SelectItem>
-                ))}
-            </SelectGroup>
-          </SelectContent>
-        </Select>
-        <FieldDescription>
-          New messages and forwards start from this mailbox. Replies use the mailbox that received
-          the original message.
-        </FieldDescription>
-      </Field>
+      {sendingEnabled ? (
+        <Field className="max-w-md">
+          <FieldLabel htmlFor="setup-default-from-mailbox">Default From mailbox</FieldLabel>
+          <Select value={defaultFromMailboxAddress} onValueChange={onSetDefaultFromMailboxAddress}>
+            <SelectTrigger id="setup-default-from-mailbox" className="w-full shadow-none">
+              <SelectValue placeholder="Choose a mailbox" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {mailboxes
+                  .filter((mailbox) => mailbox.address)
+                  .map((mailbox, index) => (
+                    <SelectItem key={`${index}:${mailbox.address}`} value={mailbox.address}>
+                      {mailbox.displayName || "Mailbox"} — {mailbox.address}
+                    </SelectItem>
+                  ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <FieldDescription>
+            New messages and forwards start from this mailbox. Replies use the mailbox that received
+            the original message.
+          </FieldDescription>
+        </Field>
+      ) : (
+        <p className="max-w-md text-sm text-muted-foreground">
+          These mailboxes can receive mail. Enable sending later in Settings → Domains.
+        </p>
+      )}
 
       {errors.form ? <FieldError>{errors.form}</FieldError> : null}
       {submitError ? (

--- a/app/features/setup/types.ts
+++ b/app/features/setup/types.ts
@@ -14,9 +14,14 @@ export type BootstrapSetupInput = {
   ownerPassword: string;
   primaryDomain: string;
   portalHostname: string;
-  emailDomains: Array<{ name: string; zoneId: string; accountId: string | null }>;
+  emailDomains: Array<{
+    name: string;
+    zoneId: string;
+    accountId: string | null;
+    sendingStatus: "ready" | "disabled";
+  }>;
   checklistAcknowledged: boolean;
-  defaultFromMailboxAddress: string;
+  defaultFromMailboxAddress: string | null;
   mailboxes: Array<{
     address: string;
     displayName: string;
@@ -41,6 +46,7 @@ export type CloudflareAccessStatus = {
 export type CloudflareDomainStatus = {
   zone: CloudflareZone;
   workerName: string;
+  sendingRequired: boolean;
   routing: {
     enabled: boolean;
     status: string | null;

--- a/app/features/setup/use-setup-cloudflare.ts
+++ b/app/features/setup/use-setup-cloudflare.ts
@@ -23,6 +23,7 @@ export function useSetupCloudflare(callbacks: {
   const [portalZoneId, setPortalZoneId] = React.useState("");
   const workerName = React.useMemo(() => inferWorkerName(), []);
   const [appSubdomain, setAppSubdomain] = React.useState("hqbase");
+  const [enableSending, setEnableSending] = React.useState(true);
   const [domainAttempted, setDomainAttempted] = React.useState(false);
   const [connectionError, setConnectionError] = React.useState<string | null>(null);
   const [results, setResults] = React.useState<ConfiguredDomain[]>([]);
@@ -37,7 +38,8 @@ export function useSetupCloudflare(callbacks: {
     ...selectedZoneIds.slice().sort(),
     portalZoneId,
     appHostname,
-    workerName
+    workerName,
+    enableSending ? "send" : "receive-only"
   ].join(":");
   const domainConnected = Boolean(
     configuredKey === currentConnectionKey &&
@@ -96,7 +98,7 @@ export function useSetupCloudflare(callbacks: {
         const result = await configureCloudflareDomain({
           ...(isPortal ? { appHostname } : {}),
           attachCustomDomain: isPortal,
-          enableSending: true,
+          enableSending,
           workerName: workerName.trim(),
           zoneId: zone.id
         });
@@ -155,6 +157,7 @@ export function useSetupCloudflare(callbacks: {
     domain: {
       appHostname,
       appSubdomain,
+      enableSending,
       connectionError,
       errors: domainErrors,
       isLoading,
@@ -167,10 +170,16 @@ export function useSetupCloudflare(callbacks: {
       onConnect: () => void handleDomainConnect(),
       onToggleZone: toggleZone,
       setAppSubdomain: (value: string) => update(() => setAppSubdomain(value)),
+      setEnableSending: (value: boolean) => update(() => setEnableSending(value)),
       setPortalZoneId: (value: string) => update(() => setPortalZoneId(value))
     },
     domainConnected,
-    emailDomains: selectedZones.map(({ accountId, id, name }) => ({ accountId, name, zoneId: id })),
+    emailDomains: selectedZones.map(({ accountId, id, name }) => ({
+      accountId,
+      name,
+      sendingStatus: enableSending ? ("ready" as const) : ("disabled" as const),
+      zoneId: id
+    })),
     primaryDomain,
     portalHostname: appHostname,
     requireConnection(message = "Connect the domains before continuing.") {

--- a/app/features/setup/use-setup-flow.ts
+++ b/app/features/setup/use-setup-flow.ts
@@ -126,7 +126,11 @@ export function useSetupFlow(onComplete: () => void) {
 
     const input: BootstrapSetupInput = {
       checklistAcknowledged: true,
-      defaultFromMailboxAddress,
+      defaultFromMailboxAddress: cloudflare.emailDomains.some(
+        (domain) => domain.sendingStatus === "ready"
+      )
+        ? defaultFromMailboxAddress
+        : null,
       mailboxes,
       ownerEmail,
       ownerName,
@@ -192,6 +196,7 @@ export function useSetupFlow(onComplete: () => void) {
       errors: mailboxErrors,
       isPending,
       mailboxes,
+      sendingEnabled: cloudflare.emailDomains.some((domain) => domain.sendingStatus === "ready"),
       submitError,
       onAdd: addMailbox,
       onBack: () => setActiveStep(OWNER_STEP),

--- a/test/integration/worker/auth.test.ts
+++ b/test/integration/worker/auth.test.ts
@@ -226,8 +226,9 @@ describe("Better Auth schema", () => {
     const timestamp = new Date().toISOString();
     await env.DB.batch([
       env.DB.prepare(
-        `INSERT INTO mail_domains (id, name, created_at, updated_at)
-         VALUES ('domain_preferences', 'preferences.example', ?, ?)`
+        `INSERT INTO mail_domains
+         (id, name, receiving_status, sending_status, dns_status, created_at, updated_at)
+         VALUES ('domain_preferences', 'preferences.example', 'ready', 'ready', 'ready', ?, ?)`
       ).bind(timestamp, timestamp),
       env.DB.prepare(
         `INSERT INTO mailboxes

--- a/test/integration/worker/receive-only-mailboxes.test.ts
+++ b/test/integration/worker/receive-only-mailboxes.test.ts
@@ -1,0 +1,57 @@
+import { env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { upsertMailDomain } from "../../../worker/features/domains/queries";
+import { findAddressIdentity } from "../../../worker/features/mailboxes/address-queries";
+import { listMailboxes } from "../../../worker/features/mailboxes/queries";
+import { createMailbox } from "../../../worker/features/mailboxes/service";
+import { applyCurrentMigrations } from "./current-migrations";
+
+describe("receive-only mailbox identities", () => {
+  beforeAll(async () => {
+    await applyCurrentMigrations();
+  });
+
+  beforeEach(async () => {
+    await env.DB.batch([
+      env.DB.prepare("DELETE FROM mailbox_addresses"),
+      env.DB.prepare("DELETE FROM mailboxes"),
+      env.DB.prepare("DELETE FROM mail_domains")
+    ]);
+  });
+
+  it("keeps receiving available while hiding sending until the domain is ready", async () => {
+    await upsertMailDomain(env.DB, {
+      name: "example.com",
+      receivingStatus: "ready",
+      sendingStatus: "disabled",
+      dnsStatus: "ready"
+    });
+    await createMailbox(env.DB, {
+      address: "support@example.com",
+      displayName: "Support"
+    });
+
+    expect((await listMailboxes(env.DB))[0]?.addresses[0]).toMatchObject({
+      receiveEnabled: true,
+      sendEnabled: true,
+      sendAvailable: false
+    });
+    await expect(
+      findAddressIdentity(env.DB, "support@example.com", "receive")
+    ).resolves.not.toBeNull();
+    await expect(findAddressIdentity(env.DB, "support@example.com", "send")).resolves.toBeNull();
+
+    await upsertMailDomain(env.DB, {
+      name: "example.com",
+      receivingStatus: "ready",
+      sendingStatus: "ready",
+      dnsStatus: "ready"
+    });
+
+    expect((await listMailboxes(env.DB))[0]?.addresses[0]?.sendAvailable).toBe(true);
+    await expect(
+      findAddressIdentity(env.DB, "support@example.com", "send")
+    ).resolves.not.toBeNull();
+  });
+});

--- a/test/integration/worker/receive-only-mailboxes.test.ts
+++ b/test/integration/worker/receive-only-mailboxes.test.ts
@@ -1,7 +1,10 @@
 import { env } from "cloudflare:test";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-import { upsertMailDomain } from "../../../worker/features/domains/queries";
+import {
+  updateMailDomainSettings,
+  upsertMailDomain
+} from "../../../worker/features/domains/queries";
 import { findAddressIdentity } from "../../../worker/features/mailboxes/address-queries";
 import { listMailboxes } from "../../../worker/features/mailboxes/queries";
 import { createMailbox } from "../../../worker/features/mailboxes/service";
@@ -21,7 +24,7 @@ describe("receive-only mailbox identities", () => {
   });
 
   it("keeps receiving available while hiding sending until the domain is ready", async () => {
-    await upsertMailDomain(env.DB, {
+    const domain = await upsertMailDomain(env.DB, {
       name: "example.com",
       receivingStatus: "ready",
       sendingStatus: "disabled",
@@ -53,5 +56,10 @@ describe("receive-only mailbox identities", () => {
     await expect(
       findAddressIdentity(env.DB, "support@example.com", "send")
     ).resolves.not.toBeNull();
+
+    await updateMailDomainSettings(env.DB, domain.id, { isEnabled: false });
+
+    expect((await listMailboxes(env.DB))[0]?.addresses[0]?.sendAvailable).toBe(false);
+    await expect(findAddressIdentity(env.DB, "support@example.com", "send")).resolves.toBeNull();
   });
 });

--- a/test/unit/app/compose/compose-state.test.ts
+++ b/test/unit/app/compose/compose-state.test.ts
@@ -46,6 +46,7 @@ describe("composer state", () => {
               displayName: "Support",
               receiveEnabled: true,
               sendEnabled: true,
+              sendAvailable: true,
               isPrimary: true
             },
             {
@@ -56,6 +57,7 @@ describe("composer state", () => {
               displayName: "Support",
               receiveEnabled: true,
               sendEnabled: false,
+              sendAvailable: false,
               isPrimary: false
             }
           ]
@@ -77,6 +79,7 @@ describe("composer state", () => {
               displayName: "Sales",
               receiveEnabled: true,
               sendEnabled: true,
+              sendAvailable: true,
               isPrimary: true
             }
           ]
@@ -86,6 +89,35 @@ describe("composer state", () => {
       { mailboxId: "mbx_1", address: "support@example.com" },
       { mailboxId: "mbx_2", address: "sales@example.net" }
     ]);
+  });
+
+  it("does not expose an address when its domain cannot send", () => {
+    expect(
+      sendingIdentities([
+        {
+          id: "mbx_1",
+          address: "support@example.com",
+          displayName: "Support",
+          isActive: true,
+          accessLevel: "manager",
+          createdAt: "now",
+          updatedAt: "now",
+          addresses: [
+            {
+              id: "addr_1",
+              mailboxId: "mbx_1",
+              mailDomainId: "dom_1",
+              address: "support@example.com",
+              displayName: "Support",
+              receiveEnabled: true,
+              sendEnabled: true,
+              sendAvailable: false,
+              isPrimary: true
+            }
+          ]
+        }
+      ])
+    ).toEqual([]);
   });
 
   it("uses crash recovery only when it is newer than the server draft", () => {
@@ -219,6 +251,7 @@ describe("composer state", () => {
             displayName: "Support",
             receiveEnabled: true,
             sendEnabled: true,
+            sendAvailable: true,
             isPrimary: true
           }
         ]
@@ -240,6 +273,7 @@ describe("composer state", () => {
             displayName: "Privacy",
             receiveEnabled: true,
             sendEnabled: true,
+            sendAvailable: true,
             isPrimary: true
           }
         ]

--- a/test/unit/app/messages/conversation-reader.test.tsx
+++ b/test/unit/app/messages/conversation-reader.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import { InboxPage } from "@/features/inbox/inbox-page";
+import type { Mailbox } from "@/features/mailboxes/types";
 import { ConversationMessages } from "@/features/messages/conversation-messages";
 import { MessageDetail } from "@/features/messages/message-detail";
 import { MessageListItem } from "@/features/messages/message-list-item";
@@ -63,12 +64,35 @@ const conversation: ConversationSummary = {
   unreadCount: 1
 };
 
+const sendableMailbox: Mailbox = {
+  id: "mbx_1",
+  address: "support@example.com",
+  addresses: [
+    {
+      id: "addr_1",
+      mailboxId: "mbx_1",
+      mailDomainId: "dom_1",
+      address: "support@example.com",
+      displayName: "Support",
+      receiveEnabled: true,
+      sendEnabled: true,
+      sendAvailable: true,
+      isPrimary: true
+    }
+  ],
+  displayName: "Support",
+  isActive: true,
+  accessLevel: "manager",
+  createdAt: "2026-07-27T14:00:00.000Z",
+  updatedAt: "2026-07-27T14:00:00.000Z"
+};
+
 describe("conversation reader", () => {
   it("renders Reply and Forward under the last message", () => {
     const html = renderToStaticMarkup(
       <MessageDetail
         defaultFromMailboxId="mbx_1"
-        mailboxes={[]}
+        mailboxes={[sendableMailbox]}
         messages={[firstMessage, secondMessage]}
         selectedId={secondMessage.id}
         onAction={() => undefined}

--- a/test/unit/app/settings/settings-presentation.test.tsx
+++ b/test/unit/app/settings/settings-presentation.test.tsx
@@ -26,7 +26,19 @@ const setup = {
 const mailbox: Mailbox = {
   id: "mailbox-1",
   address: "support@example.com",
-  addresses: [],
+  addresses: [
+    {
+      id: "address-1",
+      mailboxId: "mailbox-1",
+      mailDomainId: "domain-1",
+      address: "support@example.com",
+      displayName: "Support",
+      receiveEnabled: true,
+      sendEnabled: true,
+      sendAvailable: true,
+      isPrimary: true
+    }
+  ],
   displayName: "Support",
   isActive: true,
   accessLevel: "manager",
@@ -38,6 +50,19 @@ const secondDomainMailbox: Mailbox = {
   ...mailbox,
   id: "mailbox-2",
   address: "privacy@example.net",
+  addresses: [
+    {
+      id: "address-2",
+      mailboxId: "mailbox-2",
+      mailDomainId: "domain-2",
+      address: "privacy@example.net",
+      displayName: "Privacy",
+      receiveEnabled: true,
+      sendEnabled: true,
+      sendAvailable: true,
+      isPrimary: true
+    }
+  ],
   displayName: "Privacy"
 };
 
@@ -229,6 +254,25 @@ describe("settings presentation", () => {
     expect(html).toContain('aria-label="Filter mailboxes by domain"');
   });
 
+  it("does not offer a default From mailbox for a receive-only domain", () => {
+    const receiveOnlyMailbox: Mailbox = {
+      ...mailbox,
+      addresses: mailbox.addresses.map((address) => ({ ...address, sendAvailable: false }))
+    };
+    const html = renderToStaticMarkup(
+      <MailboxSettings
+        canManage
+        defaultFromMailboxId={null}
+        mailboxes={[receiveOnlyMailbox]}
+        users={[member]}
+        onChanged={() => undefined}
+        onDefaultFromMailboxChange={() => undefined}
+      />
+    );
+
+    expect(html).not.toContain("Default From mailbox");
+  });
+
   it("only shows one bulk action after mailbox selection", () => {
     expect(
       renderToStaticMarkup(<MailboxSelectionBar selectedCount={0} onManage={() => undefined} />)
@@ -259,7 +303,12 @@ describe("settings presentation", () => {
 
   it("renders connected domains in the compact settings table", () => {
     const html = renderToStaticMarkup(
-      <DomainTable domains={[connectedDomain]} pendingDomainId={null} onToggle={() => undefined} />
+      <DomainTable
+        domains={[connectedDomain]}
+        pendingDomainId={null}
+        onEnableSending={() => undefined}
+        onToggle={() => undefined}
+      />
     );
 
     expect(html).toContain(">Domain<");

--- a/test/unit/app/setup/setup-ui.test.tsx
+++ b/test/unit/app/setup/setup-ui.test.tsx
@@ -143,4 +143,27 @@ describe("setup UI", () => {
     expect(html).not.toContain(">Review<");
     expect(html).not.toContain(">Mailbox 1<");
   });
+
+  it("shows receive-only guidance without a default From control", () => {
+    const html = renderToStaticMarkup(
+      <MailboxStep
+        defaultFromMailboxAddress=""
+        errors={{ rows: [{}] }}
+        isPending={false}
+        mailboxes={[{ address: "support@northstar.example", displayName: "Support" }]}
+        sendingEnabled={false}
+        onAdd={() => undefined}
+        onBack={() => undefined}
+        onComplete={() => undefined}
+        onRemove={() => undefined}
+        onSetDefaultFromMailboxAddress={() => undefined}
+        onUpdate={() => undefined}
+        submitError={null}
+      />
+    );
+
+    expect(html).not.toContain("Default From mailbox");
+    expect(html).toContain("These mailboxes can receive mail");
+    expect(html).toContain("Enable sending later in Settings");
+  });
 });

--- a/test/unit/app/setup/setup-ui.test.tsx
+++ b/test/unit/app/setup/setup-ui.test.tsx
@@ -121,6 +121,7 @@ describe("setup UI", () => {
         errors={{ rows: mailboxes.map(() => ({})) }}
         isPending={false}
         mailboxes={mailboxes}
+        sendingEnabled
         onAdd={() => undefined}
         onBack={() => undefined}
         onComplete={() => undefined}

--- a/test/unit/worker/features/setup/api-validation.test.ts
+++ b/test/unit/worker/features/setup/api-validation.test.ts
@@ -54,7 +54,10 @@ describe("setup API validation", () => {
         ownerName: "Owner",
         ownerEmail: "owner@example.com",
         ownerPassword: "password123",
-        emailDomains: [{ name: "support.example" }, { name: "example.com" }],
+        emailDomains: [
+          { name: "support.example", sendingStatus: "ready" },
+          { name: "example.com", sendingStatus: "ready" }
+        ],
         checklistAcknowledged: true,
         defaultFromMailboxAddress: "hello@example.com",
         mailboxes: [{ address: "hello@example.com", displayName: "Hello" }]
@@ -90,7 +93,41 @@ describe("setup API validation", () => {
         defaultFromMailboxAddress: "privacy@example.com",
         mailboxes: [{ address: "hello@example.com", displayName: "Hello" }]
       })
-    ).toThrow("Choose one of the setup mailboxes as the default From mailbox.");
+    ).toThrow("Choose a mailbox on a send-enabled domain as the default From mailbox.");
+  });
+
+  it("accepts receive-only setup without a default From mailbox", () => {
+    expect(
+      bootstrapSetupSchema.parse({
+        ownerName: "Owner",
+        ownerEmail: "owner@gmail.com",
+        ownerPassword: "password123",
+        emailDomains: [{ name: "example.com", sendingStatus: "disabled" }],
+        checklistAcknowledged: true,
+        defaultFromMailboxAddress: null,
+        mailboxes: [{ address: "hello@example.com", displayName: "Hello" }]
+      })
+    ).toMatchObject({ defaultFromMailboxAddress: null });
+  });
+
+  it("requires a send-enabled default From mailbox when any domain can send", () => {
+    expect(() =>
+      bootstrapSetupSchema.parse({
+        ownerName: "Owner",
+        ownerEmail: "owner@gmail.com",
+        ownerPassword: "password123",
+        emailDomains: [
+          { name: "receive.example", sendingStatus: "disabled" },
+          { name: "send.example", sendingStatus: "ready" }
+        ],
+        checklistAcknowledged: true,
+        defaultFromMailboxAddress: "hello@receive.example",
+        mailboxes: [
+          { address: "hello@receive.example", displayName: "Hello" },
+          { address: "support@send.example", displayName: "Support" }
+        ]
+      })
+    ).toThrow("Choose a mailbox on a send-enabled domain as the default From mailbox.");
   });
 
   it("rejects credentials in Cloudflare zone listing input", () => {

--- a/test/unit/worker/features/setup/bootstrap-service.test.ts
+++ b/test/unit/worker/features/setup/bootstrap-service.test.ts
@@ -1,0 +1,56 @@
+import type { WorkerEnv } from "@worker/lib/env";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createMailbox: vi.fn(),
+  getSetupStatus: vi.fn(),
+  setChecklistAcknowledged: vi.fn(),
+  setDefaultFromMailboxId: vi.fn(),
+  setPrimaryDomain: vi.fn(),
+  setSetupComplete: vi.fn(),
+  signUpOwnerUser: vi.fn(),
+  upsertMailDomain: vi.fn(),
+  upsertWorkspaceHost: vi.fn()
+}));
+
+vi.mock("@worker/auth/user-actions", () => ({ signUpOwnerUser: mocks.signUpOwnerUser }));
+vi.mock("@worker/features/domains/queries", () => ({ upsertMailDomain: mocks.upsertMailDomain }));
+vi.mock("@worker/features/mailboxes/service", () => ({ createMailbox: mocks.createMailbox }));
+vi.mock("@worker/features/preferences/queries", () => ({
+  setDefaultFromMailboxId: mocks.setDefaultFromMailboxId
+}));
+vi.mock("@worker/features/setup/queries", () => ({
+  getSetupStatus: mocks.getSetupStatus,
+  setChecklistAcknowledged: mocks.setChecklistAcknowledged,
+  setPrimaryDomain: mocks.setPrimaryDomain,
+  setSetupComplete: mocks.setSetupComplete,
+  upsertWorkspaceHost: mocks.upsertWorkspaceHost
+}));
+
+import { bootstrapSetup } from "@worker/features/setup/service";
+
+describe("setup bootstrap service validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSetupStatus.mockResolvedValue({ isComplete: false, userCount: 0 });
+  });
+
+  it("rejects a missing default From mailbox before creating sending-enabled setup records", async () => {
+    const env = { DB: {} as D1Database } as WorkerEnv;
+
+    await expect(
+      bootstrapSetup(env, new Request("https://hqbase.test/api/setup/bootstrap"), {
+        checklistAcknowledged: true,
+        defaultFromMailboxAddress: null,
+        emailDomains: [{ name: "example.com", sendingStatus: "ready" }],
+        mailboxes: [{ address: "support@example.com", displayName: "Support" }],
+        ownerEmail: "owner@gmail.com",
+        ownerName: "Owner",
+        ownerPassword: "password123"
+      })
+    ).rejects.toMatchObject({ code: "DEFAULT_FROM_MAILBOX_REQUIRED", status: 400 });
+
+    expect(mocks.upsertMailDomain).not.toHaveBeenCalled();
+    expect(mocks.signUpOwnerUser).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/worker/features/setup/cloudflare-setup-api.test.ts
+++ b/test/unit/worker/features/setup/cloudflare-setup-api.test.ts
@@ -234,6 +234,38 @@ describe("Cloudflare setup API", () => {
     ).toBe(false);
   });
 
+  it("finishes receive-only setup without changing Email Sending", async () => {
+    const fetchMock = vi.fn<typeof fetch>((input, init) => {
+      const url = fetchInputUrl(input);
+      const method = init?.method ?? "GET";
+      if (url === `${API_BASE}/zones/zone-1/email/sending/subdomains`) {
+        return Promise.resolve(jsonResponse({ result: [] }));
+      }
+      return Promise.resolve(cloudflareSetupResponse(url, method));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await configureCloudflareDomain({
+      apiToken: "token-123",
+      enableSending: false,
+      workerName: "hqbase",
+      zoneId: "zone-1"
+    });
+
+    expect(result.status).toMatchObject({ ready: true, sendingRequired: false });
+    expect(result.steps.find((step) => step.id === "sending")).toMatchObject({
+      message: "Skipped. This workspace receives mail but cannot send it.",
+      status: "skipped"
+    });
+    expect(
+      fetchMock.mock.calls.some(
+        ([input, init]) =>
+          fetchInputUrl(input) === `${API_BASE}/zones/zone-1/email/sending/subdomains` &&
+          init?.method === "POST"
+      )
+    ).toBe(false);
+  });
+
   it("accepts the current Email Routing DNS record response", async () => {
     const fetchMock = vi.fn<typeof fetch>((input, init) => {
       const url = fetchInputUrl(input);

--- a/worker/features/domains/routes.ts
+++ b/worker/features/domains/routes.ts
@@ -123,7 +123,11 @@ domainRoutes.post("/provision", async (c) => {
     accountId: result.status.zone.accountId,
     receivingStatus:
       result.status.routing.enabled && result.status.catchAll.enabled ? "ready" : "degraded",
-    sendingStatus: result.status.sending.enabled ? "ready" : "degraded",
+    sendingStatus: input.enableSending
+      ? result.status.sending.enabled
+        ? "ready"
+        : "degraded"
+      : "disabled",
     dnsStatus: result.status.routing.dnsReady ? "ready" : "degraded"
   });
   await recordAudit(c.env.DB, {

--- a/worker/features/mailboxes/address-queries.ts
+++ b/worker/features/mailboxes/address-queries.ts
@@ -22,7 +22,7 @@ export async function findAddressIdentity(
   >(
     db,
     sql`SELECT a.id, a.mailbox_id, a.mail_domain_id, a.address, a.display_name,
-            a.receive_enabled, a.send_enabled, a.is_primary,
+            a.receive_enabled, a.send_enabled, a.is_primary, d.sending_status,
             m.address AS mailbox_address, m.display_name AS mailbox_display_name,
             m.is_active, m.created_at, m.updated_at
      FROM mailbox_addresses a

--- a/worker/features/mailboxes/address-queries.ts
+++ b/worker/features/mailboxes/address-queries.ts
@@ -23,6 +23,7 @@ export async function findAddressIdentity(
     db,
     sql`SELECT a.id, a.mailbox_id, a.mail_domain_id, a.address, a.display_name,
             a.receive_enabled, a.send_enabled, a.is_primary, d.sending_status,
+            d.is_enabled AS domain_is_enabled,
             m.address AS mailbox_address, m.display_name AS mailbox_display_name,
             m.is_active, m.created_at, m.updated_at
      FROM mailbox_addresses a

--- a/worker/features/mailboxes/queries.ts
+++ b/worker/features/mailboxes/queries.ts
@@ -37,6 +37,7 @@ export function mapMailboxAddress(row: MailboxAddressRow): MailboxAddress {
     displayName: row.display_name,
     receiveEnabled: row.receive_enabled === 1,
     sendEnabled: row.send_enabled === 1,
+    sendAvailable: row.send_enabled === 1 && row.sending_status === "ready",
     isPrimary: row.is_primary === 1
   };
 }
@@ -49,9 +50,10 @@ export async function addressMap(
   if (mailboxIds.length === 0) return mapped;
   const rows = await getRows<MailboxAddressRow>(
     db,
-    sql`SELECT id, mailbox_id, mail_domain_id, address, display_name,
-     receive_enabled, send_enabled, is_primary
-     FROM mailbox_addresses
+    sql`SELECT a.id, a.mailbox_id, a.mail_domain_id, a.address, a.display_name,
+     a.receive_enabled, a.send_enabled, a.is_primary, d.sending_status
+     FROM mailbox_addresses a
+     JOIN mail_domains d ON d.id = a.mail_domain_id
      WHERE mailbox_id IN (${sql.join(
        mailboxIds.map((mailboxId) => sql`${mailboxId}`),
        sql`, `
@@ -158,7 +160,8 @@ export async function findMailboxById(db: D1Database, id: string): Promise<Mailb
 export async function insertMailbox(
   db: D1Database,
   input: CreateMailboxInput,
-  mailDomainId: string
+  mailDomainId: string,
+  sendingReady: boolean
 ): Promise<Mailbox> {
   const timestamp = nowIso();
   const id = newId("mbx");
@@ -201,6 +204,7 @@ export async function insertMailbox(
         displayName: input.displayName,
         receiveEnabled: true,
         sendEnabled: true,
+        sendAvailable: sendingReady,
         isPrimary: true
       }
     ],
@@ -215,7 +219,8 @@ export async function insertMailboxAddress(
   db: D1Database,
   mailboxId: string,
   mailDomainId: string,
-  input: CreateMailboxAddressInput
+  input: CreateMailboxAddressInput,
+  sendingReady: boolean
 ): Promise<MailboxAddress> {
   const id = newId("addr");
   const timestamp = nowIso();
@@ -243,6 +248,7 @@ export async function insertMailboxAddress(
     displayName: input.displayName,
     receiveEnabled: input.receiveEnabled !== false,
     sendEnabled: input.sendEnabled !== false,
+    sendAvailable: input.sendEnabled !== false && sendingReady,
     isPrimary: false
   };
 }

--- a/worker/features/mailboxes/queries.ts
+++ b/worker/features/mailboxes/queries.ts
@@ -37,7 +37,8 @@ export function mapMailboxAddress(row: MailboxAddressRow): MailboxAddress {
     displayName: row.display_name,
     receiveEnabled: row.receive_enabled === 1,
     sendEnabled: row.send_enabled === 1,
-    sendAvailable: row.send_enabled === 1 && row.sending_status === "ready",
+    sendAvailable:
+      row.send_enabled === 1 && row.domain_is_enabled === 1 && row.sending_status === "ready",
     isPrimary: row.is_primary === 1
   };
 }
@@ -51,7 +52,8 @@ export async function addressMap(
   const rows = await getRows<MailboxAddressRow>(
     db,
     sql`SELECT a.id, a.mailbox_id, a.mail_domain_id, a.address, a.display_name,
-     a.receive_enabled, a.send_enabled, a.is_primary, d.sending_status
+     a.receive_enabled, a.send_enabled, a.is_primary, d.sending_status,
+     d.is_enabled AS domain_is_enabled
      FROM mailbox_addresses a
      JOIN mail_domains d ON d.id = a.mail_domain_id
      WHERE mailbox_id IN (${sql.join(

--- a/worker/features/mailboxes/service.ts
+++ b/worker/features/mailboxes/service.ts
@@ -29,7 +29,7 @@ export async function createMailbox(db: D1Database, input: CreateMailboxInput): 
     throw new AppError("MAILBOX_EXISTS", "A mailbox with this address already exists.", 409);
   }
 
-  return insertMailbox(db, input, domain.id);
+  return insertMailbox(db, input, domain.id, domain.sendingStatus === "ready");
 }
 
 export async function createMailboxAddress(
@@ -46,7 +46,7 @@ export async function createMailboxAddress(
   if (await findMailboxByAddress(db, input.address)) {
     throw new AppError("MAILBOX_ADDRESS_EXISTS", "This email address is already in use.", 409);
   }
-  return insertMailboxAddress(db, mailboxId, domain.id, input);
+  return insertMailboxAddress(db, mailboxId, domain.id, input, domain.sendingStatus === "ready");
 }
 
 export async function removeMailboxAddress(

--- a/worker/features/mailboxes/types.ts
+++ b/worker/features/mailboxes/types.ts
@@ -29,6 +29,7 @@ export type MailboxAddressRow = {
   receive_enabled: number;
   send_enabled: number;
   sending_status: "pending" | "ready" | "degraded" | "disabled";
+  domain_is_enabled: number;
   is_primary: number;
 };
 

--- a/worker/features/mailboxes/types.ts
+++ b/worker/features/mailboxes/types.ts
@@ -16,6 +16,7 @@ export type MailboxAddress = {
   displayName: string;
   receiveEnabled: boolean;
   sendEnabled: boolean;
+  sendAvailable: boolean;
   isPrimary: boolean;
 };
 
@@ -27,6 +28,7 @@ export type MailboxAddressRow = {
   display_name: string;
   receive_enabled: number;
   send_enabled: number;
+  sending_status: "pending" | "ready" | "degraded" | "disabled";
   is_primary: number;
 };
 

--- a/worker/features/preferences/service.ts
+++ b/worker/features/preferences/service.ts
@@ -14,9 +14,9 @@ export async function updateDefaultFromMailbox(
 ): Promise<void> {
   await requireMailboxAccess(db, input.userId, input.role, input.mailboxId, "agent");
   const mailbox = await findMailboxById(db, input.mailboxId);
-  const primaryCanSend =
-    mailbox?.addresses.length === 0 ||
-    mailbox?.addresses.some((address) => address.isPrimary && address.sendEnabled);
+  const primaryCanSend = mailbox?.addresses.some(
+    (address) => address.isPrimary && address.sendAvailable
+  );
   if (!mailbox?.isActive || !primaryCanSend) {
     throw new AppError(
       "MAILBOX_NOT_SENDABLE",

--- a/worker/features/preferences/service.ts
+++ b/worker/features/preferences/service.ts
@@ -20,7 +20,7 @@ export async function updateDefaultFromMailbox(
   if (!mailbox?.isActive || !primaryCanSend) {
     throw new AppError(
       "MAILBOX_NOT_SENDABLE",
-      "Choose an active mailbox with a send-enabled primary address.",
+      "Choose an active mailbox with a primary address that can send.",
       400
     );
   }

--- a/worker/features/setup/cloudflare.ts
+++ b/worker/features/setup/cloudflare.ts
@@ -18,6 +18,7 @@ type CloudflareInput = { apiToken: string };
 type CloudflareZoneInput = CloudflareInput & {
   zoneId: string;
   workerName?: string | undefined;
+  requireSending?: boolean | undefined;
 };
 
 type CloudflareConfigureInput = CloudflareZoneInput & {
@@ -114,6 +115,7 @@ export async function inspectCloudflareDomain(
   input: CloudflareZoneInput
 ): Promise<CloudflareDomainStatus> {
   const workerName = normalizeWorkerName(input.workerName);
+  const sendingRequired = input.requireSending ?? true;
   const zone = mapZone(
     await cloudflareRequestResult(input.apiToken, `/zones/${input.zoneId}`, cloudflareZoneSchema)
   );
@@ -130,13 +132,14 @@ export async function inspectCloudflareDomain(
     routing.dnsReady &&
     catchAll.enabled &&
     catchAll.configuredForWorker &&
-    sending.enabled;
+    (!sendingRequired || sending.enabled);
 
   return {
     catchAll,
     ready,
     routing,
     sending,
+    sendingRequired,
     workerName,
     zone
   };
@@ -229,7 +232,7 @@ export async function configureCloudflareDomain(
     steps.push({
       id: "sending",
       label: "Enable Email Sending",
-      message: "Skipped by setup option.",
+      message: "Skipped. This workspace receives mail but cannot send it.",
       status: "skipped"
     });
   }
@@ -237,6 +240,7 @@ export async function configureCloudflareDomain(
   return {
     status: await inspectCloudflareDomain({
       apiToken: input.apiToken,
+      requireSending: input.enableSending,
       workerName,
       zoneId: zone.id
     }),

--- a/worker/features/setup/service.ts
+++ b/worker/features/setup/service.ts
@@ -27,10 +27,11 @@ type BootstrapInput = {
         name: string;
         zoneId?: string | null | undefined;
         accountId?: string | null | undefined;
+        sendingStatus: "ready" | "disabled";
       }>
     | undefined;
   checklistAcknowledged: boolean;
-  defaultFromMailboxAddress: string;
+  defaultFromMailboxAddress: string | null;
   mailboxes: Array<{
     address: string;
     displayName: string;
@@ -50,7 +51,9 @@ export async function bootstrapSetup(
     throw new AppError("SETUP_OWNER_EXISTS", "An owner user already exists.", 409);
   }
 
-  const domains = input.emailDomains ?? [{ name: input.primaryDomain ?? "" }];
+  const domains = input.emailDomains ?? [
+    { name: input.primaryDomain ?? "", sendingStatus: "ready" as const }
+  ];
   if (!domains[0]?.name) throw new AppError("DOMAIN_REQUIRED", "Choose an email domain.", 400);
   assertLoginEmailOutsideDomains(
     input.ownerEmail,
@@ -61,7 +64,7 @@ export async function bootstrapSetup(
     await upsertMailDomain(env.DB, {
       ...domain,
       receivingStatus: "ready",
-      sendingStatus: "ready",
+      sendingStatus: domain.sendingStatus,
       dnsStatus: "ready"
     });
   }
@@ -89,17 +92,19 @@ export async function bootstrapSetup(
   for (const mailbox of input.mailboxes) {
     mailboxes.push(await createMailbox(env.DB, mailbox));
   }
-  const defaultFromMailbox = mailboxes.find(
-    (mailbox) => mailbox.address === input.defaultFromMailboxAddress
-  );
-  if (!defaultFromMailbox) {
-    throw new AppError(
-      "DEFAULT_FROM_MAILBOX_REQUIRED",
-      "Choose one of the setup mailboxes as the default From mailbox.",
-      400
+  if (input.defaultFromMailboxAddress) {
+    const defaultFromMailbox = mailboxes.find(
+      (mailbox) => mailbox.address === input.defaultFromMailboxAddress
     );
+    if (!defaultFromMailbox) {
+      throw new AppError(
+        "DEFAULT_FROM_MAILBOX_REQUIRED",
+        "Choose one of the setup mailboxes as the default From mailbox.",
+        400
+      );
+    }
+    await setDefaultFromMailboxId(env.DB, owner.id, defaultFromMailbox.id);
   }
-  await setDefaultFromMailboxId(env.DB, owner.id, defaultFromMailbox.id);
 
   await completeSetupIfReady(env.DB);
 

--- a/worker/features/setup/service.ts
+++ b/worker/features/setup/service.ts
@@ -55,6 +55,29 @@ export async function bootstrapSetup(
     { name: input.primaryDomain ?? "", sendingStatus: "ready" as const }
   ];
   if (!domains[0]?.name) throw new AppError("DOMAIN_REQUIRED", "Choose an email domain.", 400);
+  const sendingDomains = new Set(
+    domains.filter((domain) => domain.sendingStatus === "ready").map((domain) => domain.name)
+  );
+  const defaultFromDomain = input.defaultFromMailboxAddress?.split("@")[1];
+  if (
+    sendingDomains.size > 0 &&
+    (!input.defaultFromMailboxAddress ||
+      !defaultFromDomain ||
+      !sendingDomains.has(defaultFromDomain))
+  ) {
+    throw new AppError(
+      "DEFAULT_FROM_MAILBOX_REQUIRED",
+      "Choose one of the setup mailboxes on a send-enabled domain as the default From mailbox.",
+      400
+    );
+  }
+  if (sendingDomains.size === 0 && input.defaultFromMailboxAddress !== null) {
+    throw new AppError(
+      "DEFAULT_FROM_MAILBOX_NOT_ALLOWED",
+      "Receive-only setup must not choose a default From mailbox.",
+      400
+    );
+  }
   assertLoginEmailOutsideDomains(
     input.ownerEmail,
     domains.map((domain) => domain.name)

--- a/worker/features/setup/types.ts
+++ b/worker/features/setup/types.ts
@@ -70,6 +70,7 @@ export type CloudflareSendingStatus = {
 export type CloudflareDomainStatus = {
   zone: CloudflareZone;
   workerName: string;
+  sendingRequired: boolean;
   routing: CloudflareRoutingStatus;
   catchAll: CloudflareCatchAllStatus;
   sending: CloudflareSendingStatus;

--- a/worker/features/setup/validation.ts
+++ b/worker/features/setup/validation.ts
@@ -27,14 +27,15 @@ export const bootstrapSetupSchema = z
         z.object({
           name: domainSchema,
           zoneId: z.string().trim().min(1).max(64).nullable().optional(),
-          accountId: z.string().trim().min(1).max(64).nullable().optional()
+          accountId: z.string().trim().min(1).max(64).nullable().optional(),
+          sendingStatus: z.enum(["ready", "disabled"])
         })
       )
       .min(1)
       .max(50)
       .optional(),
     checklistAcknowledged: z.literal(true),
-    defaultFromMailboxAddress: emailAddressSchema,
+    defaultFromMailboxAddress: emailAddressSchema.nullable(),
     mailboxes: z.array(createMailboxSchema).min(1).max(20)
   })
   .superRefine((input, context) => {
@@ -75,10 +76,28 @@ export const bootstrapSetupSchema = z
       }
       seen.add(mailbox.address);
     }
-    if (!input.mailboxes.some((mailbox) => mailbox.address === input.defaultFromMailboxAddress)) {
+    const sendingDomains = new Set(
+      input.emailDomains
+        ?.filter((domain) => domain.sendingStatus === "ready")
+        .map((domain) => domain.name) ?? domains
+    );
+    const defaultFromMailbox = input.mailboxes.find(
+      (mailbox) => mailbox.address === input.defaultFromMailboxAddress
+    );
+    const defaultFromDomain = defaultFromMailbox?.address.split("@")[1];
+    if (
+      sendingDomains.size > 0 &&
+      (!defaultFromMailbox || !defaultFromDomain || !sendingDomains.has(defaultFromDomain))
+    ) {
       context.addIssue({
         code: "custom",
-        message: "Choose one of the setup mailboxes as the default From mailbox.",
+        message: "Choose a mailbox on a send-enabled domain as the default From mailbox.",
+        path: ["defaultFromMailboxAddress"]
+      });
+    } else if (sendingDomains.size === 0 && input.defaultFromMailboxAddress !== null) {
+      context.addIssue({
+        code: "custom",
+        message: "Receive-only setup must not choose a default From mailbox.",
         path: ["defaultFromMailboxAddress"]
       });
     }
@@ -90,6 +109,7 @@ export const listCloudflareZonesSchema = z.object({}).strict();
 
 export const inspectCloudflareDomainSchema = z.object({
   workerName: z.string().trim().min(1).max(63).optional(),
+  requireSending: z.boolean().optional(),
   zoneId: z.string().trim().min(1).max(64)
 });
 


### PR DESCRIPTION
## Summary

- let setup and later domain connections skip outbound sending
- persist each domain as sending disabled instead of falsely marking it ready
- allow receive-only setup without a default From mailbox
- remove compose, reply, forward, and Default From options until a domain can send
- add an owner and admin flow that uses fresh Cloudflare authorization to enable sending later
- verify Cloudflare configuration, API validation, identity filtering, and D1 readiness behavior

This replaces the receive-only part of #20 and completes the behavior first proposed by @MRZHUH.

## Documentation

- HQBase/hqbase-site#24

The setup-race repair is separate in #63.

## Verification

- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-pr20-receive-check-final.log pnpm check`
- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-pr20-receive-dry-run-final.log pnpm deploy:dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added receive-only domain setup, allowing users to connect domains without enabling outbound sending.
  * Added an option to enable outbound sending during domain setup and later from domain settings.
  * Added status messaging and guidance for domains that can receive but not send mail.
* **Bug Fixes**
  * Disabled compose and default “From” selections when no send-capable mailbox is available.
  * Improved validation for default sending mailboxes.
* **Tests**
  * Added coverage for receive-only configurations and sending availability transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->