### PR TITLE
feat(mail-api): add draft synchronization

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -74,7 +74,7 @@ jobs:
           legacy_dir=".hqbase/deployments/$DEPLOYMENT_NAME/migrations-before-0014"
           mkdir -p "$legacy_dir"
           for migration in migrations/00*.sql; do
-            if [[ "$(basename "$migration")" != "0014_unassigned_messages.sql" ]]; then
+            if [[ "$(basename "$migration")" < "0014_" ]]; then
               cp "$migration" "$legacy_dir/"
             fi
           done
@@ -98,7 +98,7 @@ jobs:
           pnpm exec wrangler d1 migrations apply DB --remote --config "$config"
           result=$(pnpm exec wrangler d1 execute DB --remote --config "$config" --json \
             --command "SELECT (SELECT value_json FROM app_settings WHERE key = 'sql-upgrade-probe') AS value_json, (SELECT is_unassigned FROM messages WHERE id = 'msg_sql_upgrade') AS is_unassigned, (SELECT is_unassigned FROM message_changes WHERE message_id = 'msg_sql_upgrade' LIMIT 1) AS change_is_unassigned, (SELECT COUNT(*) FROM d1_migrations) AS migration_count")
-          jq -e '.[0].results[0] == {"value_json":"{\"state\":\"preserved\"}","is_unassigned":1,"change_is_unassigned":1,"migration_count":14}' <<<"$result"
+          jq -e '.[0].results[0] == {"value_json":"{\"state\":\"preserved\"}","is_unassigned":1,"change_is_unassigned":1,"migration_count":15}' <<<"$result"
       - name: Deploy reviewed source candidate
         run: |
           config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"

--- a/api/hqbase-mail-api-v1.openapi.json
+++ b/api/hqbase-mail-api-v1.openapi.json
@@ -315,7 +315,7 @@
               "type": "string",
               "enum": ["inbox", "sent", "drafts", "archived", "trash", "catchall"]
             },
-            "description": "Folder to list."
+            "description": "Message folder to list. The `drafts` value remains for v1 compatibility, but current write paths do not store drafts as message rows. Use `/api/v1/drafts` for drafts."
           },
           {
             "in": "query",
@@ -1292,7 +1292,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Drafts",
+            "description": "One page of drafts, newest update first.",
+            "headers": {
+              "Link": {
+                "required": false,
+                "description": "RFC 8288 link to the next page, as `<url>; rel=\"next\"`. The header is absent on the last page.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1305,7 +1314,7 @@
             }
           },
           "400": {
-            "description": "Invalid request",
+            "description": "Invalid request. `INVALID_LIMIT` when limit is not an integer from 1 to 100. `INVALID_DRAFT_CURSOR` when the cursor is malformed or is not a draft-list cursor.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1356,7 +1365,31 @@
           }
         },
         "tags": ["Drafts"],
-        "operationId": "listDrafts"
+        "operationId": "listDrafts",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            },
+            "description": "Maximum number of draft rows read for this page. Live access filtering can make the returned array shorter."
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 512
+            },
+            "description": "Opaque cursor from the previous page. Read it from the Link header and send it unchanged."
+          }
+        ]
       },
       "post": {
         "summary": "Create a draft",
@@ -1454,6 +1487,108 @@
             }
           }
         }
+      }
+    },
+    "/api/v1/drafts/changes": {
+      "get": {
+        "summary": "Read draft changes",
+        "description": "Returns a bounded page of private draft upserts and deletion tombstones in journal order. A request without a cursor returns an empty checkpoint at the current user-specific high-water sequence.",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A bounded page of draft changes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DraftChangePage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. `INVALID_LIMIT` when limit is not an integer from 1 to 100. `INVALID_DRAFT_CHANGE_CURSOR` when the cursor is malformed, foreign, or beyond the user's current journal. `INVALID_DRAFT_CHANGE_FILTER` when a mailbox, folder, search, or timestamp filter is supplied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "`DRAFT_CHANGE_CURSOR_EXPIRED` when future journal retention removes a required range. The client must start a new full draft bootstrap.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Drafts"],
+        "operationId": "listDraftChanges",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 512
+            },
+            "description": "Opaque cursor from a draft checkpoint or previous draft-changes page. Omit it only to create a new checkpoint."
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            },
+            "description": "Maximum number of draft journal entries read for this page."
+          }
+        ]
       }
     },
     "/api/v1/drafts/{id}": {
@@ -2432,7 +2567,8 @@
           },
           "folder": {
             "type": "string",
-            "enum": ["inbox", "sent", "drafts", "archived", "trash", "catchall"]
+            "enum": ["inbox", "sent", "drafts", "archived", "trash", "catchall"],
+            "description": "Stored message folder. Drafts use the separate Draft schema and endpoints; current write paths do not produce message summaries with `folder: drafts`."
           },
           "fromAddress": {
             "type": "string",
@@ -2952,6 +3088,60 @@
             }
           }
         ]
+      },
+      "DraftChangeUpsert": {
+        "type": "object",
+        "required": ["type", "draft"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "upsert"
+          },
+          "draft": {
+            "$ref": "#/components/schemas/Draft"
+          }
+        }
+      },
+      "DraftChangeDelete": {
+        "type": "object",
+        "required": ["type", "draftId"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "delete"
+          },
+          "draftId": {
+            "type": "string"
+          }
+        }
+      },
+      "DraftChange": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DraftChangeUpsert"
+          },
+          {
+            "$ref": "#/components/schemas/DraftChangeDelete"
+          }
+        ]
+      },
+      "DraftChangePage": {
+        "type": "object",
+        "required": ["changes", "nextCursor", "hasMore"],
+        "properties": {
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DraftChange"
+            }
+          },
+          "nextCursor": {
+            "type": "string"
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        }
       },
       "SendInput": {
         "type": "object",

--- a/api/hqbase-mail-api-v1.postman_collection.json
+++ b/api/hqbase-mail-api-v1.postman_collection.json
@@ -198,7 +198,7 @@
                   "key": "folder",
                   "value": "inbox",
                   "disabled": false,
-                  "description": "Folder to list."
+                  "description": "Message folder to list. The `drafts` value remains for v1 compatibility, but current write paths do not store drafts as message rows. Use `/api/v1/drafts` for drafts."
                 },
                 {
                   "key": "mailboxId",
@@ -464,7 +464,21 @@
             "header": [],
             "url": {
               "raw": "{{base_url}}/api/v1/drafts",
-              "variable": []
+              "variable": [],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "",
+                  "disabled": true,
+                  "description": "Maximum number of draft rows read for this page. Live access filtering can make the returned array shorter."
+                },
+                {
+                  "key": "cursor",
+                  "value": "",
+                  "disabled": true,
+                  "description": "Opaque cursor from the previous page. Read it from the Link header and send it unchanged."
+                }
+              ]
             },
             "description": "List drafts"
           },
@@ -494,6 +508,33 @@
                 }
               }
             }
+          },
+          "response": []
+        },
+        {
+          "name": "Read draft changes",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/v1/drafts/changes",
+              "variable": [],
+              "query": [
+                {
+                  "key": "cursor",
+                  "value": "",
+                  "disabled": true,
+                  "description": "Opaque cursor from a draft checkpoint or previous draft-changes page. Omit it only to create a new checkpoint."
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "disabled": true,
+                  "description": "Maximum number of draft journal entries read for this page."
+                }
+              ]
+            },
+            "description": "Returns a bounded page of private draft upserts and deletion tombstones in journal order. A request without a cursor returns an empty checkpoint at the current user-specific high-water sequence."
           },
           "response": []
         },

--- a/app/features/drafts/api.ts
+++ b/app/features/drafts/api.ts
@@ -1,8 +1,18 @@
-import { apiDelete, apiGet, apiPatch, apiPost } from "@/lib/api-client";
+import { apiDelete, apiGetPage, apiPatch, apiPost } from "@/lib/api-client";
 
 import type { Draft, DraftAttachment, DraftInput } from "./types";
 
-export const listDrafts = () => apiGet<Draft[]>("/api/v1/drafts");
+export async function listDrafts(): Promise<Draft[]> {
+  const drafts: Draft[] = [];
+  let nextPageUrl: string | null = "/api/v1/drafts?limit=100";
+  while (nextPageUrl) {
+    const page: { data: Draft[]; nextPageUrl: string | null } =
+      await apiGetPage<Draft[]>(nextPageUrl);
+    drafts.push(...page.data);
+    nextPageUrl = page.nextPageUrl;
+  }
+  return drafts;
+}
 
 export const createDraft = (input: DraftInput) => apiPost<Draft>("/api/v1/drafts", input);
 

--- a/app/lib/api-client.ts
+++ b/app/lib/api-client.ts
@@ -19,9 +19,109 @@ export async function apiGetPage<T>(
       typeof data === "object" && data && "error" in data ? data.error.message : "Request failed.";
     throw new Error(message);
   }
