### PR TITLE
fix: forward original attachments from web composer

### DIFF
--- a/test/integration/worker/mail-api.test.ts
+++ b/test/integration/worker/mail-api.test.ts
@@ -427,6 +427,48 @@ describe("HQBase Mail API v1", () => {
     });
   });
 
+  it("sends a web forward draft with its original attachments", async () => {
+    const created = await apiFetch("/api/v1/drafts", fullToken, {
+      body: JSON.stringify({
+        mailboxId: "mbx_api",
+        forwardOfMessageId: "msg_api",
+        from: "support@example.com",
+        to: ["person@example.net"],
+        subject: "Fwd: API message",
+        text: "---------- Forwarded message ---------\n\nBody",
+        html: "<blockquote>Body</blockquote>"
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST"
+    });
+    expect(created.status, await created.clone().text()).toBe(201);
+    const draft = (await created.json()) as { id: string };
+
+    const response = await apiFetch("/api/v1/send", fullToken, {
+      body: JSON.stringify({
+        from: "support@example.com",
+        to: ["person@example.net"],
+        subject: "Fwd: API message",
+        text: "---------- Forwarded message ---------\n\nBody",
+        html: "<blockquote>Body</blockquote>",
+        draftId: draft.id
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST"
+    });
+    expect(response.status, await response.clone().text()).toBe(201);
+    const forwarded = (await response.json()) as { id: string };
+    const detail = await apiFetch(`/api/v1/messages/${forwarded.id}`, readToken);
+    await expect(detail.json()).resolves.toMatchObject({
+      attachments: [{ contentType: "text/plain", filename: "hello.txt", sizeBytes: 5 }],
+      folder: "sent",
+      hasAttachments: true,
+      subject: "Fwd: API message"
+    });
+    const deletedDraft = await apiFetch(`/api/v1/drafts/${draft.id}`, fullToken);
+    expect(deletedDraft.status).toBe(404);
+  });
+
   it("limits unassigned mail to authenticated owners", async () => {
     try {
       for (const role of ["member", "admin"] as const) {

--- a/test/unit/worker/features/send/forward-service.test.ts
+++ b/test/unit/worker/features/send/forward-service.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@worker/features/drafts/queries", () => ({
   addDraftAttachment: vi.fn(),
   deleteDraft: vi.fn(),
+  removeDraftAttachment: vi.fn(),
   saveDraft: vi.fn()
 }));
 vi.mock("@worker/features/mailboxes/queries", () => ({
@@ -15,10 +16,15 @@ vi.mock("@worker/features/send/service", () => ({
   sendNewMessage: vi.fn()
 }));
 
-import { addDraftAttachment, deleteDraft, saveDraft } from "@worker/features/drafts/queries";
+import {
+  addDraftAttachment,
+  deleteDraft,
+  removeDraftAttachment,
+  saveDraft
+} from "@worker/features/drafts/queries";
 import { findMailboxForSending } from "@worker/features/mailboxes/queries";
 import { getMessageDetail } from "@worker/features/messages/queries";
-import { forwardMessage } from "@worker/features/send/forward";
+import { forwardMessage, sendForwardDraft } from "@worker/features/send/forward";
 import { sendNewMessage } from "@worker/features/send/service";
 import type { WorkerEnv } from "@worker/lib/env";
 
@@ -196,5 +202,124 @@ describe("forward service", () => {
       "user-1"
     );
     expect(deleteDraft).not.toHaveBeenCalled();
+  });
+
+  it("adds original attachments when the web UI sends a forward draft", async () => {
+    vi.mocked(getMessageDetail).mockResolvedValue({
+      ...original,
+      attachments: [
+        {
+          id: "attachment-1",
+          messageId: original.id,
+          filename: "original.txt",
+          contentType: "text/plain",
+          sizeBytes: 8,
+          contentId: null,
+          r2Key: "mail/original.txt",
+          createdAt: original.createdAt
+        }
+      ],
+      hasAttachments: true
+    });
+    get.mockResolvedValue({
+      arrayBuffer: async () => new TextEncoder().encode("original").buffer
+    });
+    vi.mocked(addDraftAttachment).mockResolvedValue({
+      attachment: {
+        id: "attachment-copy",
+        filename: "original.txt",
+        contentType: "text/plain",
+        sizeBytes: 8
+      },
+      r2Key: "drafts/user-1/draft-web/attachment-copy"
+    });
+
+    await sendForwardDraft(
+      env,
+      {
+        from: mailbox.address,
+        to: ["recipient@example.com"],
+        cc: [],
+        bcc: [],
+        subject: "Fwd: Original",
+        text: "---------- Forwarded message ---------",
+        attachmentIds: ["attachment-added"],
+        draftId: "draft-web"
+      },
+      "draft-web",
+      original.id,
+      "user-1"
+    );
+
+    expect(sendNewMessage).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({
+        attachmentIds: ["attachment-added", "attachment-copy"],
+        draftId: "draft-web",
+        text: "---------- Forwarded message ---------"
+      }),
+      "user-1"
+    );
+    expect(saveDraft).not.toHaveBeenCalled();
+    expect(removeDraftAttachment).not.toHaveBeenCalled();
+  });
+
+  it("removes copied attachments when a web forward draft is not sent", async () => {
+    vi.mocked(getMessageDetail).mockResolvedValue({
+      ...original,
+      attachments: [
+        {
+          id: "attachment-1",
+          messageId: original.id,
+          filename: "original.txt",
+          contentType: "text/plain",
+          sizeBytes: 8,
+          contentId: null,
+          r2Key: "mail/original.txt",
+          createdAt: original.createdAt
+        }
+      ],
+      hasAttachments: true
+    });
+    get.mockResolvedValue({
+      arrayBuffer: async () => new TextEncoder().encode("original").buffer
+    });
+    vi.mocked(addDraftAttachment).mockResolvedValue({
+      attachment: {
+        id: "attachment-copy",
+        filename: "original.txt",
+        contentType: "text/plain",
+        sizeBytes: 8
+      },
+      r2Key: "drafts/user-1/draft-web/attachment-copy"
+    });
+    vi.mocked(sendNewMessage).mockRejectedValueOnce(new Error("Delivery failed."));
+
+    await expect(
+      sendForwardDraft(
+        env,
+        {
+          from: mailbox.address,
+          to: ["recipient@example.com"],
+          cc: [],
+          bcc: [],
+          subject: "Fwd: Original",
+          text: "---------- Forwarded message ---------",
+          attachmentIds: [],
+          draftId: "draft-web"
+        },
+        "draft-web",
+        original.id,
+        "user-1"
+      )
+    ).rejects.toThrow("Delivery failed.");
+
+    expect(removeDraftAttachment).toHaveBeenCalledWith(
+      env.DB,
+      env.MAIL_OBJECTS,
+      "user-1",
+      "draft-web",
+      "attachment-copy"
+    );
   });
 });

--- a/test/unit/worker/features/send/routes.test.ts
+++ b/test/unit/worker/features/send/routes.test.ts
@@ -4,11 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   enforceRateLimit: vi.fn(),
   findMailboxForSending: vi.fn(),
+  getAccessibleDraft: vi.fn(),
   recordAudit: vi.fn(),
   requireDraftAttachmentIdsAccess: vi.fn(),
   requireDraftIdAccess: vi.fn(),
   requireMailApiContext: vi.fn(),
   requireMailboxAccess: vi.fn(),
+  sendForwardDraft: vi.fn(),
   sendNewMessage: vi.fn()
 }));
 
@@ -25,6 +27,7 @@ vi.mock("@worker/features/audit/service", () => ({
   recordAudit: mocks.recordAudit
 }));
 vi.mock("@worker/features/drafts/access", () => ({
+  getAccessibleDraft: mocks.getAccessibleDraft,
   requireDraftAttachmentIdsAccess: mocks.requireDraftAttachmentIdsAccess,
   requireDraftIdAccess: mocks.requireDraftIdAccess
 }));
@@ -34,6 +37,10 @@ vi.mock("@worker/features/mailboxes/queries", () => ({
 vi.mock("@worker/features/send/service", () => ({
   replyToMessage: vi.fn(),
   sendNewMessage: mocks.sendNewMessage
+}));
+vi.mock("@worker/features/send/forward", () => ({
+  forwardMessage: vi.fn(),
+  sendForwardDraft: mocks.sendForwardDraft
 }));
 
 import { sendRoutes } from "@worker/features/send/routes";
@@ -45,6 +52,11 @@ describe("send routes", () => {
       user: { id: "user-1", role: "member" }
     });
     mocks.findMailboxForSending.mockResolvedValue({ id: "mailbox-1" });
+    mocks.getAccessibleDraft.mockResolvedValue({
+      forwardOfMessageId: null,
+      id: "draft-forward"
+    });
+    mocks.sendForwardDraft.mockResolvedValue({ id: "sent-message-1" });
     mocks.sendNewMessage.mockResolvedValue({ id: "sent-message-1" });
   });
 
@@ -82,5 +94,44 @@ describe("send routes", () => {
       "agent"
     );
     expect(mocks.sendNewMessage).toHaveBeenCalledOnce();
+  });
+
+  it("includes original attachments when sending a web forward draft", async () => {
+    mocks.getAccessibleDraft.mockResolvedValue({
+      forwardOfMessageId: "message-original",
+      id: "draft-forward"
+    });
+    const db = {} as D1Database;
+    const response = await sendRoutes.request(
+      "/send",
+      {
+        body: JSON.stringify({
+          from: "sender@example.com",
+          to: ["reader@example.com"],
+          cc: [],
+          bcc: [],
+          subject: "Fwd: Example",
+          text: "Forwarded message",
+          attachmentIds: [],
+          draftId: "draft-forward"
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST"
+      },
+      {
+        BETTER_AUTH_SECRET: "test-secret",
+        DB: db
+      } as WorkerEnv
+    );
+
+    expect(response.status).toBe(201);
+    expect(mocks.sendForwardDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ DB: db }),
+      expect.objectContaining({ draftId: "draft-forward" }),
+      "draft-forward",
+      "message-original",
+      "user-1"
+    );
+    expect(mocks.sendNewMessage).not.toHaveBeenCalled();
   });
 });

