### PR TITLE
fix(release): provision secrets on every deploy path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,6 @@ jobs:
           HQBASE_EXPECTED_RELEASE_VERSION="$previous_version" \
           HQBASE_RELEASE_ARTIFACT_FILE="$previous_archive" \
           HQBASE_RELEASE_MANIFEST_FILE="/tmp/hqbase-previous/stable.json" \
-          WORKERS_CI=1 \
             node scripts/release/deploy.mjs --config "$config"
       - name: Wait for the previous stable release
         if: needs.candidate.outputs.previous_tag != ''
@@ -234,7 +233,6 @@ jobs:
           HQBASE_EXPECTED_RELEASE_VERSION="$CANDIDATE_VERSION" \
           HQBASE_RELEASE_ARTIFACT_FILE="release/hqbase-${CANDIDATE_VERSION}.tar.gz" \
           HQBASE_RELEASE_MANIFEST_FILE="release/stable.json" \
-          WORKERS_CI=1 \
             node scripts/release/deploy.mjs --config "$config"
       - name: Wait for the signed candidate
         run: |

--- a/scripts/hqbase/install.mjs
+++ b/scripts/hqbase/install.mjs
@@ -82,7 +82,6 @@ export function install(flags, options = {}) {
       dryRun,
       env: {
         CLOUDFLARE_ACCOUNT_ID: manifest.accountId,
-        WORKERS_CI: "1",
         ...((optionalString(flags, "auth-secret") ?? process.env.HQBASE_AUTH_SECRET)
           ? {
               HQBASE_AUTH_SECRET:

--- a/scripts/release/worker-deploy.mjs
+++ b/scripts/release/worker-deploy.mjs
@@ -10,7 +10,6 @@ import { attemptRun, emitCommandOutput, run } from "./command.mjs";
 export function deploySource(cwd, options = {}) {
   const execute = options.run ?? run;
   const attempt = options.attempt ?? attemptRun;
-  const workersCi = options.workersCi ?? process.env.WORKERS_CI === "1";
   const workerName = options.workerName ?? workerNameFromConfigFile(resolve(cwd, "wrangler.jsonc"));
   const deployArgs = [
     "exec",
@@ -21,11 +20,6 @@ export function deploySource(cwd, options = {}) {
     `HQBASE_WORKER_NAME:${workerName}`
   ];
   if (options.releaseTag) deployArgs.push("--tag", options.releaseTag);
-
-  if (!workersCi) {
-    execute("pnpm", deployArgs, cwd);
-    return;
-  }
 
   const inspection = attempt(
     "pnpm",

--- a/test/unit/scripts/deploy.test.mjs
+++ b/test/unit/scripts/deploy.test.mjs
@@ -267,10 +267,9 @@ describe("HQBase release deployment", () => {
       /HQBASE_FORCE_SOURCE_DEPLOY supports only the repository-root wrangler\.jsonc/
     );
   });
-  it("generates masked auth and Web Push secrets when the first Workers Build needs them", () => {
+  it("generates masked auth and Web Push secrets for a first deployment outside CI", () => {
     let secretFile;
     deploySource("/customer/repo", {
-      workersCi: true,
       workerName: "hqbase-deeptake-test",
       attempt: () => ({
         status: 0,
@@ -313,7 +312,6 @@ describe("HQBase release deployment", () => {
   it("preserves existing secrets and detects only missing installation secrets", () => {
     let deployCalls = 0;
     deploySource("/customer/repo", {
-      workersCi: true,
       workerName: "hqbase-deeptake-test",
       attempt: () => ({
         status: 0,
@@ -359,7 +357,6 @@ describe("HQBase release deployment", () => {
   });
   it("adds a VAPID pair to an existing installation without rotating its auth identity", () => {
     deploySource("/customer/repo", {
-      workersCi: true,
       workerName: "hqbase-existing",
       attempt: () => ({
         status: 0,


### PR DESCRIPTION
## Summary

- inspect required Worker secrets on every source deploy, not only when `WORKERS_CI=1`
- reuse the existing restricted temporary secrets-file flow when a new Worker has no secrets yet
- preserve configured secrets and generate only missing auth or Web Push values
- remove the obsolete `WORKERS_CI` switches from install and release automation

This addresses the independent first-deploy defect reported in the lower-priority section of #50.

## Verification

- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-first-deploy-wrangler.log pnpm check`
- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-first-deploy-dry-run.log pnpm deploy:dry-run`
- focused deploy and install tests: 27 passed

The focused first-deploy test now exercises the default non-CI path. It verifies that the deploy uses `--secrets-file`, that generated values are masked from process arguments, and that the temporary file is removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment processes now consistently verify required authentication and Web Push secrets before release.
  * Missing secrets are automatically generated or supplied when needed, including during initial deployments.
  * Staging and signed candidate deployments now follow the same secret-handling behavior as other releases.

* **Tests**
  * Added coverage for first-time deployments and secret generation.
  * Updated deployment scenarios to reflect the unified release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->