### PR TITLE
fix(windows): use native paths for tests and release tools

### DIFF
--- a/scripts/release/deploy.mjs
+++ b/scripts/release/deploy.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
 import { recordWorkerDeployedForConfig } from "../hqbase/manifest.mjs";
+import { windowsSystem32Executable } from "../windows-system32.mjs";
 import { inspectActiveRelease } from "./active-version.mjs";
 import { capture, run } from "./command.mjs";
 import {
@@ -58,7 +59,7 @@ export async function deploy(options = {}) {
     const source = resolve(workspace, "source");
     writeFileSync(archive, bytes);
     mkdirSync(source, { recursive: true });
-    run("tar", ["-xzf", archive, "-C", source], root);
+    run(archiveExtractor(), ["-xzf", archive, "-C", source], root);
     const config = normalizeConfig(
       JSON.parse(readFileSync(configFile, "utf8")),
       manifest.version,
@@ -188,6 +189,11 @@ export async function deploy(options = {}) {
   } finally {
     rmSync(workspace, { recursive: true, force: true });
   }
+}
+
+export function archiveExtractor(options = {}) {
+  const platform = options.platform ?? process.platform;
+  return platform === "win32" ? windowsSystem32Executable("tar.exe", options.environment) : "tar";
 }
 
 export function assertSourceDeployConfig(

--- a/scripts/secure-directory.mjs
+++ b/scripts/secure-directory.mjs
@@ -3,8 +3,11 @@ import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
 import { spawnProcess } from "./shell.mjs";
+import { windowsSystem32Executable } from "./windows-system32.mjs";
 
 const isWindows = process.platform === "win32";
+const WHOAMI = windowsSystem32Executable("whoami.exe");
+const ICACLS = windowsSystem32Executable("icacls.exe");
 
 // Windows keeps the machine's trusted principals on every directory, and a member of
 // Administrators can read any file regardless of its access control list by taking ownership or
@@ -33,7 +36,7 @@ function runOrThrow(command, args) {
 // autoloading is unavailable.
 export function currentUserSid() {
   if (cachedSid) return cachedSid;
-  const sid = /S-1-[\d-]+/.exec(runOrThrow("whoami", ["/user", "/fo", "csv", "/nh"]))?.[0];
+  const sid = /S-1-[\d-]+/.exec(runOrThrow(WHOAMI, ["/user", "/fo", "csv", "/nh"]))?.[0];
   if (!sid) throw new Error("Could not determine the SID of the current Windows account.");
   cachedSid = sid;
   return sid;
@@ -45,7 +48,7 @@ export function currentUserSid() {
 export function directorySecurityDescriptor(directory) {
   const aclFile = `${directory}.acl`;
   try {
-    runOrThrow("icacls", [directory, "/save", aclFile, "/q"]);
+    runOrThrow(ICACLS, [directory, "/save", aclFile, "/q"]);
     return readFileSync(aclFile, "utf16le").split(/\r?\n/)[1] ?? "";
   } finally {
     rmSync(aclFile, { force: true });
@@ -79,7 +82,7 @@ function restrictDirectory(directory) {
     chmodSync(directory, 0o700);
     return;
   }
-  runOrThrow("icacls", [directory, "/inheritance:r", "/grant:r", `*${currentUserSid()}:(OI)(CI)F`]);
+  runOrThrow(ICACLS, [directory, "/inheritance:r", "/grant:r", `*${currentUserSid()}:(OI)(CI)F`]);
 }
 
 // Returns null when the directory is restricted, otherwise a description of what was observed.

--- a/scripts/windows-system32.mjs
+++ b/scripts/windows-system32.mjs
@@ -1,0 +1,6 @@
+import { win32 } from "node:path";
+
+export function windowsSystem32Executable(executable, environment = process.env) {
+  const systemRoot = environment.SystemRoot || "C:\\Windows";
+  return win32.resolve(systemRoot, "System32", executable);
+}

--- a/test/unit/scripts/windows-system32.test.mjs
+++ b/test/unit/scripts/windows-system32.test.mjs
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { archiveExtractor } from "../../../scripts/release/deploy.mjs";
+import { windowsSystem32Executable } from "../../../scripts/windows-system32.mjs";
+
+describe("Windows system executables", () => {
+  it("resolves commands from System32 without using PATH", () => {
+    expect(windowsSystem32Executable("whoami.exe", { SystemRoot: "D:\\Windows" })).toBe(
+      "D:\\Windows\\System32\\whoami.exe"
+    );
+    expect(windowsSystem32Executable("icacls.exe", {})).toBe("C:\\Windows\\System32\\icacls.exe");
+  });
+
+  it("uses the Windows archive extractor only on Windows", () => {
+    expect(
+      archiveExtractor({ platform: "win32", environment: { SystemRoot: "D:\\Windows" } })
+    ).toBe("D:\\Windows\\System32\\tar.exe");
+    expect(archiveExtractor({ platform: "linux" })).toBe("tar");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -6,8 +7,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@": new URL("./app", import.meta.url).pathname,
-      "@worker": new URL("./worker", import.meta.url).pathname
+      "@": fileURLToPath(new URL("./app", import.meta.url)),
+      "@worker": fileURLToPath(new URL("./worker", import.meta.url))
     }
   },
   test: {


### PR DESCRIPTION
## Summary

- convert Vitest alias URLs with `fileURLToPath()` so drive letters and encoded checkout characters become native paths
- resolve `whoami.exe`, `icacls.exe`, and `tar.exe` from Windows `System32` instead of the user-controlled `PATH`
- keep the existing non-Windows `tar` behavior and add portable command-selection tests

Fixes #50.

## Verification

- `CI=true pnpm check`
- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-issue-50-wrangler.log pnpm deploy:dry-run`
- focused release and secure-directory tests: 22 passed, 2 Windows-only tests skipped on macOS

## Verification note

Current `main` does not reproduce the report's broad Vitest failure on GitHub's Windows runner: its latest run passed all 96 unit-test files. The alias still uses a URL pathname as a filesystem path, which leaves percent encoding in checkout paths such as a directory with spaces. The native conversion is valid even though the failure is narrower than reported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release deployment compatibility across Windows and non-Windows platforms.
  * Enhanced secure directory operations on Windows by reliably locating required system utilities.

* **Tests**
  * Added coverage for platform-specific archive extraction and Windows System32 executable resolution.

* **Chores**
  * Improved test environment path handling for more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->