--- a/worker/features/send/forward.ts
+++ b/worker/features/send/forward.ts
@@ -1,13 +1,18 @@
 import type { WorkerEnv } from "../../lib/env";
 import { AppError } from "../../lib/errors";
 import { parseWith } from "../../lib/validation";
-import { addDraftAttachment, deleteDraft, saveDraft } from "../drafts/queries";
+import {
+  addDraftAttachment,
+  deleteDraft,
+  removeDraftAttachment,
+  saveDraft
+} from "../drafts/queries";
 import { findMailboxForSending } from "../mailboxes/queries";
 import { getMessageDetail } from "../messages/queries";
 import type { MessageDetail } from "../messages/types";
 
 import { sendNewMessage } from "./service";
-import { type ForwardMessageInput, sendMessageSchema } from "./validation";
+import { type ForwardMessageInput, type SendMessageInput, sendMessageSchema } from "./validation";
 
 const maxForwardedAttachments = 20;
 
@@ -34,13 +39,7 @@ export async function forwardMessage(env: WorkerEnv, input: ForwardMessageInput,
     return sendNewMessage(env, outbound, userId);
   }
 
-  if (original.attachments.length + input.attachmentIds.length > maxForwardedAttachments) {
-    throw new AppError(
-      "ATTACHMENTS_TOO_MANY",
-      "A forwarded message may contain at most 20 attachments.",
-      400
-    );
-  }
+  requireForwardedAttachmentCount(original.attachments.length, input.attachmentIds.length);
 
   const draft = await saveDraft(env.DB, userId, {
     mailboxId: mailbox.id,
@@ -56,26 +55,14 @@ export async function forwardMessage(env: WorkerEnv, input: ForwardMessageInput,
     version: undefined
   });
 
-  const copiedAttachmentIds: string[] = [];
+  let copiedAttachmentIds: string[];
   try {
-    for (const attachment of original.attachments) {
-      const object = await env.MAIL_OBJECTS.get(attachment.r2Key);
-      if (!object) {
-        throw new AppError(
-          "ATTACHMENT_NOT_FOUND",
-          "A forwarded attachment object is unavailable.",
-          404
-        );
-      }
-      const file = new File([await object.arrayBuffer()], attachment.filename, {
-        type: attachment.contentType
-      });
-      const added = await addDraftAttachment(env.DB, userId, draft.id, file);
-      await env.MAIL_OBJECTS.put(added.r2Key, file.stream(), {
-        httpMetadata: { contentType: added.attachment.contentType }
-      });
-      copiedAttachmentIds.push(added.attachment.id);
-    }
+    copiedAttachmentIds = await copyOriginalAttachments(
+      env,
+      userId,
+      draft.id,
+      original.attachments
+    );
   } catch (error) {
     await deleteDraft(env.DB, env.MAIL_OBJECTS, userId, draft.id);
     throw error;
@@ -90,6 +77,96 @@ export async function forwardMessage(env: WorkerEnv, input: ForwardMessageInput,
     }),
     userId
   );
