### PR TITLE
Fix literal Mail API search terms

### DIFF
--- a/api/hqbase-mail-api-v1.openapi.json
+++ b/api/hqbase-mail-api-v1.openapi.json
@@ -335,7 +335,7 @@
               "type": "string",
               "maxLength": 200
             },
-            "description": "Search subject, sender, recipient, and message text."
+            "description": "Search one literal substring in the subject, sender, To recipients, snippet, and plain-text body. The characters %, _, and \\ are ordinary text."
           },
           {
             "in": "query",
@@ -1142,7 +1142,7 @@
               "type": "string",
               "maxLength": 200
             },
-            "description": "Search subject, sender, recipient, and message text."
+            "description": "Search one literal substring in the subject, sender, To recipients, snippet, and plain-text body. The characters %, _, and \\ are ordinary text."
           },
           {
             "in": "query",

--- a/api/hqbase-mail-api-v1.postman_collection.json
+++ b/api/hqbase-mail-api-v1.postman_collection.json
@@ -210,7 +210,7 @@
                   "key": "search",
                   "value": "",
                   "disabled": true,
-                  "description": "Search subject, sender, recipient, and message text."
+                  "description": "Search one literal substring in the subject, sender, To recipients, snippet, and plain-text body. The characters %, _, and \\ are ordinary text."
                 },
                 {
                   "key": "limit",
@@ -402,7 +402,7 @@
                   "key": "search",
                   "value": "",
                   "disabled": true,
-                  "description": "Search subject, sender, recipient, and message text."
+                  "description": "Search one literal substring in the subject, sender, To recipients, snippet, and plain-text body. The characters %, _, and \\ are ordinary text."
                 },
                 {
                   "key": "cursor",

--- a/test/integration/worker/message-search.test.ts
+++ b/test/integration/worker/message-search.test.ts
@@ -1,0 +1,63 @@
+import { env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { listConversationPage } from "../../../worker/features/messages/conversation-queries";
+import { listMessagePage } from "../../../worker/features/messages/queries";
+import { applyCurrentMigrations } from "./current-migrations";
+
+const mailboxId = "mbx_search";
+const scope = { includeUnassigned: false, mailboxIds: [mailboxId] };
+
+describe("message search", () => {
+  beforeAll(async () => {
+    await applyCurrentMigrations();
+    const stamp = "2026-08-22T00:00:00.000Z";
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO mailboxes (id, address, display_name, is_active, created_at, updated_at)
+         VALUES (?, 'search@example.com', 'Search', 1, ?, ?)`
+      ).bind(mailboxId, stamp, stamp),
+      ...searchMessageRows("percent", "Save 100% today", stamp),
+      ...searchMessageRows("percent_noise", "Save 100 dollars today", stamp),
+      ...searchMessageRows("underscore", "Project a_b", stamp),
+      ...searchMessageRows("underscore_noise", "Project axb", stamp),
+      ...searchMessageRows("backslash", String.raw`Path C:\mail`, stamp),
+      ...searchMessageRows("backslash_noise", "Path C:/mail", stamp)
+    ]);
+  });
+
+  it.each([
+    ["100%", "msg_search_percent"],
+    ["a_b", "msg_search_underscore"],
+    [String.raw`C:\mail`, "msg_search_backslash"]
+  ])("treats metacharacters as literal text in both search paths", async (search, expectedId) => {
+    const messagePage = await listMessagePage(env.DB, { scope, search });
+    const conversationPage = await listConversationPage(env.DB, { scope, search });
+
+    expect(messagePage.messages.map((message) => message.id)).toEqual([expectedId]);
+    expect(conversationPage.conversations.map((conversation) => conversation.id)).toEqual([
+      expectedId
+    ]);
+  });
+});
+
+function searchMessageRows(id: string, subject: string, stamp: string): D1PreparedStatement[] {
+  const threadId = `thr_search_${id}`;
+  const messageId = `msg_search_${id}`;
+  return [
+    env.DB.prepare(
+      `INSERT INTO threads (id, subject_normalized, last_message_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`
+    ).bind(threadId, subject, stamp, stamp, stamp),
+    env.DB.prepare(
+      `INSERT INTO messages (
+         id, thread_id, mailbox_id, direction, folder, from_address, to_json, cc_json, bcc_json,
+         subject, snippet, text_body, references_json, received_at, has_attachments,
+         created_at, updated_at
+       ) VALUES (
+         ?, ?, ?, 'inbound', 'inbox', 'sender@example.net', '[]', '[]', '[]',
+         ?, '', '', '[]', ?, 0, ?, ?
+       )`
+    ).bind(messageId, threadId, mailboxId, subject, stamp, stamp, stamp)
+  ];
+}

--- a/worker/features/messages/conversation-queries.ts
+++ b/worker/features/messages/conversation-queries.ts
@@ -9,6 +9,7 @@ import { AppError } from "../../lib/errors";
 
 import type { MessageAction } from "./actions";
 import { decodeKeysetCursor, encodeKeysetCursor, type KeysetCursor } from "./keyset-cursor";
+import { literalSearchPattern } from "./search";
 import type {
   ConversationFolder,
   ConversationPage,
@@ -67,11 +68,13 @@ export async function listConversationPage(
     eligibilityWhere.push(sql`accessible.folder = ${filters.folder}`);
   }
   if (filters.search) {
-    const like = `%${filters.search}%`;
+    const like = literalSearchPattern(filters.search);
     eligibilityWhere.push(
-      sql`(accessible.subject LIKE ${like} OR accessible.from_address LIKE ${like}
-           OR accessible.to_json LIKE ${like} OR accessible.snippet LIKE ${like}
-           OR accessible.text_body LIKE ${like})`
+      sql`(accessible.subject LIKE ${like} ESCAPE '\\'
+           OR accessible.from_address LIKE ${like} ESCAPE '\\'
+           OR accessible.to_json LIKE ${like} ESCAPE '\\'
+           OR accessible.snippet LIKE ${like} ESCAPE '\\'
+           OR accessible.text_body LIKE ${like} ESCAPE '\\')`
     );
   }
 

--- a/worker/features/messages/queries.ts
+++ b/worker/features/messages/queries.ts
@@ -9,6 +9,7 @@ import { AppError } from "../../lib/errors";
 import type { MessageAction } from "./actions";
 import { buildMessageActionPatch } from "./actions";
 import { decodeKeysetCursor, encodeKeysetCursor, type KeysetCursor } from "./keyset-cursor";
+import { literalSearchPattern } from "./search";
 import type {
   AttachmentRow,
   InsertAttachmentInput,
@@ -155,10 +156,11 @@ export async function listMessagePage(
     where.push(sql`mailbox_id = ${filters.mailboxId}`);
   }
   if (filters.search) {
-    const like = `%${filters.search}%`;
+    const like = literalSearchPattern(filters.search);
     where.push(
-      sql`(subject LIKE ${like} OR from_address LIKE ${like} OR to_json LIKE ${like}
-           OR snippet LIKE ${like} OR text_body LIKE ${like})`
+      sql`(subject LIKE ${like} ESCAPE '\\' OR from_address LIKE ${like} ESCAPE '\\'
+           OR to_json LIKE ${like} ESCAPE '\\' OR snippet LIKE ${like} ESCAPE '\\'
+           OR text_body LIKE ${like} ESCAPE '\\')`
     );
   }
 

--- a/worker/features/messages/search.ts
+++ b/worker/features/messages/search.ts
@@ -1,0 +1,4 @@
+/** Escapes user text for a literal substring match with `LIKE ... ESCAPE '\\'`. */
+export function literalSearchPattern(value: string): string {
+  return `%${value.replace(/[\\%_]/gu, "\\$&")}%`;
+}


### PR DESCRIPTION
## Summary

- Escape percent, underscore, and backslash before both Mail API LIKE predicates.
- Use one shared helper for message and conversation search.
- Add Worker integration coverage for literal percent, underscore, and backslash searches.
- Update the OpenAPI source and generated Postman collection.

## Documentation

- HQBase/hqbase-site#25

## Issue scope

Closes #44.

This PR does not implement #49. D1 supports FTS5, but the proposed external-content column does not exist on messages and a one-statement rebuild is not a safe update path for large databases. That issue should stay open for a bounded backfill design.

## Validation

- pnpm check
- pnpm deploy:dry-run