-  const link = response.headers.get("link");
-  const match = link?.match(/^<([^>]+)>;\s*rel="next"$/u);
-  return { data: data as T, nextPageUrl: match?.[1] ?? null };
+  return { data: data as T, nextPageUrl: nextPageUrl(response.headers.get("link")) };
+}
+
+function nextPageUrl(header: string | null): string | null {
+  if (header === null) return null;
+  const links = splitLinkHeader(header).map(parseLinkValue);
+  return links.find((link) => link.relations.includes("next"))?.target ?? null;
+}
+
+function splitLinkHeader(header: string): string[] {
+  const values: string[] = [];
+  let inTarget = false;
+  let inQuotes = false;
+  let escaped = false;
+  let start = 0;
+  for (let index = 0; index < header.length; index += 1) {
+    const character = header[index];
+    if (inTarget) {
+      if (character === ">") inTarget = false;
+      continue;
+    }
+    if (inQuotes) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') inQuotes = false;
+      continue;
+    }
+    if (character === "<") inTarget = true;
+    else if (character === '"') inQuotes = true;
+    else if (character === ",") {
+      values.push(header.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  values.push(header.slice(start).trim());
+  if (inTarget || inQuotes || values.some((value) => value.length === 0)) {
+    throw new Error("Malformed Link header.");
+  }
+  return values;
+}
+
+function parseLinkValue(value: string): { relations: string[]; target: string } {
+  if (!value.startsWith("<")) throw new Error("Malformed Link header.");
+  const targetEnd = value.indexOf(">");
+  if (targetEnd < 2) throw new Error("Malformed Link header.");
+  const target = value.slice(1, targetEnd);
+  const relations: string[] = [];
+  let remainder = value.slice(targetEnd + 1);
+  while (remainder.trim().length > 0) {
+    remainder = remainder.trimStart();
+    if (!remainder.startsWith(";")) throw new Error("Malformed Link header.");
+    remainder = remainder.slice(1).trimStart();
+    const nameEnd = tokenLength(remainder);
+    if (nameEnd === 0) throw new Error("Malformed Link header.");
+    const name = remainder.slice(0, nameEnd).toLowerCase();
+    remainder = remainder.slice(nameEnd).trimStart();
+    let parameterValue: string | null = null;
+    if (remainder.startsWith("=")) {
+      remainder = remainder.slice(1).trimStart();
+      if (remainder.startsWith('"')) {
+        const quoted = readQuotedValue(remainder);
+        parameterValue = quoted.value;
+        remainder = quoted.remainder;
+      } else {
+        const valueEnd = tokenLength(remainder);
+        if (valueEnd === 0) throw new Error("Malformed Link header.");
+        parameterValue = remainder.slice(0, valueEnd);
+        remainder = remainder.slice(valueEnd);
+      }
+    }
+    if (name === "rel") {
+      if (parameterValue === null) throw new Error("Malformed Link header.");
+      relations.push(...parameterValue.toLowerCase().split(/\s+/u).filter(Boolean));
+    }
+  }
+  return { relations, target };
+}
+
+function tokenLength(value: string): number {
+  let length = 0;
+  while (length < value.length && /[!#$%&'*+\-.^_`|~0-9A-Za-z]/u.test(value[length] ?? "")) {
+    length += 1;
+  }
+  return length;
+}
+
+function readQuotedValue(value: string): { remainder: string; value: string } {
+  let parsed = "";
+  let escaped = false;
+  for (let index = 1; index < value.length; index += 1) {
+    const character = value[index] ?? "";
+    if (escaped) {
+      parsed += character;
+      escaped = false;
+    } else if (character === "\\") {
+      escaped = true;
+    } else if (character === '"') {
+      return { remainder: value.slice(index + 1), value: parsed };
+    } else {
+      parsed += character;
+    }
+  }
+  throw new Error("Malformed Link header.");
 }
 
 export async function apiPost<T>(path: string, body?: unknown): Promise<T> {

--- a/app/lib/api-client.ts
+++ b/app/lib/api-client.ts
@@ -9,6 +9,21 @@ export async function apiGet<T>(path: string): Promise<T> {
   return apiRequest<T>(path, { method: "GET" });
 }
 
+export async function apiGetPage<T>(
+  path: string
+): Promise<{ data: T; nextPageUrl: string | null }> {
+  const response = await fetch(path, { credentials: "include", method: "GET" });
+  const data = (await readResponseJson(response)) as T | ApiError;
+  if (!response.ok) {
+    const message =
+      typeof data === "object" && data && "error" in data ? data.error.message : "Request failed.";
+    throw new Error(message);
+  }
+  const link = response.headers.get("link");
+  const match = link?.match(/^<([^>]+)>;\s*rel="next"$/u);
+  return { data: data as T, nextPageUrl: match?.[1] ?? null };
+}
+
 export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
   const init: RequestInit = { method: "POST" };
   if (body !== undefined) {

--- a/migrations/0015_draft_changes.sql
+++ b/migrations/0015_draft_changes.sql
@@ -1,0 +1,57 @@
+-- Durable draft change journal for GET /api/v1/drafts/changes.
+-- Journal rows have no foreign key to drafts so deletion tombstones survive hard deletes.
+
+DROP INDEX IF EXISTS drafts_user_updated_idx;
+
+CREATE INDEX IF NOT EXISTS drafts_user_updated_id_idx
+ON drafts(user_id, updated_at DESC, id DESC);
+
+CREATE TABLE IF NOT EXISTS draft_changes (
+  sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+  draft_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('upsert', 'delete')),
+  changed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS draft_changes_user_sequence_idx
+ON draft_changes(user_id, sequence);
+
+CREATE TRIGGER IF NOT EXISTS draft_changes_after_insert
+AFTER INSERT ON drafts
+BEGIN
+  INSERT INTO draft_changes (draft_id, user_id, kind, changed_at)
+  VALUES (NEW.id, NEW.user_id, 'upsert', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+END;
+
+CREATE TRIGGER IF NOT EXISTS draft_changes_after_update
+AFTER UPDATE ON drafts
+BEGIN
+  INSERT INTO draft_changes (draft_id, user_id, kind, changed_at)
+  VALUES (NEW.id, NEW.user_id, 'upsert', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+END;
+
+CREATE TRIGGER IF NOT EXISTS draft_changes_after_delete
+AFTER DELETE ON drafts
+BEGIN
+  INSERT INTO draft_changes (draft_id, user_id, kind, changed_at)
+  VALUES (OLD.id, OLD.user_id, 'delete', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+END;
+
+CREATE TRIGGER IF NOT EXISTS draft_changes_after_attachment_insert
+AFTER INSERT ON draft_attachments
+BEGIN
+  INSERT INTO draft_changes (draft_id, user_id, kind, changed_at)
+  SELECT id, user_id, 'upsert', strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+  FROM drafts
+  WHERE id = NEW.draft_id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS draft_changes_after_attachment_delete
+AFTER DELETE ON draft_attachments
+BEGIN
+  INSERT INTO draft_changes (draft_id, user_id, kind, changed_at)
+  SELECT id, user_id, 'upsert', strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+  FROM drafts
+  WHERE id = OLD.draft_id;
+END;

--- a/scripts/generate-mail-api-artifacts.mjs
+++ b/scripts/generate-mail-api-artifacts.mjs
@@ -85,6 +85,7 @@ function validateOpenApi(document) {
     "/api/v1/changes",
     "/api/v1/conversations",
     "/api/v1/drafts",
+    "/api/v1/drafts/changes",
     "/api/v1/send",
     "/api/v1/reply",
     "/api/v1/forward"

--- a/scripts/hqbase/reset-d1.sql
+++ b/scripts/hqbase/reset-d1.sql
@@ -12,6 +12,7 @@ DROP TABLE IF EXISTS push_subscriptions;
 DROP TABLE IF EXISTS message_sender_preferences;
 DROP TABLE IF EXISTS user_mail_preferences;
 DROP TABLE IF EXISTS user_onboarding;
+DROP TABLE IF EXISTS draft_changes;
 DROP TABLE IF EXISTS update_history;
 DROP TABLE IF EXISTS release_state;
 DROP TABLE IF EXISTS installation_identity;

--- a/test/e2e/staging/lifecycle.spec.ts
+++ b/test/e2e/staging/lifecycle.spec.ts
@@ -93,6 +93,13 @@ test("HQBase web lifecycle remains healthy", async ({ page, request }) => {
       nextCursor: expect.any(String),
       hasMore: false
     });
+    const draftCheckpoint = await request.get(stagingMailApiPath("/drafts/changes"));
+    expect(draftCheckpoint.ok(), await draftCheckpoint.text()).toBeTruthy();
+    await expect(draftCheckpoint.json()).resolves.toMatchObject({
+      changes: [],
+      nextCursor: expect.any(String),
+      hasMore: false
+    });
   }
   const primaryEmailAction = page.getByRole("button", {
     name: /^(?:Compose|New email)$/

--- a/test/integration/worker/draft-changes-migration.test.ts
+++ b/test/integration/worker/draft-changes-migration.test.ts
@@ -1,0 +1,163 @@
+import { env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import initialMigration from "../../../migrations/0001_initial.sql?raw";
+import workspaceMigration from "../../../migrations/0002_workspace.sql?raw";
+import oauthResourcesMigration from "../../../migrations/0003_oauth_resources.sql?raw";
+import conversationMigration from "../../../migrations/0004_conversations.sql?raw";
+import threadRebuildMigration from "../../../migrations/0005_rebuild_threads.sql?raw";
+import pushMigration from "../../../migrations/0006_push_notifications.sql?raw";
+import userMailPreferencesMigration from "../../../migrations/0007_user_mail_preferences.sql?raw";
+import userOnboardingMigration from "../../../migrations/0008_user_onboarding.sql?raw";
+import loginEmailDomainMigration from "../../../migrations/0009_login_email_domain_isolation.sql?raw";
+import deviceAuthorizationMigration from "../../../migrations/0010_oauth_device_authorization.sql?raw";
+import latestPasswordResetTokenMigration from "../../../migrations/0011_latest_password_reset_token.sql?raw";
+import messageActivityIndexMigration from "../../../migrations/0012_message_activity_index.sql?raw";
+import messageChangesMigration from "../../../migrations/0013_message_changes.sql?raw";
+import unassignedMessagesMigration from "../../../migrations/0014_unassigned_messages.sql?raw";
+import draftChangesMigration from "../../../migrations/0015_draft_changes.sql?raw";
+import { migrationStatements } from "./migration-statements";
+
+const priorMigrations = [
+  initialMigration,
+  workspaceMigration,
+  oauthResourcesMigration,
+  conversationMigration,
+  threadRebuildMigration,
+  pushMigration,
+  userMailPreferencesMigration,
+  userOnboardingMigration,
+  loginEmailDomainMigration,
+  deviceAuthorizationMigration,
+  latestPasswordResetTokenMigration,
+  messageActivityIndexMigration,
+  messageChangesMigration,
+  unassignedMessagesMigration
+];
+
+describe("draft changes migration", () => {
+  beforeAll(async () => {
+    for (const migration of priorMigrations) await applyMigration(migration);
+    const stamp = "2026-08-22T00:00:00.000Z";
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO "user" (id, name, email, emailVerified, createdAt, updatedAt, role)
+         VALUES ('usr_draft_migration', 'Draft Migration', 'draft-migration@example.com',
+                 1, ?, ?, 'member')`
+      ).bind(stamp, stamp),
+      draftRow("drf_before_migration", stamp)
+    ]);
+    await applyMigration(draftChangesMigration);
+  });
+
+  it("upgrades without creating false history for existing drafts", async () => {
+    const count = await env.DB.prepare("SELECT COUNT(*) AS count FROM draft_changes").first<{
+      count: number;
+    }>();
+    expect(count?.count).toBe(0);
+    const indexes = await env.DB.prepare("PRAGMA index_list('drafts')").all<{ name: string }>();
+    expect(indexes.results.map((row) => row.name)).toContain("drafts_user_updated_id_idx");
+    expect(indexes.results.map((row) => row.name)).not.toContain("drafts_user_updated_idx");
+    const plan = await env.DB.prepare(
+      `EXPLAIN QUERY PLAN
+       SELECT * FROM drafts
+       WHERE user_id = ?
+         AND (updated_at < ? OR (updated_at = ? AND id < ?))
+       ORDER BY updated_at DESC, id DESC
+       LIMIT 101`
+    )
+      .bind(
+        "usr_draft_migration",
+        "2026-08-22T00:00:00.000Z",
+        "2026-08-22T00:00:00.000Z",
+        "drf_before_migration"
+      )
+      .all<{ detail: string }>();
+    expect(plan.results.some((row) => row.detail.includes("drafts_user_updated_id_idx"))).toBe(
+      true
+    );
+    expect(plan.results.some((row) => row.detail.includes("USE TEMP B-TREE"))).toBe(false);
+  });
+
+  it("journals draft and attachment changes with a durable deletion tombstone", async () => {
+    const stamp = "2026-08-22T00:01:00.000Z";
+    await draftRow("drf_after_migration", stamp).run();
+    await env.DB.prepare(
+      "UPDATE drafts SET subject = 'Changed', version = 2, updated_at = ? WHERE id = ?"
+    )
+      .bind(stamp, "drf_after_migration")
+      .run();
+    await env.DB.prepare(
+      `INSERT INTO draft_attachments
+       (id, draft_id, filename, content_type, size_bytes, r2_key, created_at)
+       VALUES ('att_draft_migration', 'drf_after_migration', 'note.txt', 'text/plain', 4,
+               'drafts/migration/note.txt', ?)`
+    )
+      .bind(stamp)
+      .run();
+    await env.DB.prepare("DELETE FROM draft_attachments WHERE id = 'att_draft_migration'").run();
+    await env.DB.prepare("DELETE FROM drafts WHERE id = 'drf_after_migration'").run();
+
+    const rows = await env.DB.prepare(
+      `SELECT sequence, draft_id, user_id, kind
+       FROM draft_changes WHERE draft_id = 'drf_after_migration' ORDER BY sequence`
+    ).all<{ sequence: number; draft_id: string; user_id: string; kind: string }>();
+    expect(rows.results).toEqual([
+      {
+        sequence: 1,
+        draft_id: "drf_after_migration",
+        user_id: "usr_draft_migration",
+        kind: "upsert"
+      },
+      {
+        sequence: 2,
+        draft_id: "drf_after_migration",
+        user_id: "usr_draft_migration",
+        kind: "upsert"
+      },
+      {
+        sequence: 3,
+        draft_id: "drf_after_migration",
+        user_id: "usr_draft_migration",
+        kind: "upsert"
+      },
+      {
+        sequence: 4,
+        draft_id: "drf_after_migration",
+        user_id: "usr_draft_migration",
+        kind: "upsert"
+      },
+      {
+        sequence: 5,
+        draft_id: "drf_after_migration",
+        user_id: "usr_draft_migration",
+        kind: "delete"
+      }
+    ]);
+  });
+
+  it("is safe to re-apply without installing duplicate triggers", async () => {
+    await applyMigration(draftChangesMigration);
+    await draftRow("drf_after_reapply", "2026-08-22T00:02:00.000Z").run();
+
+    const rows = await env.DB.prepare(
+      "SELECT kind FROM draft_changes WHERE draft_id = 'drf_after_reapply'"
+    ).all<{ kind: string }>();
+    expect(rows.results).toEqual([{ kind: "upsert" }]);
+  });
+});
+
+function draftRow(id: string, stamp: string): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO drafts
+     (id, user_id, mailbox_id, from_address, to_json, cc_json, bcc_json, subject,
+      text_body, html_body, created_at, updated_at)
+     VALUES (?, 'usr_draft_migration', NULL, '', '[]', '[]', '[]', ?, '', '', ?, ?)`
+  ).bind(id, id, stamp, stamp);
+}
+
+async function applyMigration(source: string): Promise<void> {
+  for (const statement of migrationStatements(source)) {
+    await env.DB.prepare(statement).run();
+  }
+}

--- a/test/integration/worker/draft-sync.test.ts
+++ b/test/integration/worker/draft-sync.test.ts
@@ -2,6 +2,10 @@ import { env, SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { createAuth } from "../../../worker/auth/auth";
+import {
+  listAccessibleDraftPage,
+  requireDraftAccess
+} from "../../../worker/features/drafts/access";
 import { encodeDraftChangeCursor } from "../../../worker/features/drafts/change-cursor";
 import { encodeChangeCursor } from "../../../worker/features/messages/change-cursor";
 import { applyCurrentMigrations } from "./current-migrations";
@@ -234,6 +238,77 @@ describe("HQBase Mail API draft synchronization", () => {
     expect(deletion.changes).toEqual([{ type: "delete", draftId: "drf_access_revoked" }]);
   });
 
+  it("uses the same access rules for banned users and inaccessible message targets", async () => {
+    const stamp = "2026-08-22T05:00:00.000Z";
+    await env.DB.batch([
+      threadRow("thr_draft_secret_target", stamp),
+      messageRow(
+        "msg_draft_secret_target",
+        "thr_draft_secret_target",
+        "mbx_draft_sync_secret",
+        stamp
+      ),
+      draftRow("drf_secret_target", "mbx_draft_sync", stamp)
+    ]);
+    await env.DB.prepare("UPDATE drafts SET reply_to_message_id = ? WHERE id = 'drf_secret_target'")
+      .bind("msg_draft_secret_target")
+      .run();
+
+    const listed = await apiFetch("/api/v1/drafts?limit=100", sendToken);
+    expect(listed.status, await listed.clone().text()).toBe(200);
+    expect((await listed.json<Array<{ id: string }>>()).map((draft) => draft.id)).not.toContain(
+      "drf_secret_target"
+    );
+    await expect(
+      requireDraftAccess(
+        env,
+        { role: "member", userId },
+        {
+          mailboxId: "mbx_draft_sync",
+          from: "draft-sync@example.com",
+          replyToMessageId: "msg_draft_secret_target",
+          forwardOfMessageId: null
+        }
+      )
+    ).rejects.toMatchObject({ code: "MAILBOX_FORBIDDEN", status: 403 });
+
+    await env.DB.prepare(`UPDATE "user" SET banned = 1 WHERE id = ?`).bind(userId).run();
+    try {
+      const page = await listAccessibleDraftPage(env, { role: "member", userId }, { limit: 100 });
+      expect(page.drafts).toEqual([]);
+      await expect(
+        requireDraftAccess(
+          env,
+          { role: "member", userId },
+          {
+            mailboxId: null,
+            from: "",
+            replyToMessageId: null,
+            forwardOfMessageId: null
+          }
+        )
+      ).rejects.toMatchObject({ code: "MAILBOX_FORBIDDEN", status: 403 });
+    } finally {
+      await env.DB.prepare(`UPDATE "user" SET banned = 0 WHERE id = ?`).bind(userId).run();
+    }
+  });
+
+  it("loads a full 100-change page within the D1 parameter limit", async () => {
+    const cursor = await checkpoint();
+    const stamp = "2026-08-22T06:00:00.000Z";
+    await env.DB.batch(
+      Array.from({ length: 100 }, (_, index) =>
+        draftRow(`drf_full_page_${String(index).padStart(3, "0")}`, "mbx_draft_sync", stamp)
+      )
+    );
+
+    const page = await changePage(
+      await apiFetch(`/api/v1/drafts/changes?cursor=${cursor}&limit=100`, sendToken)
+    );
+    expect(page.hasMore).toBe(false);
+    expect(page.changes).toHaveLength(100);
+  });
+
   it("validates scope, filters, limits, and foreign cursors", async () => {
     const noSend = await apiFetch("/api/v1/drafts/changes", readToken);
     expect(noSend.status).toBe(403);
@@ -327,6 +402,29 @@ function grantRow(mailboxId: string, stamp: string): D1PreparedStatement {
     `INSERT INTO mailbox_grants (mailbox_id, user_id, access_level, created_by, created_at, updated_at)
      VALUES (?, ?, 'agent', ?, ?, ?)`
   ).bind(mailboxId, userId, userId, stamp, stamp);
+}
+
+function threadRow(id: string, stamp: string): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO threads (id, subject_normalized, last_message_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`
+  ).bind(id, id, stamp, stamp, stamp);
+}
+
+function messageRow(
+  id: string,
+  threadId: string,
+  mailboxId: string,
+  stamp: string
+): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO messages
+     (id, thread_id, mailbox_id, direction, folder, from_address, to_json, cc_json, bcc_json,
+      subject, snippet, text_body, message_id, dedupe_key, in_reply_to, references_json,
+      received_at, sent_at, read_at, has_attachments, created_at, updated_at)
+     VALUES (?, ?, ?, 'inbound', 'inbox', 'sender@example.net', '[]', '[]', '[]', ?, '', '',
+             NULL, ?, NULL, '[]', ?, NULL, NULL, 0, ?, ?)`
+  ).bind(id, threadId, mailboxId, id, `dedupe-${id}`, stamp, stamp, stamp);
 }
 
 function draftRow(id: string, mailboxId: string, stamp: string): D1PreparedStatement {

--- a/test/integration/worker/draft-sync.test.ts
+++ b/test/integration/worker/draft-sync.test.ts
@@ -1,0 +1,343 @@
+import { env, SELF } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { createAuth } from "../../../worker/auth/auth";
+import { encodeDraftChangeCursor } from "../../../worker/features/drafts/change-cursor";
+import { encodeChangeCursor } from "../../../worker/features/messages/change-cursor";
+import { applyCurrentMigrations } from "./current-migrations";
+import { tokenRow } from "./mail-api-token-fixture";
+
+const origin = "https://hqbase.test";
+const apiResource = `${origin}/api/v1`;
+const sendToken = "hqb_access_draft-sync-send-token";
+const readToken = "hqb_access_draft-sync-read-token";
+let userId = "";
+
+describe("HQBase Mail API draft synchronization", () => {
+  beforeAll(async () => {
+    await applyCurrentMigrations();
+    const auth = createAuth(env, new Request(`${origin}/api/auth/sign-up/email`));
+    const signUp = await auth.handler(
+      new Request(`${origin}/api/auth/sign-up/email`, {
+        body: JSON.stringify({
+          email: "draft-sync-member@login.example",
+          name: "Draft Sync Member",
+          password: "draft-sync-test-password",
+          rememberMe: false
+        }),
+        headers: { "content-type": "application/json", origin },
+        method: "POST"
+      })
+    );
+    expect(signUp.status, await signUp.clone().text()).toBe(200);
+
+    const user = await env.DB.prepare(
+      `SELECT u.id, s.id AS sessionId
+       FROM "user" u JOIN "session" s ON s.userId = u.id
+       WHERE u.email = ? ORDER BY s.createdAt DESC LIMIT 1`
+    )
+      .bind("draft-sync-member@login.example")
+      .first<{ id: string; sessionId: string }>();
+    if (!user) throw new Error("Draft sync API test user was not created.");
+    userId = user.id;
+
+    const stamp = "2026-08-22T00:00:00.000Z";
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const tokenRows = await Promise.all([
+      tokenRow(
+        env.DB,
+        "tok_draft_sync_send",
+        sendToken,
+        "client_draft_sync_api",
+        user.sessionId,
+        user.id,
+        future,
+        ["mail:send"],
+        apiResource
+      ),
+      tokenRow(
+        env.DB,
+        "tok_draft_sync_read",
+        readToken,
+        "client_draft_sync_api",
+        user.sessionId,
+        user.id,
+        future,
+        ["mail:read"],
+        apiResource
+      )
+    ]);
+    await env.DB.batch([
+      mailboxRow("mbx_draft_sync", "draft-sync@example.com", stamp),
+      mailboxRow("mbx_draft_sync_secret", "secret-draft@example.com", stamp),
+      grantRow("mbx_draft_sync", stamp),
+      env.DB.prepare(
+        `INSERT INTO oauthClient
+         (id, clientId, disabled, redirectUris, public, requirePKCE, createdAt, updatedAt)
+         VALUES ('client_row_draft_sync', 'client_draft_sync_api', 0, ?, 1, 1, ?, ?)`
+      ).bind(JSON.stringify(["https://client.example/drafts"]), stamp, stamp),
+      env.DB.prepare(
+        `INSERT INTO oauthConsent
+         (id, clientId, userId, scopes, resources, createdAt, updatedAt)
+         VALUES ('consent_draft_sync', 'client_draft_sync_api', ?, ?, ?, ?, ?)`
+      ).bind(
+        user.id,
+        JSON.stringify(["mail:read", "mail:send"]),
+        JSON.stringify([apiResource]),
+        stamp,
+        stamp
+      ),
+      ...tokenRows,
+      draftRow("drf_sync_historical", "mbx_draft_sync", "2026-08-22T00:00:00.000Z")
+    ]);
+  });
+
+  it("starts with a checkpoint and does not replay historical drafts", async () => {
+    const first = await changePage(await apiFetch("/api/v1/drafts/changes", sendToken));
+    expect(first).toMatchObject({ changes: [], hasMore: false });
+
+    const next = await changePage(
+      await apiFetch(`/api/v1/drafts/changes?cursor=${first.nextCursor}`, sendToken)
+    );
+    expect(next).toMatchObject({ changes: [], hasMore: false });
+  });
+
+  it("paginates drafts in stable update and id order without exposing inaccessible rows", async () => {
+    const tie = "2026-08-22T01:00:02.000Z";
+    await env.DB.batch([
+      draftRow("drf_page_1", "mbx_draft_sync", "2026-08-22T01:00:03.000Z"),
+      draftRow("drf_page_2", "mbx_draft_sync", tie),
+      draftRow("drf_page_3", "mbx_draft_sync", tie),
+      draftRow("drf_page_4", "mbx_draft_sync", tie),
+      draftRow("drf_page_5", "mbx_draft_sync", "2026-08-22T01:00:01.000Z"),
+      draftRow("drf_page_secret", "mbx_draft_sync_secret", tie)
+    ]);
+    await env.DB.prepare(
+      `INSERT INTO draft_attachments
+       (id, draft_id, filename, content_type, size_bytes, r2_key, created_at)
+       VALUES ('att_page_1', 'drf_page_1', 'page.txt', 'text/plain', 4,
+               'drafts/page/page.txt', ?)`
+    )
+      .bind(tie)
+      .run();
+
+    const pages: Array<Array<{ id: string; attachments: Array<{ id: string }> }>> = [];
+    let next: string | null = `${origin}/api/v1/drafts?limit=2`;
+    while (next) {
+      if (pages.length > 20) throw new Error("Draft pagination did not terminate.");
+      const response = await apiFetch(next.slice(origin.length), sendToken);
+      expect(response.status, await response.clone().text()).toBe(200);
+      pages.push(await response.json());
+      next = nextPageUrl(response);
+    }
+
+    const drafts = pages.flat();
+    const pageDrafts = drafts.filter((draft) => draft.id.startsWith("drf_page_"));
+    expect(pageDrafts.map((draft) => draft.id)).toEqual([
+      "drf_page_1",
+      "drf_page_4",
+      "drf_page_3",
+      "drf_page_2",
+      "drf_page_5"
+    ]);
+    expect(drafts.map((draft) => draft.id)).not.toContain("drf_page_secret");
+    expect(drafts.find((draft) => draft.id === "drf_page_1")?.attachments).toEqual([
+      expect.objectContaining({ id: "att_page_1" })
+    ]);
+  });
+
+  it("starts with a checkpoint and journals draft and attachment changes", async () => {
+    const cursor = await checkpoint();
+    const stamp = "2026-08-22T02:00:00.000Z";
+    await draftRow("drf_changes", "mbx_draft_sync", stamp).run();
+    await env.DB.prepare(
+      `INSERT INTO draft_attachments
+       (id, draft_id, filename, content_type, size_bytes, r2_key, created_at)
+       VALUES ('att_changes', 'drf_changes', 'change.txt', 'text/plain', 6,
+               'drafts/changes/change.txt', ?)`
+    )
+      .bind(stamp)
+      .run();
+    await env.DB.prepare("DELETE FROM draft_attachments WHERE id = 'att_changes'").run();
+
+    const upserts = await changePage(
+      await apiFetch(`/api/v1/drafts/changes?cursor=${cursor}`, sendToken)
+    );
+    expect(upserts.hasMore).toBe(false);
+    expect(upserts.changes).toHaveLength(3);
+    for (const change of upserts.changes) {
+      expect(change).toMatchObject({
+        type: "upsert",
+        draft: { id: "drf_changes", attachments: [] }
+      });
+    }
+
+    await env.DB.prepare("DELETE FROM drafts WHERE id = 'drf_changes'").run();
+    const deletion = await changePage(
+      await apiFetch(`/api/v1/drafts/changes?cursor=${upserts.nextCursor}`, sendToken)
+    );
+    expect(deletion.changes).toEqual([{ type: "delete", draftId: "drf_changes" }]);
+  });
+
+  it("bounds each change cycle at its high-water sequence", async () => {
+    const cursor = await checkpoint();
+    const stamp = "2026-08-22T03:00:00.000Z";
+    await env.DB.batch([
+      draftRow("drf_cycle_1", "mbx_draft_sync", stamp),
+      draftRow("drf_cycle_2", "mbx_draft_sync", stamp),
+      draftRow("drf_cycle_3", "mbx_draft_sync", stamp)
+    ]);
+
+    const first = await changePage(
+      await apiFetch(`/api/v1/drafts/changes?cursor=${cursor}&limit=2`, sendToken)
+    );
+    expect(first.hasMore).toBe(true);
+    expect(first.changes.map(upsertId)).toEqual(["drf_cycle_1", "drf_cycle_2"]);
+
+    await env.DB.prepare(
+      "UPDATE drafts SET subject = 'Later', version = 2, updated_at = ? WHERE id = ?"
+    )
+      .bind("2026-08-22T03:00:01.000Z", "drf_cycle_1")
+      .run();
+    const second = await changePage(
+      await apiFetch(`/api/v1/drafts/changes?cursor=${first.nextCursor}&limit=2`, sendToken)
+    );
+    expect(second.hasMore).toBe(false);
+    expect(second.changes.map(upsertId)).toEqual(["drf_cycle_3"]);
+
+    const nextCycle = await changePage(
+      await apiFetch(`/api/v1/drafts/changes?cursor=${second.nextCursor}`, sendToken)
+    );
+    expect(nextCycle.changes.map(upsertId)).toEqual(["drf_cycle_1"]);
+  });
+
+  it("applies live mailbox access to upserts and uses user-owned tombstones", async () => {
+    const cursor = await checkpoint();
+    const stamp = "2026-08-22T04:00:00.000Z";
+    await draftRow("drf_access_revoked", "mbx_draft_sync", stamp).run();
+    await env.DB.prepare(
+      "DELETE FROM mailbox_grants WHERE mailbox_id = 'mbx_draft_sync' AND user_id = ?"
+    )
+      .bind(userId)
+      .run();
+
+    const hidden = await changePage(
+      await apiFetch(`/api/v1/drafts/changes?cursor=${cursor}`, sendToken)
+    );
+    expect(hidden.changes).toEqual([]);
+
+    await grantRow("mbx_draft_sync", stamp).run();
+    await env.DB.prepare("DELETE FROM drafts WHERE id = 'drf_access_revoked'").run();
+    const deletion = await changePage(
+      await apiFetch(`/api/v1/drafts/changes?cursor=${hidden.nextCursor}`, sendToken)
+    );
+    expect(deletion.changes).toEqual([{ type: "delete", draftId: "drf_access_revoked" }]);
+  });
+
+  it("validates scope, filters, limits, and foreign cursors", async () => {
+    const noSend = await apiFetch("/api/v1/drafts/changes", readToken);
+    expect(noSend.status).toBe(403);
+    expect(noSend.headers.get("www-authenticate")).toContain('scope="mail:send"');
+
+    for (const path of [
+      "/api/v1/drafts?limit=0",
+      "/api/v1/drafts?limit=101",
+      "/api/v1/drafts/changes?limit=1.5"
+    ]) {
+      const response = await apiFetch(path, sendToken);
+      expect(response.status, path).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: { code: "INVALID_LIMIT" } });
+    }
+
+    const filtered = await apiFetch("/api/v1/drafts/changes?updatedSince=now", sendToken);
+    expect(filtered.status).toBe(400);
+    await expect(filtered.json()).resolves.toMatchObject({
+      error: { code: "INVALID_DRAFT_CHANGE_FILTER" }
+    });
+
+    const messageCursor = encodeChangeCursor({ after: "0", highWater: null });
+    const listWithForeignCursor = await apiFetch(
+      `/api/v1/drafts?cursor=${encodeURIComponent(messageCursor)}`,
+      sendToken
+    );
+    expect(listWithForeignCursor.status).toBe(400);
+    await expect(listWithForeignCursor.json()).resolves.toMatchObject({
+      error: { code: "INVALID_DRAFT_CURSOR" }
+    });
+
+    const future = encodeDraftChangeCursor({
+      after: "9223372036854775807",
+      highWater: null,
+      userId
+    });
+    for (const value of [messageCursor, future]) {
+      const response = await apiFetch(
+        `/api/v1/drafts/changes?cursor=${encodeURIComponent(value)}`,
+        sendToken
+      );
+      expect(response.status, value).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: { code: "INVALID_DRAFT_CHANGE_CURSOR" }
+      });
+    }
+  });
+});
+
+type DraftChangePage = {
+  changes: Array<{
+    type: "upsert" | "delete";
+    draft?: { id: string };
+    draftId?: string;
+  }>;
+  nextCursor: string;
+  hasMore: boolean;
+};
+
+async function checkpoint(): Promise<string> {
+  return (await changePage(await apiFetch("/api/v1/drafts/changes", sendToken))).nextCursor;
+}
+
+async function changePage(response: Response): Promise<DraftChangePage> {
+  expect(response.status, await response.clone().text()).toBe(200);
+  return response.json<DraftChangePage>();
+}
+
+function upsertId(change: DraftChangePage["changes"][number]): string {
+  if (change.type !== "upsert" || !change.draft) throw new Error("Expected a draft upsert.");
+  return change.draft.id;
+}
+
+function nextPageUrl(response: Response): string | null {
+  const link = response.headers.get("link");
+  if (!link) return null;
+  const match = link.match(/^<([^>]+)>;\s*rel="next"$/u);
+  if (!match?.[1]) throw new Error(`Malformed Link header: ${link}`);
+  return match[1];
+}
+
+function mailboxRow(id: string, address: string, stamp: string): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO mailboxes (id, address, display_name, is_active, created_at, updated_at)
+     VALUES (?, ?, ?, 1, ?, ?)`
+  ).bind(id, address, id, stamp, stamp);
+}
+
+function grantRow(mailboxId: string, stamp: string): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO mailbox_grants (mailbox_id, user_id, access_level, created_by, created_at, updated_at)
+     VALUES (?, ?, 'agent', ?, ?, ?)`
+  ).bind(mailboxId, userId, userId, stamp, stamp);
+}
+
+function draftRow(id: string, mailboxId: string, stamp: string): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO drafts
+     (id, user_id, mailbox_id, from_address, to_json, cc_json, bcc_json, subject,
+      text_body, html_body, created_at, updated_at)
+     VALUES (?, ?, ?, 'draft-sync@example.com', '[]', '[]', '[]', ?, '', '', ?, ?)`
+  ).bind(id, userId, mailboxId, id, stamp, stamp);
+}
+
+function apiFetch(path: string, token: string): Promise<Response> {
+  return SELF.fetch(`${origin}${path}`, { headers: { authorization: `Bearer ${token}` } });
+}

--- a/test/unit/app/drafts/draft-api.test.ts
+++ b/test/unit/app/drafts/draft-api.test.ts
@@ -11,7 +11,7 @@ describe("draft API", () => {
       .mockResolvedValueOnce(
         Response.json([{ id: "drf_newer" }], {
           headers: {
-            link: '<https://hqbase.test/api/v1/drafts?limit=100&cursor=next>; rel="next"'
+            link: '<https://hqbase.test/api/v1/drafts?cursor=previous>; rel=prev; title="Older, drafts", <https://hqbase.test/api/v1/drafts?limit=100&cursor=next>; type="application/json"; rel="alternate next"'
           }
         })
       )
@@ -28,5 +28,30 @@ describe("draft API", () => {
       "https://hqbase.test/api/v1/drafts?limit=100&cursor=next",
       { credentials: "include", method: "GET" }
     );
+  });
+
+  it("stops when a valid Link header has no next relation", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      Response.json([{ id: "drf_only" }], {
+        headers: { link: "<https://hqbase.test/api/v1/drafts?cursor=previous>; rel=prev" }
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(listDrafts()).resolves.toEqual([{ id: "drf_only" }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a malformed non-empty Link header", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValueOnce(
+        Response.json([{ id: "drf_only" }], {
+          headers: { link: "not-a-link" }
+        })
+      )
+    );
+
+    await expect(listDrafts()).rejects.toThrow("Malformed Link header.");
   });
 });

--- a/test/unit/app/drafts/draft-api.test.ts
+++ b/test/unit/app/drafts/draft-api.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { listDrafts } from "../../../../app/features/drafts/api";
+
+describe("draft API", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("follows every draft page from the Link header", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        Response.json([{ id: "drf_newer" }], {
+          headers: {
+            link: '<https://hqbase.test/api/v1/drafts?limit=100&cursor=next>; rel="next"'
+          }
+        })
+      )
+      .mockResolvedValueOnce(Response.json([{ id: "drf_older" }]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(listDrafts()).resolves.toEqual([{ id: "drf_newer" }, { id: "drf_older" }]);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/v1/drafts?limit=100", {
+      credentials: "include",
+      method: "GET"
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://hqbase.test/api/v1/drafts?limit=100&cursor=next",
+      { credentials: "include", method: "GET" }
+    );
+  });
+});

--- a/test/unit/scripts/mail-api-artifacts.test.mjs
+++ b/test/unit/scripts/mail-api-artifacts.test.mjs
@@ -15,7 +15,15 @@ describe("Mail API public artifacts", () => {
     expect(openApi.paths["/api/v1/changes"].get.security).toContainEqual({
       oauth2: ["mail:read"]
     });
+    expect(openApi.paths["/api/v1/drafts/changes"].get.security).toContainEqual({
+      oauth2: ["mail:send"]
+    });
     expect(openApi.components.schemas.MessageChangePage.required).toEqual([
+      "changes",
+      "nextCursor",
+      "hasMore"
+    ]);
+    expect(openApi.components.schemas.DraftChangePage.required).toEqual([
       "changes",
       "nextCursor",
       "hasMore"

--- a/test/unit/scripts/sql-migrations.test.mjs
+++ b/test/unit/scripts/sql-migrations.test.mjs
@@ -19,7 +19,8 @@ const expectedMigrationNames = [
   "0011_latest_password_reset_token.sql",
   "0012_message_activity_index.sql",
   "0013_message_changes.sql",
-  "0014_unassigned_messages.sql"
+  "0014_unassigned_messages.sql",
+  "0015_draft_changes.sql"
 ];
 const databases = [];
 
@@ -132,15 +133,16 @@ describe("SQL migration contract", () => {
     const tables = database
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
       .all();
-    expect(tables).toHaveLength(39);
+    expect(tables).toHaveLength(40);
   });
 
   it("preserves populated data through the latest upgrade and skips it on retry", async () => {
     const database = createDatabase();
     const migrations = await readD1Migrations(migrationsDirectory);
-    for (const migration of migrations.slice(0, -1)) applyMigration(database, migration);
+    for (const migration of migrations.slice(0, -2)) applyMigration(database, migration);
     insertRepresentativeData(database);
 
+    expect(applyMigration(database, migrations.at(-2))).toBe(true);
     expect(applyMigration(database, migrations.at(-1))).toBe(true);
     expect(database.prepare("SELECT id, email FROM user WHERE id = 'usr_upgrade'").get()).toEqual({
       id: "usr_upgrade",
@@ -164,7 +166,7 @@ describe("SQL migration contract", () => {
 
     expect(applyMigration(database, migrations.at(-1))).toBe(false);
     expect(database.prepare("SELECT count(*) AS count FROM d1_migrations").get()).toEqual({
-      count: 14
+      count: 15
     });
   });
 });

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -21,8 +21,9 @@ describe("staging workflow lifecycle record", () => {
     expect(deploy).toBeGreaterThan(current);
     expect(workflow).toContain("sql-upgrade-probe");
     expect(workflow).toContain("msg_sql_upgrade");
+    expect(workflow).toContain('"$(basename "$migration")" < "0014_"');
     expect(workflow).toContain('"is_unassigned":1');
-    expect(workflow).toContain('"migration_count":14');
+    expect(workflow).toContain('"migration_count":15');
   });
 
   it("records the reviewed Worker deploy before cleanup", () => {

--- a/test/unit/worker/features/drafts/change-cursor.test.ts
+++ b/test/unit/worker/features/drafts/change-cursor.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compareDraftChangeSequences,
+  decodeDraftChangeCursor,
+  encodeDraftChangeCursor
+} from "../../../../../worker/features/drafts/change-cursor";
+
+describe("draft change cursor", () => {
+  const userId = "usr_cursor";
+
+  it("round-trips a checkpoint and an active high-water cursor", () => {
+    expect(
+      decodeDraftChangeCursor(
+        encodeDraftChangeCursor({ after: "12", highWater: null, userId }),
+        userId
+      )
+    ).toEqual({ after: "12", highWater: null, userId });
+    expect(
+      decodeDraftChangeCursor(
+        encodeDraftChangeCursor({ after: "12", highWater: "25", userId }),
+        userId
+      )
+    ).toEqual({ after: "12", highWater: "25", userId });
+  });
+
+  it("compares decimal sequences without number precision loss", () => {
+    expect(compareDraftChangeSequences("9007199254740992", "9007199254740993")).toBe(-1);
+    expect(compareDraftChangeSequences("9007199254740993", "9007199254740993")).toBe(0);
+    expect(compareDraftChangeSequences("9007199254740994", "9007199254740993")).toBe(1);
+  });
+
+  it("rejects malformed, foreign, reversed, and out-of-range cursors", () => {
+    const values = [
+      "not-a-cursor",
+      encode(["c1", "12", null]),
+      encode(["dc1", userId, "12", "11"]),
+      encode(["dc1", userId, "01", null]),
+      encode(["dc1", userId, "9223372036854775808", null]),
+      encode(["dc1", "usr_other", "12", null])
+    ];
+    for (const value of values) {
+      expect(() => decodeDraftChangeCursor(value, userId)).toThrowError(
+        /Draft change cursor is invalid/u
+      );
+    }
+  });
+});
+
+function encode(value: unknown): string {
+  return btoa(JSON.stringify(value)).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+}

--- a/worker/db/schema-messages.ts
+++ b/worker/db/schema-messages.ts
@@ -135,7 +135,11 @@ export const drafts = sqliteTable(
     })
   },
   (table) => [
-    index("drafts_user_updated_idx").on(table.userId, sql`${table.updatedAt} DESC`),
+    index("drafts_user_updated_id_idx").on(
+      table.userId,
+      sql`${table.updatedAt} DESC`,
+      sql`${table.id} DESC`
+    ),
     index("drafts_forward_message_idx").on(table.forwardOfMessageId)
   ]
 );
@@ -154,4 +158,19 @@ export const draftAttachments = sqliteTable(
     createdAt: text("created_at").notNull()
   },
   (table) => [index("draft_attachments_draft_idx").on(table.draftId, table.createdAt)]
+);
+
+export const draftChanges = sqliteTable(
+  "draft_changes",
+  {
+    sequence: integer("sequence").primaryKey({ autoIncrement: true }),
+    draftId: text("draft_id").notNull(),
+    userId: text("user_id").notNull(),
+    kind: text("kind", { enum: ["upsert", "delete"] }).notNull(),
+    changedAt: text("changed_at").notNull()
+  },
+  (table) => [
+    check("draft_changes_kind_check", sql`${table.kind} IN ('upsert', 'delete')`),
+    index("draft_changes_user_sequence_idx").on(table.userId, table.sequence)
+  ]
 );

--- a/worker/features/drafts/access.ts
+++ b/worker/features/drafts/access.ts
@@ -3,16 +3,14 @@ import { sql } from "drizzle-orm";
 import {
   accessAllows,
   canAccessUnassignedMail,
-  type MailboxAccessLevel,
-  requireMailboxAccess
+  type MailboxAccessLevel
 } from "../../auth/mailbox-access";
-import { getRows } from "../../db/drizzle";
+import { getRow, getRows } from "../../db/drizzle";
 import type { WorkerEnv } from "../../lib/env";
 import { AppError } from "../../lib/errors";
 import type { WorkspaceRole } from "../../lib/validation";
 import { listMailboxesForUser } from "../mailboxes/queries";
 import type { Mailbox } from "../mailboxes/types";
-import { requireMessageAccess } from "../messages/access";
 
 import { defaultDraftLimit, listDraftPage } from "./list-queries";
 import { draftIdsForAttachmentIds, getDraft } from "./queries";
@@ -60,18 +58,8 @@ export async function filterAccessibleDrafts(
   drafts: Draft[]
 ): Promise<Draft[]> {
   if (drafts.length === 0) return [];
-  const mailboxes = await listMailboxesForUser(env.DB, principal.userId, principal.role);
-  const messageIds = [
-    ...new Set(
-      drafts.flatMap((draft) =>
-        [draft.replyToMessageId, draft.forwardOfMessageId].filter((id): id is string => id !== null)
-      )
-    )
-  ];
-  const messageTargets = await getDraftMessageTargets(env.DB, messageIds);
-  return drafts.filter((draft) =>
-    draftIsAccessible({ draft, mailboxes, messageTargets, principal })
-  );
+  const context = await loadDraftAccessContext(env, principal, drafts);
+  return drafts.filter((draft) => draftAccessDenial({ context, draft, principal }) === null);
 }
 
 export async function getAccessibleDraft(
@@ -106,36 +94,128 @@ export async function requireDraftAttachmentIdsAccess(
 export async function requireDraftAccess(
   env: WorkerEnv,
   principal: DraftPrincipal,
-  draft: Pick<Draft, "mailboxId" | "from" | "replyToMessageId" | "forwardOfMessageId">,
-  knownMailboxes?: Array<Mailbox & { accessLevel: MailboxAccessLevel | null }>
+  draft: DraftAccessTarget
 ): Promise<void> {
+  const context = await loadDraftAccessContext(env, principal, [draft]);
+  const denial = draftAccessDenial({ context, draft, principal });
+  if (denial) throw new AppError(denial.code, denial.message, denial.status);
+}
+
+type DraftAccessTarget = Pick<
+  Draft,
+  "mailboxId" | "from" | "replyToMessageId" | "forwardOfMessageId"
+>;
+
+type DraftAccessContext = {
+  active: boolean;
+  mailboxes: Array<Mailbox & { accessLevel: MailboxAccessLevel | null }>;
+  messageTargets: Map<string, DraftMessageTarget>;
+};
+
+type DraftAccessDenial = {
+  code: string;
+  message: string;
+  status: number;
+};
+
+async function loadDraftAccessContext(
+  env: WorkerEnv,
+  principal: DraftPrincipal,
+  drafts: DraftAccessTarget[]
+): Promise<DraftAccessContext> {
+  const messageIds = [
+    ...new Set(
+      drafts.flatMap((draft) =>
+        [draft.replyToMessageId, draft.forwardOfMessageId].filter((id): id is string => id !== null)
+      )
+    )
+  ];
+  const [active, mailboxes, messageTargets] = await Promise.all([
+    draftPrincipalIsActive(env.DB, principal.userId),
+    listMailboxesForUser(env.DB, principal.userId, principal.role),
+    getDraftMessageTargets(env.DB, messageIds)
+  ]);
+  return { active, mailboxes, messageTargets };
+}
+
+async function draftPrincipalIsActive(db: D1Database, userId: string): Promise<boolean> {
+  const row = await getRow<{ active: number }>(
+    db,
+    sql`SELECT CASE WHEN COALESCE(banned, 0) = 0 THEN 1 ELSE 0 END AS active
+        FROM "user" WHERE id = ${userId}`
+  );
+  return row?.active === 1;
+}
+
+function draftAccessDenial(input: {
+  context: DraftAccessContext;
+  draft: DraftAccessTarget;
+  principal: DraftPrincipal;
+}): DraftAccessDenial | null {
+  const { context, draft, principal } = input;
+  if (!context.active) {
+    return {
+      code: "MAILBOX_FORBIDDEN",
+      message: "You do not have access to drafts.",
+      status: 403
+    };
+  }
   let sendingMailboxId = draft.mailboxId;
   if (draft.from) {
-    const mailboxes =
-      knownMailboxes ?? (await listMailboxesForUser(env.DB, principal.userId, principal.role));
     const normalizedFrom = draft.from.toLowerCase();
-    const mailbox = mailboxes.find(
+    const mailbox = context.mailboxes.find(
       (candidate) =>
         candidate.address.toLowerCase() === normalizedFrom ||
         candidate.addresses.some((address) => address.address.toLowerCase() === normalizedFrom)
     );
-    if (!mailbox) throw new AppError("MAILBOX_NOT_FOUND", "Sending mailbox not found.", 404);
+    if (!mailbox) {
+      return { code: "MAILBOX_NOT_FOUND", message: "Sending mailbox not found.", status: 404 };
+    }
     if (sendingMailboxId && sendingMailboxId !== mailbox.id) {
-      throw new AppError(
-        "DRAFT_MAILBOX_MISMATCH",
-        "Draft sender does not belong to the selected mailbox.",
-        400
-      );
+      return {
+        code: "DRAFT_MAILBOX_MISMATCH",
+        message: "Draft sender does not belong to the selected mailbox.",
+        status: 400
+      };
     }
     sendingMailboxId = mailbox.id;
   }
   if (sendingMailboxId) {
-    await requireMailboxAccess(env.DB, principal.userId, principal.role, sendingMailboxId, "agent");
+    const mailbox = context.mailboxes.find((candidate) => candidate.id === sendingMailboxId);
+    if (!mailbox || !accessAllows(mailbox.accessLevel, "agent")) {
+      return {
+        code: "MAILBOX_FORBIDDEN",
+        message: "You do not have access to this mailbox.",
+        status: 403
+      };
+    }
   }
   for (const messageId of [draft.replyToMessageId, draft.forwardOfMessageId]) {
     if (!messageId) continue;
-    await requireMessageAccess(env.DB, principal.userId, principal.role, messageId, "agent");
+    const target = context.messageTargets.get(messageId);
+    if (!target || (target.is_unassigned !== 1 && target.mailbox_id === null)) {
+      return { code: "MESSAGE_NOT_FOUND", message: "Message not found.", status: 404 };
+    }
+    if (target.is_unassigned === 1) {
+      if (!canAccessUnassignedMail(principal.role)) {
+        return {
+          code: "MAILBOX_FORBIDDEN",
+          message: "You do not have access to this message.",
+          status: 403
+        };
+      }
+      continue;
+    }
+    const mailbox = context.mailboxes.find((candidate) => candidate.id === target.mailbox_id);
+    if (!mailbox || !accessAllows(mailbox.accessLevel, "agent")) {
+      return {
+        code: "MAILBOX_FORBIDDEN",
+        message: "You do not have access to this mailbox.",
+        status: 403
+      };
+    }
   }
+  return null;
 }
 
 type DraftMessageTarget = {
@@ -149,51 +229,20 @@ async function getDraftMessageTargets(
   messageIds: string[]
 ): Promise<Map<string, DraftMessageTarget>> {
   if (messageIds.length === 0) return new Map();
-  const rows = await getRows<DraftMessageTarget>(
-    db,
-    sql`SELECT id, mailbox_id, is_unassigned
-        FROM messages
-        WHERE id IN (${sql.join(
-          messageIds.map((id) => sql`${id}`),
-          sql`, `
-        )})`
-  );
-  return new Map(rows.map((row) => [row.id, row]));
-}
-
-function draftIsAccessible(input: {
-  draft: Draft;
-  mailboxes: Array<Mailbox & { accessLevel: MailboxAccessLevel | null }>;
-  messageTargets: Map<string, DraftMessageTarget>;
-  principal: DraftPrincipal;
-}): boolean {
-  const { draft, mailboxes, messageTargets, principal } = input;
-  let sendingMailboxId = draft.mailboxId;
-  if (draft.from) {
-    const normalizedFrom = draft.from.toLowerCase();
-    const mailbox = mailboxes.find(
-      (candidate) =>
-        candidate.address.toLowerCase() === normalizedFrom ||
-        candidate.addresses.some((address) => address.address.toLowerCase() === normalizedFrom)
+  const rows: DraftMessageTarget[] = [];
+  for (let index = 0; index < messageIds.length; index += 100) {
+    const batch = messageIds.slice(index, index + 100);
+    rows.push(
+      ...(await getRows<DraftMessageTarget>(
+        db,
+        sql`SELECT id, mailbox_id, is_unassigned
+            FROM messages
+            WHERE id IN (${sql.join(
+              batch.map((id) => sql`${id}`),
+              sql`, `
+            )})`
+      ))
     );
-    if (!mailbox || (sendingMailboxId !== null && sendingMailboxId !== mailbox.id)) return false;
-    sendingMailboxId = mailbox.id;
   }
-  if (sendingMailboxId) {
-    const mailbox = mailboxes.find((candidate) => candidate.id === sendingMailboxId);
-    if (!mailbox || !accessAllows(mailbox.accessLevel, "agent")) return false;
-  }
-  for (const messageId of [draft.replyToMessageId, draft.forwardOfMessageId]) {
-    if (!messageId) continue;
-    const target = messageTargets.get(messageId);
-    if (!target) return false;
-    if (target.is_unassigned === 1) {
-      if (!canAccessUnassignedMail(principal.role)) return false;
-      continue;
-    }
-    if (!target.mailbox_id) return false;
-    const mailbox = mailboxes.find((candidate) => candidate.id === target.mailbox_id);
-    if (!mailbox || !accessAllows(mailbox.accessLevel, "agent")) return false;
-  }
-  return true;
+  return new Map(rows.map((row) => [row.id, row]));
 }

--- a/worker/features/drafts/access.ts
+++ b/worker/features/drafts/access.ts
@@ -1,4 +1,12 @@
-import { type MailboxAccessLevel, requireMailboxAccess } from "../../auth/mailbox-access";
+import { sql } from "drizzle-orm";
+
+import {
+  accessAllows,
+  canAccessUnassignedMail,
+  type MailboxAccessLevel,
+  requireMailboxAccess
+} from "../../auth/mailbox-access";
+import { getRows } from "../../db/drizzle";
 import type { WorkerEnv } from "../../lib/env";
 import { AppError } from "../../lib/errors";
 import type { WorkspaceRole } from "../../lib/validation";
@@ -6,29 +14,64 @@ import { listMailboxesForUser } from "../mailboxes/queries";
 import type { Mailbox } from "../mailboxes/types";
 import { requireMessageAccess } from "../messages/access";
 
-import { draftIdsForAttachmentIds, getDraft, listDrafts } from "./queries";
+import { defaultDraftLimit, listDraftPage } from "./list-queries";
+import { draftIdsForAttachmentIds, getDraft } from "./queries";
 import type { Draft } from "./types";
 
 export type DraftPrincipal = { role: WorkspaceRole; userId: string };
+
+export type AccessibleDraftPage = {
+  drafts: Draft[];
+  nextCursor: string | null;
+};
 
 export async function listAccessibleDrafts(
   env: WorkerEnv,
   principal: DraftPrincipal
 ): Promise<Draft[]> {
-  const drafts = await listDrafts(env.DB, principal.userId);
+  const drafts: Draft[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await listAccessibleDraftPage(env, principal, {
+      cursor,
+      limit: defaultDraftLimit
+    });
+    drafts.push(...page.drafts);
+    cursor = page.nextCursor ?? undefined;
+  } while (cursor);
+  return drafts;
+}
+
+export async function listAccessibleDraftPage(
+  env: WorkerEnv,
+  principal: DraftPrincipal,
+  input: { cursor?: string | undefined; limit: number }
+): Promise<AccessibleDraftPage> {
+  const page = await listDraftPage(env.DB, principal.userId, input);
+  return {
+    drafts: await filterAccessibleDrafts(env, principal, page.drafts),
+    nextCursor: page.nextCursor
+  };
+}
+
+export async function filterAccessibleDrafts(
+  env: WorkerEnv,
+  principal: DraftPrincipal,
+  drafts: Draft[]
+): Promise<Draft[]> {
+  if (drafts.length === 0) return [];
   const mailboxes = await listMailboxesForUser(env.DB, principal.userId, principal.role);
-  const visibility = await Promise.all(
-    drafts.map(async (draft) => {
-      try {
-        await requireDraftAccess(env, principal, draft, mailboxes);
-        return draft;
-      } catch (error) {
-        if (!(error instanceof AppError)) throw error;
-        return null;
-      }
-    })
+  const messageIds = [
+    ...new Set(
+      drafts.flatMap((draft) =>
+        [draft.replyToMessageId, draft.forwardOfMessageId].filter((id): id is string => id !== null)
+      )
+    )
+  ];
+  const messageTargets = await getDraftMessageTargets(env.DB, messageIds);
+  return drafts.filter((draft) =>
+    draftIsAccessible({ draft, mailboxes, messageTargets, principal })
   );
-  return visibility.filter((draft): draft is Draft => draft !== null);
 }
 
 export async function getAccessibleDraft(
@@ -93,4 +136,64 @@ export async function requireDraftAccess(
     if (!messageId) continue;
     await requireMessageAccess(env.DB, principal.userId, principal.role, messageId, "agent");
   }
+}
+
+type DraftMessageTarget = {
+  id: string;
+  is_unassigned: number;
+  mailbox_id: string | null;
+};
+
+async function getDraftMessageTargets(
+  db: D1Database,
+  messageIds: string[]
+): Promise<Map<string, DraftMessageTarget>> {
+  if (messageIds.length === 0) return new Map();
+  const rows = await getRows<DraftMessageTarget>(
+    db,
+    sql`SELECT id, mailbox_id, is_unassigned
+        FROM messages
+        WHERE id IN (${sql.join(
+          messageIds.map((id) => sql`${id}`),
+          sql`, `
+        )})`
+  );
+  return new Map(rows.map((row) => [row.id, row]));
+}
+
+function draftIsAccessible(input: {
+  draft: Draft;
+  mailboxes: Array<Mailbox & { accessLevel: MailboxAccessLevel | null }>;
+  messageTargets: Map<string, DraftMessageTarget>;
+  principal: DraftPrincipal;
+}): boolean {
+  const { draft, mailboxes, messageTargets, principal } = input;
+  let sendingMailboxId = draft.mailboxId;
+  if (draft.from) {
+    const normalizedFrom = draft.from.toLowerCase();
+    const mailbox = mailboxes.find(
+      (candidate) =>
+        candidate.address.toLowerCase() === normalizedFrom ||
+        candidate.addresses.some((address) => address.address.toLowerCase() === normalizedFrom)
+    );
+    if (!mailbox || (sendingMailboxId !== null && sendingMailboxId !== mailbox.id)) return false;
+    sendingMailboxId = mailbox.id;
+  }
+  if (sendingMailboxId) {
+    const mailbox = mailboxes.find((candidate) => candidate.id === sendingMailboxId);
+    if (!mailbox || !accessAllows(mailbox.accessLevel, "agent")) return false;
+  }
+  for (const messageId of [draft.replyToMessageId, draft.forwardOfMessageId]) {
+    if (!messageId) continue;
+    const target = messageTargets.get(messageId);
+    if (!target) return false;
+    if (target.is_unassigned === 1) {
+      if (!canAccessUnassignedMail(principal.role)) return false;
+      continue;
+    }
+    if (!target.mailbox_id) return false;
+    const mailbox = mailboxes.find((candidate) => candidate.id === target.mailbox_id);
+    if (!mailbox || !accessAllows(mailbox.accessLevel, "agent")) return false;
+  }
+  return true;
 }

--- a/worker/features/drafts/change-cursor.ts
+++ b/worker/features/drafts/change-cursor.ts
@@ -1,0 +1,53 @@
+import { AppError } from "../../lib/errors";
+
+const draftChangeCursorVersion = "dc1";
+const maximumSqliteSequence = 9_223_372_036_854_775_807n;
+
+export type DraftChangeCursor = {
+  after: string;
+  highWater: string | null;
+  userId: string;
+};
+
+export function encodeDraftChangeCursor(cursor: DraftChangeCursor): string {
+  return btoa(
+    JSON.stringify([draftChangeCursorVersion, cursor.userId, cursor.after, cursor.highWater])
+  )
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+export function decodeDraftChangeCursor(value: string, userId: string): DraftChangeCursor {
+  try {
+    if (value.length === 0 || value.length > 512) throw new Error("Invalid cursor length.");
+    const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+    const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+    const decoded: unknown = JSON.parse(atob(`${base64}${padding}`));
+    if (
+      !Array.isArray(decoded) ||
+      decoded.length !== 4 ||
+      decoded[0] !== draftChangeCursorVersion ||
+      decoded[1] !== userId ||
+      !isDraftChangeSequence(decoded[2]) ||
+      !(decoded[3] === null || isDraftChangeSequence(decoded[3])) ||
+      (decoded[3] !== null && BigInt(decoded[2]) > BigInt(decoded[3]))
+    ) {
+      throw new Error("Invalid cursor payload.");
+    }
+    return { after: decoded[2], highWater: decoded[3], userId };
+  } catch {
+    throw new AppError("INVALID_DRAFT_CHANGE_CURSOR", "Draft change cursor is invalid.", 400);
+  }
+}
+
+export function compareDraftChangeSequences(left: string, right: string): number {
+  const a = BigInt(left);
+  const b = BigInt(right);
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function isDraftChangeSequence(value: unknown): value is string {
+  if (typeof value !== "string" || !/^(?:0|[1-9]\d{0,18})$/u.test(value)) return false;
+  return BigInt(value) <= maximumSqliteSequence;
+}

--- a/worker/features/drafts/change-queries.ts
+++ b/worker/features/drafts/change-queries.ts
@@ -1,0 +1,110 @@
+import { sql } from "drizzle-orm";
+
+import { getRow, getRows } from "../../db/drizzle";
+import type { WorkerEnv } from "../../lib/env";
+import { AppError } from "../../lib/errors";
+import { type DraftPrincipal, filterAccessibleDrafts } from "./access";
+import {
+  compareDraftChangeSequences,
+  type DraftChangeCursor,
+  decodeDraftChangeCursor,
+  encodeDraftChangeCursor
+} from "./change-cursor";
+import { getDraftsByIds } from "./list-queries";
+import type { Draft } from "./types";
+
+export const defaultDraftChangeLimit = 100;
+export const maxDraftChangeLimit = 100;
+
+export type DraftChange = { type: "upsert"; draft: Draft } | { type: "delete"; draftId: string };
+
+export type DraftChangePage = {
+  changes: DraftChange[];
+  nextCursor: string;
+  hasMore: boolean;
+};
+
+type DraftJournalRow = {
+  sequence: string;
+  draft_id: string;
+  kind: "upsert" | "delete";
+};
+
+export async function listDraftChanges(
+  env: WorkerEnv,
+  principal: DraftPrincipal,
+  input: { cursor?: string | undefined; limit: number }
+): Promise<DraftChangePage> {
+  const currentHighWater = await getCurrentHighWater(env.DB, principal.userId);
+  if (!input.cursor) {
+    return emptyPage({ after: currentHighWater, highWater: null, userId: principal.userId });
+  }
+
+  const cursor = decodeDraftChangeCursor(input.cursor, principal.userId);
+  validateCursorBounds(cursor, currentHighWater);
+  const highWater = cursor.highWater ?? currentHighWater;
+  if (compareDraftChangeSequences(cursor.after, highWater) === 0) {
+    return emptyPage({ after: highWater, highWater: null, userId: principal.userId });
+  }
+
+  const journal = await getRows<DraftJournalRow>(
+    env.DB,
+    sql`SELECT CAST(sequence AS TEXT) AS sequence, draft_id, kind
+        FROM draft_changes
+        WHERE user_id = ${principal.userId}
+          AND sequence > CAST(${cursor.after} AS INTEGER)
+          AND sequence <= CAST(${highWater} AS INTEGER)
+        ORDER BY sequence ASC
+        LIMIT ${input.limit + 1}`
+  );
+  const pageRows = journal.slice(0, input.limit);
+  const hasMore = journal.length > input.limit;
+  const current = await getDraftsByIds(env.DB, principal.userId, [
+    ...new Set(pageRows.filter((row) => row.kind === "upsert").map((row) => row.draft_id))
+  ]);
+  const accessible = await filterAccessibleDrafts(env, principal, current);
+  const drafts = new Map(accessible.map((draft) => [draft.id, draft]));
+  const changes = pageRows.flatMap<DraftChange>((row) => {
+    if (row.kind === "delete") return [{ type: "delete", draftId: row.draft_id }];
+    const draft = drafts.get(row.draft_id);
+    return draft ? [{ type: "upsert", draft }] : [];
+  });
+
+  const finalRow = pageRows.at(-1);
+  const nextCursor =
+    hasMore && finalRow
+      ? encodeDraftChangeCursor({
+          after: finalRow.sequence,
+          highWater,
+          userId: principal.userId
+        })
+      : encodeDraftChangeCursor({
+          after: highWater,
+          highWater: null,
+          userId: principal.userId
+        });
+  return { changes, nextCursor, hasMore };
+}
+
+async function getCurrentHighWater(db: D1Database, userId: string): Promise<string> {
+  const row = await getRow<{ sequence: string }>(
+    db,
+    sql`SELECT CAST(COALESCE(MAX(sequence), 0) AS TEXT) AS sequence
+        FROM draft_changes WHERE user_id = ${userId}`
+  );
+  return row?.sequence ?? "0";
+}
+
+function validateCursorBounds(cursor: DraftChangeCursor, currentHighWater: string): void {
+  if (
+    compareDraftChangeSequences(cursor.after, currentHighWater) > 0 ||
+    (cursor.highWater !== null &&
+      compareDraftChangeSequences(cursor.highWater, currentHighWater) > 0)
+  ) {
+    throw new AppError("INVALID_DRAFT_CHANGE_CURSOR", "Draft change cursor is invalid.", 400);
+  }
+}
+
+function emptyPage(cursor: DraftChangeCursor): DraftChangePage {
+  return { changes: [], nextCursor: encodeDraftChangeCursor(cursor), hasMore: false };
+}

--- a/worker/features/drafts/list-queries.ts
+++ b/worker/features/drafts/list-queries.ts
@@ -1,0 +1,90 @@
+import { type SQL, sql } from "drizzle-orm";
+
+import { getRows } from "../../db/drizzle";
+import { AppError } from "../../lib/errors";
+import { decodeKeysetCursor, encodeKeysetCursor } from "../messages/keyset-cursor";
+import { attachmentsForDrafts, type DraftRow, mapAttachment, mapDraftRow } from "./queries";
+import type { Draft, DraftAttachment } from "./types";
+
+const draftCursorVersion = "d1";
+export const defaultDraftLimit = 100;
+export const maxDraftLimit = 100;
+
+export type DraftPage = {
+  drafts: Draft[];
+  nextCursor: string | null;
+};
+
+export function decodeDraftCursor(value: string) {
+  const cursor = decodeKeysetCursor(draftCursorVersion, value);
+  if (!cursor) throw new AppError("INVALID_DRAFT_CURSOR", "Draft cursor is invalid.", 400);
+  return { id: cursor.id, updatedAt: cursor.activityAt };
+}
+
+export async function listDraftPage(
+  db: D1Database,
+  userId: string,
+  input: { cursor?: string | undefined; limit?: number | undefined } = {}
+): Promise<DraftPage> {
+  const where: SQL[] = [sql`user_id = ${userId}`];
+  const cursor = input.cursor ? decodeDraftCursor(input.cursor) : null;
+  if (cursor) {
+    where.push(
+      sql`(updated_at < ${cursor.updatedAt}
+           OR (updated_at = ${cursor.updatedAt} AND id < ${cursor.id}))`
+    );
+  }
+  const limit = Math.min(Math.max(input.limit ?? defaultDraftLimit, 1), maxDraftLimit);
+  const rows = await getRows<DraftRow>(
+    db,
+    sql`SELECT * FROM drafts
+        WHERE ${sql.join(where, sql` AND `)}
+        ORDER BY updated_at DESC, id DESC
+        LIMIT ${limit + 1}`
+  );
+  const pageRows = rows.slice(0, limit);
+  const drafts = await mapDraftRows(db, pageRows);
+  const finalRow = pageRows.at(-1);
+  return {
+    drafts,
+    nextCursor:
+      rows.length > limit && finalRow
+        ? encodeKeysetCursor(draftCursorVersion, {
+            activityAt: finalRow.updated_at,
+            id: finalRow.id
+          })
+        : null
+  };
+}
+
+export async function getDraftsByIds(
+  db: D1Database,
+  userId: string,
+  ids: string[]
+): Promise<Draft[]> {
+  if (ids.length === 0) return [];
+  const rows = await getRows<DraftRow>(
+    db,
+    sql`SELECT * FROM drafts
+        WHERE user_id = ${userId}
+          AND id IN (${sql.join(
+            ids.map((id) => sql`${id}`),
+            sql`, `
+          )})`
+  );
+  return mapDraftRows(db, rows);
+}
+
+async function mapDraftRows(db: D1Database, rows: DraftRow[]): Promise<Draft[]> {
+  const attachmentRows = await attachmentsForDrafts(
+    db,
+    rows.map((row) => row.id)
+  );
+  const attachmentsByDraft = new Map<string, DraftAttachment[]>();
+  for (const row of attachmentRows) {
+    const values = attachmentsByDraft.get(row.draft_id) ?? [];
+    values.push(mapAttachment(row));
+    attachmentsByDraft.set(row.draft_id, values);
+  }
+  return rows.map((row) => mapDraftRow(row, attachmentsByDraft.get(row.id) ?? []));
+}

--- a/worker/features/drafts/list-queries.ts
+++ b/worker/features/drafts/list-queries.ts
@@ -63,15 +63,21 @@ export async function getDraftsByIds(
   ids: string[]
 ): Promise<Draft[]> {
   if (ids.length === 0) return [];
-  const rows = await getRows<DraftRow>(
-    db,
-    sql`SELECT * FROM drafts
-        WHERE user_id = ${userId}
-          AND id IN (${sql.join(
-            ids.map((id) => sql`${id}`),
-            sql`, `
-          )})`
-  );
+  const rows: DraftRow[] = [];
+  for (let index = 0; index < ids.length; index += 99) {
+    const batch = ids.slice(index, index + 99);
+    rows.push(
+      ...(await getRows<DraftRow>(
+        db,
+        sql`SELECT * FROM drafts
+            WHERE user_id = ${userId}
+              AND id IN (${sql.join(
+                batch.map((id) => sql`${id}`),
+                sql`, `
+              )})`
+      ))
+    );
+  }
   return mapDraftRows(db, rows);
 }
 

--- a/worker/features/drafts/queries.ts
+++ b/worker/features/drafts/queries.ts
@@ -6,7 +6,7 @@ import { draftAttachments, drafts } from "../../db/schema";
 import { AppError } from "../../lib/errors";
 import type { Draft, DraftAttachment } from "./types";
 
-type DraftRow = {
+export type DraftRow = {
   id: string;
   mailbox_id: string | null;
   reply_to_message_id: string | null;
@@ -21,13 +21,14 @@ type DraftRow = {
   version: number;
   updated_at: string;
 };
-type AttachmentRow = {
+export type AttachmentRow = {
   id: string;
   filename: string;
   content_type: string;
   size_bytes: number;
   r2_key: string;
 };
+export type PageAttachmentRow = AttachmentRow & { draft_id: string };
 const parse = (value: string): string[] => {
   try {
     const result: unknown = JSON.parse(value);
@@ -38,7 +39,7 @@ const parse = (value: string): string[] => {
     return [];
   }
 };
-const mapAttachment = (row: AttachmentRow): DraftAttachment => ({
+export const mapAttachment = (row: AttachmentRow): DraftAttachment => ({
   id: row.id,
   filename: row.filename,
   contentType: row.content_type,
@@ -55,6 +56,9 @@ async function attachments(db: D1Database, draftId: string) {
   );
 }
 async function mapDraft(db: D1Database, row: DraftRow): Promise<Draft> {
+  return mapDraftRow(row, (await attachments(db, row.id)).map(mapAttachment));
+}
+export function mapDraftRow(row: DraftRow, draftAttachments: DraftAttachment[]): Draft {
   return {
     id: row.id,
     mailboxId: row.mailbox_id,
@@ -69,15 +73,8 @@ async function mapDraft(db: D1Database, row: DraftRow): Promise<Draft> {
     html: row.html_body,
     version: row.version,
     updatedAt: row.updated_at,
-    attachments: (await attachments(db, row.id)).map(mapAttachment)
+    attachments: draftAttachments
   };
-}
-export async function listDrafts(db: D1Database, userId: string): Promise<Draft[]> {
-  const rows = await getRows<DraftRow>(
-    db,
-    sql`SELECT * FROM drafts WHERE user_id = ${userId} ORDER BY updated_at DESC`
-  );
-  return Promise.all(rows.map((row) => mapDraft(db, row)));
 }
 export async function getDraft(db: D1Database, userId: string, id: string): Promise<Draft | null> {
   const row = await getRow<DraftRow>(
@@ -85,6 +82,23 @@ export async function getDraft(db: D1Database, userId: string, id: string): Prom
     sql`SELECT * FROM drafts WHERE id = ${id} AND user_id = ${userId}`
   );
   return row ? mapDraft(db, row) : null;
+}
+
+export async function attachmentsForDrafts(
+  db: D1Database,
+  draftIds: string[]
+): Promise<PageAttachmentRow[]> {
+  if (draftIds.length === 0) return [];
+  return getRows<PageAttachmentRow>(
+    db,
+    sql`SELECT draft_id, id, filename, content_type, size_bytes, r2_key
+        FROM draft_attachments
+        WHERE draft_id IN (${sql.join(
+          draftIds.map((id) => sql`${id}`),
+          sql`, `
+        )})
+        ORDER BY draft_id, created_at`
+  );
 }
 export async function saveDraft(
   db: D1Database,

--- a/worker/features/drafts/routes.ts
+++ b/worker/features/drafts/routes.ts
@@ -4,14 +4,42 @@ import type { HonoApp } from "../../lib/env";
 import { AppError } from "../../lib/errors";
 import { readJson } from "../../lib/json";
 import { parseWith } from "../../lib/validation";
-import { getAccessibleDraft, listAccessibleDrafts, requireDraftAccess } from "./access";
+import { getAccessibleDraft, listAccessibleDraftPage, requireDraftAccess } from "./access";
+import { defaultDraftChangeLimit, listDraftChanges, maxDraftChangeLimit } from "./change-queries";
+import { defaultDraftLimit, maxDraftLimit } from "./list-queries";
 import { addDraftAttachment, deleteDraft, removeDraftAttachment, saveDraft } from "./queries";
 import { draftSchema } from "./validation";
 
 export const draftRoutes = new Hono<HonoApp>();
 draftRoutes.get("/", async (c) => {
   const auth = await requireMailApiContext(c.env, c.req.raw, "mail:send");
-  return c.json(await listAccessibleDrafts(c.env, principal(auth)));
+  const page = await listAccessibleDraftPage(c.env, principal(auth), {
+    cursor: c.req.query("cursor"),
+    limit: parseDraftLimit(c.req.query("limit"), defaultDraftLimit, maxDraftLimit)
+  });
+  const response = c.json(page.drafts);
+  if (page.nextCursor) {
+    response.headers.set("link", `<${nextDraftPageUrl(c.req.url, page.nextCursor)}>; rel="next"`);
+  }
+  return response;
+});
+draftRoutes.get("/changes", async (c) => {
+  const auth = await requireMailApiContext(c.env, c.req.raw, "mail:send");
+  for (const name of ["mailboxId", "folder", "search", "updatedSince"]) {
+    if (c.req.query(name) !== undefined) {
+      throw new AppError(
+        "INVALID_DRAFT_CHANGE_FILTER",
+        "The draft changes feed does not accept mailbox, folder, search, or timestamp filters.",
+        400
+      );
+    }
+  }
+  return c.json(
+    await listDraftChanges(c.env, principal(auth), {
+      cursor: c.req.query("cursor"),
+      limit: parseDraftLimit(c.req.query("limit"), defaultDraftChangeLimit, maxDraftChangeLimit)
+    })
+  );
 });
 draftRoutes.get("/:id", async (c) => {
   const auth = await requireMailApiContext(c.env, c.req.raw, "mail:send");
@@ -67,4 +95,27 @@ draftRoutes.delete("/:draftId/attachments/:id", async (c) => {
 
 function principal(auth: Awaited<ReturnType<typeof requireMailApiContext>>) {
   return { role: auth.user.role, userId: auth.user.id };
+}
+
+function parseDraftLimit(
+  value: string | undefined,
+  defaultLimit: number,
+  maximumLimit: number
+): number {
+  if (value === undefined) return defaultLimit;
+  const limit = Number(value);
+  if (!/^\d+$/u.test(value) || !Number.isInteger(limit) || limit < 1 || limit > maximumLimit) {
+    throw new AppError("INVALID_LIMIT", `Limit must be an integer from 1 to ${maximumLimit}.`, 400);
+  }
+  return limit;
+}
+
+function nextDraftPageUrl(requestUrl: string, cursor: string): string {
+  const url = new URL(requestUrl);
+  const preserved = new URLSearchParams();
+  const limit = url.searchParams.get("limit");
+  if (limit !== null) preserved.set("limit", limit);
+  preserved.set("cursor", cursor);
+  url.search = preserved.toString();
+  return url.toString();
 }

--- a/worker/features/mail-api/discovery.ts
+++ b/worker/features/mail-api/discovery.ts
@@ -133,17 +133,19 @@ The method index is an orientation aid. Consult ${openApiUrl} for exact paramete
 ## Operating rules
 
 - Use \`Content-Type: application/json\` for JSON requests and \`multipart/form-data\` for draft attachment uploads.
-- Treat message, conversation, and change cursors as opaque strings and return them unchanged. Do not construct or edit a cursor.
-- \`GET ${apiBase}/messages\` returns one page. Follow the \`Link: <url>; rel="next"\` response header for the next page. No \`Link\` header means the last page.
+- Treat message, conversation, draft-list, and change cursors as opaque strings and return them unchanged. Do not construct or edit a cursor.
+- \`GET ${apiBase}/messages\` and \`GET ${apiBase}/drafts\` return one page. Follow the \`Link: <url>; rel="next"\` response header for the next page. No \`Link\` header means the last page.
 - To start message synchronization, get a checkpoint from \`GET ${apiBase}/changes\` without a cursor, paginate the full message list, then read changes after the checkpoint until \`hasMore\` is false.
+- To start draft synchronization, get a checkpoint from \`GET ${apiBase}/drafts/changes\` without a cursor, paginate the full draft list, then read draft changes after the checkpoint until \`hasMore\` is false.
 - List mailboxes before each change cycle. Remove cached mail for mailboxes that are no longer readable, and bootstrap each newly readable mailbox.
+- Repeat a full draft bootstrap when mailbox access changes so newly hidden or visible drafts are reconciled.
 - Ignore response fields you do not recognize.
 - Do not log access tokens, refresh tokens, message bodies, or attachments.
 - Do not log device codes or user codes, and do not paste them into unrelated chats or tools.
 - Do not send, reply, or forward unless that external action matches the person's request.
 - Sending, replying, and forwarding are not idempotent. Never retry them blindly.
 - Use the returned draft version when updating a draft so newer work is not overwritten.
-- A \`410 CHANGE_CURSOR_EXPIRED\` response requires a new full message bootstrap.
+- A \`410 CHANGE_CURSOR_EXPIRED\` response requires a new full message bootstrap. A \`410 DRAFT_CHANGE_CURSOR_EXPIRED\` response requires a new full draft bootstrap.
 
 ## Errors
 


### PR DESCRIPTION
## Summary

- paginate GET /api/v1/drafts with a stable opaque cursor and batched page reads
- add GET /api/v1/drafts/changes with user-bound checkpoints, attachment upserts, and durable deletion tombstones
- add migration, generated contracts, web pagination, staging coverage, and focused sync and access tests

## Validation

- CI=true pnpm check
- CI=true pnpm deploy:dry-run

## Documentation

- HQBase/hqbase-site#27

Fixes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination for draft listings with continuation links.
  * Added a paginated draft changes feed covering updates, attachment changes, and deletions.
  * Added validation for pagination limits, permissions, and invalid or expired cursors.
  * Draft synchronization now supports stable checkpoints and access-change handling.
  * Improved handling of pagination link headers.

* **Documentation**
  * Updated API and Postman documentation with draft pagination and synchronization details.

* **Tests**
  * Expanded coverage for pagination, synchronization, access changes, cursors, migrations, and API validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->