+}
+
+export async function sendForwardDraft(
+  env: WorkerEnv,
+  input: SendMessageInput,
+  draftId: string,
+  originalMessageId: string,
+  userId: string
+) {
+  const original = await getMessageDetail(env.DB, originalMessageId);
+  if (!original) throw new AppError("MESSAGE_NOT_FOUND", "Message not found.", 404);
+  if (original.attachments.length === 0) {
+    return sendNewMessage(env, { ...input, draftId }, userId);
+  }
+
+  requireForwardedAttachmentCount(original.attachments.length, input.attachmentIds.length);
+  const copiedAttachmentIds = await copyOriginalAttachments(
+    env,
+    userId,
+    draftId,
+    original.attachments
+  );
+  try {
+    return await sendNewMessage(
+      env,
+      {
+        ...input,
+        attachmentIds: [...input.attachmentIds, ...copiedAttachmentIds],
+        draftId
+      },
+      userId
+    );
+  } catch (error) {
+    await removeCopiedAttachments(env, userId, draftId, copiedAttachmentIds);
+    throw error;
+  }
+}
+
+async function copyOriginalAttachments(
+  env: WorkerEnv,
+  userId: string,
+  draftId: string,
+  attachments: MessageDetail["attachments"]
+): Promise<string[]> {
+  const copiedAttachmentIds: string[] = [];
+  try {
+    for (const attachment of attachments) {
+      const object = await env.MAIL_OBJECTS.get(attachment.r2Key);
+      if (!object) {
+        throw new AppError(
+          "ATTACHMENT_NOT_FOUND",
+          "A forwarded attachment object is unavailable.",
+          404
+        );
+      }
+      const file = new File([await object.arrayBuffer()], attachment.filename, {
+        type: attachment.contentType
+      });
+      const added = await addDraftAttachment(env.DB, userId, draftId, file);
+      copiedAttachmentIds.push(added.attachment.id);
+      await env.MAIL_OBJECTS.put(added.r2Key, file.stream(), {
+        httpMetadata: { contentType: added.attachment.contentType }
+      });
+    }
+    return copiedAttachmentIds;
+  } catch (error) {
+    await removeCopiedAttachments(env, userId, draftId, copiedAttachmentIds);
+    throw error;
+  }
+}
+
+async function removeCopiedAttachments(
+  env: WorkerEnv,
+  userId: string,
+  draftId: string,
+  attachmentIds: string[]
+): Promise<void> {
+  for (const attachmentId of attachmentIds) {
+    await removeDraftAttachment(env.DB, env.MAIL_OBJECTS, userId, draftId, attachmentId);
+  }
+}
+
+function requireForwardedAttachmentCount(originalCount: number, draftCount: number): void {
+  if (originalCount + draftCount > maxForwardedAttachments) {
+    throw new AppError(
+      "ATTACHMENTS_TOO_MANY",
+      "A forwarded message may contain at most 20 attachments.",
+      400
+    );
+  }
 }
 
 export function forwardedBody(

--- a/worker/features/send/routes.ts
+++ b/worker/features/send/routes.ts
@@ -7,11 +7,15 @@ import { readJson } from "../../lib/json";
 import { parseWith } from "../../lib/validation";
 import { enforceRateLimit } from "../../security/rate-limit";
 import { recordAudit } from "../audit/service";
-import { requireDraftAttachmentIdsAccess, requireDraftIdAccess } from "../drafts/access";
+import {
+  getAccessibleDraft,
+  requireDraftAttachmentIdsAccess,
+  requireDraftIdAccess
+} from "../drafts/access";
 import { findMailboxForSending } from "../mailboxes/queries";
 import { requireMessageAccess } from "../messages/access";
 
-import { forwardMessage } from "./forward";
+import { forwardMessage, sendForwardDraft } from "./forward";
 import { replyToMessage, sendNewMessage } from "./service";
 import { forwardMessageSchema, replyMessageSchema, sendMessageSchema } from "./validation";
 
@@ -36,9 +40,11 @@ sendRoutes.post("/send", async (c) => {
     "agent"
   );
   const principal = { role: authContext.user.role, userId: authContext.user.id };
-  await requireDraftIdAccess(c.env, principal, input.draftId);
+  const draft = input.draftId ? await getAccessibleDraft(c.env, principal, input.draftId) : null;
   await requireDraftAttachmentIdsAccess(c.env, principal, input.attachmentIds);
-  const sent = await sendNewMessage(c.env, input, authContext.user.id);
+  const sent = draft?.forwardOfMessageId
+    ? await sendForwardDraft(c.env, input, draft.id, draft.forwardOfMessageId, authContext.user.id)
+    : await sendNewMessage(c.env, input, authContext.user.id);
   await recordAudit(c.env.DB, {
     correlationId: c.get("correlationId"),
     actorType: "user",


### PR DESCRIPTION
## Summary

- honor a draft's forward context when the web composer sends through `/api/v1/send`
- combine original attachments with files added to the draft while enforcing attachment limits
- remove temporary attachment copies after a failed send and preserve normal draft cleanup after success
- add unit and Worker integration regression coverage

## Validation

- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-issue-56-check.log pnpm check`
- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-issue-56-dry-run.log pnpm deploy:dry-run`

Fixes #56.

Documentation: HQBase/hqbase-site#26
