### PR TITLE
fix: bind signed updates to managed Workers Builds releases

### DIFF
--- a/app/features/updates/api.ts
+++ b/app/features/updates/api.ts
@@ -5,6 +5,6 @@ export function getUpdateStatus(): Promise<UpdateStatus> {
   return apiGet<UpdateStatus>("/api/updates");
 }
 
-export function applyUpdate(): Promise<{ buildId: string; status: string }> {
-  return apiPost("/api/updates/apply", {});
+export function applyUpdate(expectedVersion: string): Promise<{ buildId: string; status: string }> {
+  return apiPost("/api/updates/apply", { expectedVersion });
 }

--- a/app/features/updates/update-settings.tsx
+++ b/app/features/updates/update-settings.tsx
@@ -9,6 +9,8 @@ import { applyUpdate, getUpdateStatus } from "./api";
 import type { UpdateStatus } from "./types";
 import type { UpdateProgress } from "./update-progress";
 
+const reviewedVersionKey = "hqb_update_expected_version";
+
 export function UpdateSettings({
   initialStatus,
   progress,
@@ -48,13 +50,20 @@ export function UpdateSettings({
     url.searchParams.delete("settings");
     window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
 
+    const expectedVersion = window.sessionStorage.getItem(reviewedVersionKey);
+    window.sessionStorage.removeItem(reviewedVersionKey);
+
     if (oauthResult !== "connected") {
       setApplyError(oauthErrorMessage(oauthResult));
       return;
     }
+    if (!expectedVersion) {
+      setApplyError("The reviewed release is no longer available. Check for updates again.");
+      return;
+    }
 
     setPendingAction("apply");
-    void applyUpdate()
+    void applyUpdate(expectedVersion)
       .then((result) => onUpdateStarted(result.buildId))
       .catch((nextError: unknown) => {
         setApplyError(nextError instanceof Error ? nextError.message : "Update could not start.");
@@ -194,6 +203,11 @@ export function UpdateSettings({
         authorizeHref="/api/updates/cloudflare/oauth/start"
         description="To install this update, HQBase needs temporary access to your Cloudflare account. You’ll return to Updates automatically, and HQBase will start the update."
         open={authorizationOpen}
+        onAuthorize={() => {
+          if (status?.release.version) {
+            window.sessionStorage.setItem(reviewedVersionKey, status.release.version);
+          }
+        }}
         onOpenChange={setAuthorizationOpen}
       />
     </SettingsSection>

--- a/test/integration/worker/update-build-lock.test.ts
+++ b/test/integration/worker/update-build-lock.test.ts
@@ -1,0 +1,96 @@
+import { env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { withUpdateBuildLock } from "../../../worker/features/updates/build-lock";
+import { applyCurrentMigrations } from "./current-migrations";
+
+describe("update build lock", () => {
+  beforeAll(async () => {
+    await applyCurrentMigrations();
+  });
+
+  beforeEach(async () => {
+    await env.DB.prepare("DELETE FROM app_settings WHERE key LIKE 'update_build_lock:%'").run();
+  });
+
+  it("allows only one update to prepare a production trigger at a time", async () => {
+    let finishFirst: (() => void) | undefined;
+    let firstStarted: (() => void) | undefined;
+    const firstReady = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    const firstCanFinish = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const first = withUpdateBuildLock(env.DB, "production-trigger", async () => {
+      firstStarted?.();
+      await firstCanFinish;
+      return "first";
+    });
+    await firstReady;
+
+    await expect(
+      withUpdateBuildLock(env.DB, "production-trigger", async () => "second")
+    ).rejects.toMatchObject({ code: "UPDATE_IN_PROGRESS", status: 409 });
+
+    finishFirst?.();
+    await expect(first).resolves.toBe("first");
+    await expect(
+      withUpdateBuildLock(env.DB, "production-trigger", async () => "next")
+    ).resolves.toBe("next");
+  });
+
+  it("does not let an old owner release a replacement lease", async () => {
+    let oldStarted: (() => void) | undefined;
+    let releaseOld: (() => void) | undefined;
+    let replacementStarted: (() => void) | undefined;
+    let releaseReplacement: (() => void) | undefined;
+    const oldReady = new Promise<void>((resolve) => {
+      oldStarted = resolve;
+    });
+    const oldCanFinish = new Promise<void>((resolve) => {
+      releaseOld = resolve;
+    });
+    const replacementReady = new Promise<void>((resolve) => {
+      replacementStarted = resolve;
+    });
+    const replacementCanFinish = new Promise<void>((resolve) => {
+      releaseReplacement = resolve;
+    });
+    const old = withUpdateBuildLock(
+      env.DB,
+      "production-trigger",
+      async () => {
+        oldStarted?.();
+        await oldCanFinish;
+      },
+      new Date("2026-08-22T12:00:00.000Z")
+    );
+    await oldReady;
+
+    const replacement = withUpdateBuildLock(
+      env.DB,
+      "production-trigger",
+      async () => {
+        replacementStarted?.();
+        await replacementCanFinish;
+      },
+      new Date("2026-08-22T12:05:00.000Z")
+    );
+    await replacementReady;
+
+    releaseOld?.();
+    await expect(old).resolves.toBeUndefined();
+    await expect(
+      withUpdateBuildLock(
+        env.DB,
+        "production-trigger",
+        async () => "third",
+        new Date("2026-08-22T12:06:00.000Z")
+      )
+    ).rejects.toMatchObject({ code: "UPDATE_IN_PROGRESS", status: 409 });
+
+    releaseReplacement?.();
+    await expect(replacement).resolves.toBeUndefined();
+  });
+});

--- a/test/unit/worker/features/updates/routes.test.ts
+++ b/test/unit/worker/features/updates/routes.test.ts
@@ -1,0 +1,96 @@
+import type { WorkerEnv } from "@worker/lib/env";
+import { AppError } from "@worker/lib/errors";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  operationalLog: vi.fn(),
+  requireAuthContext: vi.fn(),
+  requireRecentSession: vi.fn(),
+  requireRole: vi.fn(),
+  resolveRuntimeCloudflareGrant: vi.fn(),
+  revokeRuntimeCloudflareGrant: vi.fn(),
+  triggerUpdate: vi.fn()
+}));
+
+vi.mock("@worker/auth/session", () => ({
+  isRecentSession: vi.fn(),
+  requireAuthContext: mocks.requireAuthContext,
+  requireRecentSession: mocks.requireRecentSession,
+  requireRole: mocks.requireRole
+}));
+vi.mock("@worker/features/cloudflare/oauth", () => ({
+  clearRuntimeCloudflareGrantCookie: () => "hqbase_cf_grant=; Max-Age=0; Path=/",
+  finishRuntimeCloudflareOAuth: vi.fn(),
+  recentAuthenticationRedirect: vi.fn(),
+  resolveRuntimeCloudflareGrant: mocks.resolveRuntimeCloudflareGrant,
+  revokeRuntimeCloudflareGrant: mocks.revokeRuntimeCloudflareGrant,
+  startRuntimeCloudflareOAuth: vi.fn()
+}));
+vi.mock("@worker/features/updates/service", () => ({
+  getUpdateStatus: vi.fn(),
+  triggerUpdate: mocks.triggerUpdate
+}));
+vi.mock("@worker/observability/log", () => ({ operationalLog: mocks.operationalLog }));
+
+import { updateRoutes } from "@worker/features/updates/routes";
+
+describe("update routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAuthContext.mockResolvedValue({
+      session: { createdAt: new Date(), id: "session-1", userId: "user-1" },
+      user: { email: "owner@example.com", id: "user-1", name: "Owner", role: "owner" }
+    });
+    mocks.resolveRuntimeCloudflareGrant.mockResolvedValue("temporary-grant");
+    mocks.revokeRuntimeCloudflareGrant.mockResolvedValue(undefined);
+    mocks.triggerUpdate.mockResolvedValue({ buildId: "build-1", status: "queued" });
+  });
+
+  it("returns the build result and clears the cookie when grant revocation fails", async () => {
+    mocks.revokeRuntimeCloudflareGrant.mockRejectedValue(
+      new AppError("CLOUDFLARE_OAUTH_REVOKE_FAILED", "Grant revocation failed.", 502)
+    );
+
+    const response = await applyUpdate();
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ buildId: "build-1", status: "queued" });
+    expect(response.headers.get("set-cookie")).toContain("hqbase_cf_grant=");
+    expect(mocks.operationalLog).toHaveBeenCalledWith(
+      "warn",
+      "cloudflare_grant_revocation_failed",
+      { errorCode: "CLOUDFLARE_OAUTH_REVOKE_FAILED" }
+    );
+  });
+
+  it("preserves the build error and clears the cookie when cleanup also fails", async () => {
+    mocks.triggerUpdate.mockRejectedValue(
+      new AppError("UPDATE_TRIGGER_NOT_FOUND", "Production trigger not found.", 409)
+    );
+    mocks.revokeRuntimeCloudflareGrant.mockRejectedValue(
+      new AppError("CLOUDFLARE_OAUTH_REVOKE_FAILED", "Grant revocation failed.", 502)
+    );
+
+    const response = await applyUpdate();
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "UPDATE_TRIGGER_NOT_FOUND", message: "Production trigger not found." }
+    });
+    expect(response.headers.get("set-cookie")).toContain("hqbase_cf_grant=");
+  });
+});
+
+function applyUpdate(): Promise<Response> {
+  return Promise.resolve(
+    updateRoutes.request(
+      "/apply",
+      {
+        body: JSON.stringify({ expectedVersion: "1.2.0" }),
+        headers: { "content-type": "application/json" },
+        method: "POST"
+      },
+      {} as WorkerEnv
+    )
+  );
+}

--- a/test/unit/worker/features/updates/service.test.ts
+++ b/test/unit/worker/features/updates/service.test.ts
@@ -114,6 +114,48 @@ describe("HQBase updates", () => {
     }
     await expect(first).resolves.toEqual({ buildId: "build-id", status: "queued" });
   });
+  it("times out Cloudflare work before the update-build lease can expire", async () => {
+    const originalTimeout = AbortSignal.timeout;
+    const controller = new AbortController();
+    const timeout = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockImplementation((delay) =>
+        delay === 30_000 ? controller.signal : originalTimeout(delay)
+      );
+    const baseFetcher = cloudflareUpdateFetcher();
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).endsWith("/environment_variables") && !init?.method) {
+        const signal = init?.signal;
+        expect(signal).toBe(controller.signal);
+        controller.abort(new DOMException("Timed out", "TimeoutError"));
+        throw signal?.reason;
+      }
+      return baseFetcher(input, init);
+    });
+    const environment = updateEnvironment();
+
+    try {
+      await expect(
+        triggerUpdate(
+          environment,
+          "temporary-token-that-is-long-enough",
+          "0.1.0",
+          fetcher as typeof fetch
+        )
+      ).rejects.toMatchObject({ code: "UPDATE_CLOUDFLARE_TIMEOUT", status: 504 });
+    } finally {
+      timeout.mockRestore();
+    }
+
+    await expect(
+      triggerUpdate(
+        environment,
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        cloudflareUpdateFetcher() as typeof fetch
+      )
+    ).resolves.toEqual({ buildId: "build-id", status: "queued" });
+  });
   it("rejects a custom-source production trigger", async () => {
     const fetcher = cloudflareUpdateFetcher({ deployCommand: "npx wrangler deploy" });
 

--- a/test/unit/worker/features/updates/service.test.ts
+++ b/test/unit/worker/features/updates/service.test.ts
@@ -124,6 +124,44 @@ describe("HQBase updates", () => {
       )
     ).toBe(false);
   });
+  it("rejects a secret release pin", async () => {
+    const fetcher = cloudflareUpdateFetcher({
+      variables: {
+        HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: true }
+      }
+    });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toThrow("plain build variable");
+    expect(
+      fetcher.mock.calls.some(
+        ([input, init]) => String(input).endsWith("/builds") && init?.method === "POST"
+      )
+    ).toBe(false);
+  });
+  it("rejects a trigger that does not include main", async () => {
+    const fetcher = cloudflareUpdateFetcher({ branchIncludes: ["production"] });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toThrow("Connect this Worker to Workers Builds");
+    expect(
+      fetcher.mock.calls.some(
+        ([input, init]) => String(input).endsWith("/builds") && init?.method === "POST"
+      )
+    ).toBe(false);
+  });
   it("requires the build to use the release reviewed by the user", async () => {
     await expect(
       triggerUpdate(
@@ -179,6 +217,24 @@ describe("HQBase updates", () => {
       )
     ).toBe(true);
   });
+  it("preserves the build error when release pin rollback fails", async () => {
+    const fetcher = cloudflareUpdateFetcher({
+      buildFails: true,
+      rollbackFails: true,
+      variables: {
+        HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.0.8" }
+      }
+    });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toThrow("Build could not start");
+  });
 });
 
 function updateEnvironment(): WorkerEnv {
@@ -196,12 +252,15 @@ function updateEnvironment(): WorkerEnv {
 
 function cloudflareUpdateFetcher(
   options: {
+    branchIncludes?: string[];
     buildFails?: boolean;
     deployCommand?: string;
+    rollbackFails?: boolean;
     rootDirectory?: string;
     variables?: Record<string, { is_secret: boolean; value?: string | null }>;
   } = {}
 ) {
+  let pinPatches = 0;
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     if (url.includes("github.com/HQBase/hqbase/releases")) return Response.json(envelope);
@@ -220,7 +279,7 @@ function cloudflareUpdateFetcher(
         result: [
           {
             id: "trigger",
-            branch_includes: ["main"],
+            branch_includes: options.branchIncludes ?? ["main"],
             deploy_command: options.deployCommand ?? "pnpm deploy",
             root_directory: options.rootDirectory ?? "/"
           }
@@ -228,6 +287,13 @@ function cloudflareUpdateFetcher(
       });
     }
     if (url.endsWith("/environment_variables")) {
+      if (init?.method === "PATCH") pinPatches += 1;
+      if (options.rollbackFails && pinPatches > 1) {
+        return Response.json(
+          { success: false, errors: [{ message: "Pin rollback failed." }] },
+          { status: 502 }
+        );
+      }
       return Response.json({
         success: true,
         result: init?.method === "PATCH" ? {} : (options.variables ?? {})

--- a/test/unit/worker/features/updates/service.test.ts
+++ b/test/unit/worker/features/updates/service.test.ts
@@ -116,17 +116,31 @@ describe("HQBase updates", () => {
   });
   it("times out Cloudflare work before the update-build lease can expire", async () => {
     const originalTimeout = AbortSignal.timeout;
-    const controller = new AbortController();
-    const timeout = vi
-      .spyOn(AbortSignal, "timeout")
-      .mockImplementation((delay) =>
-        delay === 30_000 ? controller.signal : originalTimeout(delay)
-      );
-    const baseFetcher = cloudflareUpdateFetcher();
+    const controllers: AbortController[] = [];
+    const timeout = vi.spyOn(AbortSignal, "timeout").mockImplementation((delay) => {
+      if (delay !== 30_000) return originalTimeout(delay);
+      const controller = new AbortController();
+      controllers.push(controller);
+      return controller.signal;
+    });
+    const baseFetcher = cloudflareUpdateFetcher({
+      variables: {
+        HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.0.8" }
+      }
+    });
+    let firstPinTimedOut = false;
     const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      if (String(input).endsWith("/environment_variables") && !init?.method) {
+      if (
+        String(input).endsWith("/environment_variables") &&
+        init?.method === "PATCH" &&
+        !firstPinTimedOut
+      ) {
+        firstPinTimedOut = true;
         const signal = init?.signal;
-        expect(signal).toBe(controller.signal);
+        const controller = controllers.find((candidate) => candidate.signal === signal);
+        expect(controller).toBeDefined();
+        if (!controller) throw new Error("Expected the request timeout signal.");
+        await baseFetcher(input, init);
         controller.abort(new DOMException("Timed out", "TimeoutError"));
         throw signal?.reason;
       }
@@ -143,6 +157,14 @@ describe("HQBase updates", () => {
           fetcher as typeof fetch
         )
       ).rejects.toMatchObject({ code: "UPDATE_CLOUDFLARE_TIMEOUT", status: 504 });
+      const pinRequests = baseFetcher.mock.calls.filter(
+        ([input, init]) =>
+          String(input).endsWith("/environment_variables") && init?.method === "PATCH"
+      );
+      expect(pinRequests.map(([, init]) => init?.body)).toEqual([
+        JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.1.0" } }),
+        JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.0.8" } })
+      ]);
     } finally {
       timeout.mockRestore();
     }

--- a/test/unit/worker/features/updates/service.test.ts
+++ b/test/unit/worker/features/updates/service.test.ts
@@ -69,6 +69,51 @@ describe("HQBase updates", () => {
     ]);
     expect(fetcher.mock.calls.some(([, init]) => init?.method === "DELETE")).toBe(false);
   });
+  it("rejects an overlapping update before it can replace the shared release pin", async () => {
+    let firstPinStarted: (() => void) | undefined;
+    let releaseFirstPin: (() => void) | undefined;
+    const firstPinReady = new Promise<void>((resolve) => {
+      firstPinStarted = resolve;
+    });
+    const firstPinCanFinish = new Promise<void>((resolve) => {
+      releaseFirstPin = resolve;
+    });
+    const environment = updateEnvironment();
+    const firstFetcher = cloudflareUpdateFetcher({
+      beforeFirstPin: async () => {
+        firstPinStarted?.();
+        await firstPinCanFinish;
+      }
+    });
+    const first = triggerUpdate(
+      environment,
+      "temporary-token-that-is-long-enough",
+      "0.1.0",
+      firstFetcher as typeof fetch
+    );
+    await firstPinReady;
+    const secondFetcher = cloudflareUpdateFetcher();
+
+    try {
+      await expect(
+        triggerUpdate(
+          environment,
+          "temporary-token-that-is-long-enough",
+          "0.1.0",
+          secondFetcher as typeof fetch
+        )
+      ).rejects.toMatchObject({ code: "UPDATE_IN_PROGRESS", status: 409 });
+      expect(
+        secondFetcher.mock.calls.some(
+          ([input, init]) =>
+            String(input).endsWith("/environment_variables") && init?.method === "PATCH"
+        )
+      ).toBe(false);
+    } finally {
+      releaseFirstPin?.();
+    }
+    await expect(first).resolves.toEqual({ buildId: "build-id", status: "queued" });
+  });
   it("rejects a custom-source production trigger", async () => {
     const fetcher = cloudflareUpdateFetcher({ deployCommand: "npx wrangler deploy" });
 
@@ -239,8 +284,25 @@ describe("HQBase updates", () => {
 
 function updateEnvironment(): WorkerEnv {
   const raw = vi.fn().mockResolvedValue([[JSON.stringify("mail.example.com")]]);
+  let lockValue: string | null = null;
   const db = {
-    prepare: vi.fn(() => ({ bind: vi.fn(() => ({ raw })) }))
+    prepare: vi.fn((query: string) => ({
+      bind: vi.fn((...values: unknown[]) => ({
+        first: vi.fn(async () => {
+          if (!query.includes("INSERT INTO app_settings")) return null;
+          if (lockValue) return null;
+          lockValue = String(values[1]);
+          return { value_json: lockValue };
+        }),
+        raw,
+        run: vi.fn(async () => {
+          if (query.startsWith("DELETE FROM app_settings") && values[1] === lockValue) {
+            lockValue = null;
+          }
+          return { success: true };
+        })
+      }))
+    }))
   } as unknown as D1Database;
   return {
     DB: db,
@@ -252,6 +314,7 @@ function updateEnvironment(): WorkerEnv {
 
 function cloudflareUpdateFetcher(
   options: {
+    beforeFirstPin?: () => Promise<void>;
     branchIncludes?: string[];
     buildFails?: boolean;
     deployCommand?: string;
@@ -288,6 +351,7 @@ function cloudflareUpdateFetcher(
     }
     if (url.endsWith("/environment_variables")) {
       if (init?.method === "PATCH") pinPatches += 1;
+      if (pinPatches === 1) await options.beforeFirstPin?.();
       if (options.rollbackFails && pinPatches > 1) {
         return Response.json(
           { success: false, errors: [{ message: "Pin rollback failed." }] },

--- a/test/unit/worker/features/updates/service.test.ts
+++ b/test/unit/worker/features/updates/service.test.ts
@@ -12,7 +12,7 @@ const payload = Buffer.from(
     channel: "stable",
     version: "0.1.0",
     schemaVersion: 2,
-    minVersion: "0.1.0",
+    minVersion: "0.0.1",
     publishedAt: "2026-07-12T00:00:00.000Z",
     notesUrl: "https://github.com/HQBase/hqbase/releases/tag/v0.1.0",
     artifact: {
@@ -51,29 +51,197 @@ describe("HQBase updates", () => {
     ).rejects.toThrow("signature");
   });
   it("triggers the production Workers Build", async () => {
-    const raw = vi.fn().mockResolvedValue([[JSON.stringify("mail.example.com")]]);
-    const db = {
-      prepare: vi.fn(() => ({ bind: vi.fn(() => ({ raw })) }))
-    } as unknown as D1Database;
-    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.includes("/zones?"))
-        return Response.json({
-          success: true,
-          result: [{ name: "example.com", account: { id: "account" } }]
-        });
-      if (url.endsWith("/workers/scripts"))
-        return Response.json({ success: true, result: [{ id: "hqbase", tag: "worker-tag" }] });
-      if (url.endsWith("/triggers"))
-        return Response.json({ success: true, result: [{ id: "trigger" }] });
-      return Response.json({ success: true, result: { build_uuid: "build-id", status: "queued" } });
-    });
+    const fetcher = cloudflareUpdateFetcher();
     await expect(
       triggerUpdate(
-        { DB: db, HQBASE_WORKER_NAME: "hqbase" } as WorkerEnv,
+        updateEnvironment(),
         "temporary-token-that-is-long-enough",
+        "0.1.0",
         fetcher as typeof fetch
       )
     ).resolves.toEqual({ buildId: "build-id", status: "queued" });
+    const pinRequests = fetcher.mock.calls.filter(
+      ([input, init]) =>
+        String(input).endsWith("/environment_variables") && init?.method === "PATCH"
+    );
+    expect(pinRequests.map(([, init]) => init?.body)).toEqual([
+      JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.1.0" } })
+    ]);
+    expect(fetcher.mock.calls.some(([, init]) => init?.method === "DELETE")).toBe(false);
+  });
+  it("rejects a custom-source production trigger", async () => {
+    const fetcher = cloudflareUpdateFetcher({ deployCommand: "npx wrangler deploy" });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toThrow("custom-source deployment process");
+    expect(
+      fetcher.mock.calls.some(
+        ([input, init]) => String(input).endsWith("/builds") && init?.method === "POST"
+      )
+    ).toBe(false);
+  });
+  it("rejects a production trigger outside the repository root", async () => {
+    const fetcher = cloudflareUpdateFetcher({ rootDirectory: "packages/hqbase" });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toThrow("repository-root Workers Builds trigger");
+    expect(
+      fetcher.mock.calls.some(
+        ([input, init]) => String(input).endsWith("/builds") && init?.method === "POST"
+      )
+    ).toBe(false);
+  });
+  it("rejects explicit source-deploy mode", async () => {
+    const fetcher = cloudflareUpdateFetcher({
+      variables: {
+        HQBASE_FORCE_SOURCE_DEPLOY: { is_secret: false, value: "1" }
+      }
+    });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toThrow("uses custom source");
+    expect(
+      fetcher.mock.calls.some(
+        ([input, init]) => String(input).endsWith("/builds") && init?.method === "POST"
+      )
+    ).toBe(false);
+  });
+  it("requires the build to use the release reviewed by the user", async () => {
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.2.0",
+        (async () => Response.json(envelope)) as typeof fetch
+      )
+    ).rejects.toThrow("changed after you reviewed it");
+  });
+  it("restores the previous release pin when the build does not start", async () => {
+    const fetcher = cloudflareUpdateFetcher({
+      buildFails: true,
+      variables: {
+        HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.0.8" }
+      }
+    });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toThrow("Build could not start");
+
+    const pinRequests = fetcher.mock.calls.filter(
+      ([input, init]) =>
+        String(input).endsWith("/environment_variables") && init?.method === "PATCH"
+    );
+    expect(pinRequests.map(([, init]) => init?.body)).toEqual([
+      JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.1.0" } }),
+      JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.0.8" } })
+    ]);
+  });
+  it("removes a new release pin when the build does not start", async () => {
+    const fetcher = cloudflareUpdateFetcher({ buildFails: true });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toThrow("Build could not start");
+    expect(
+      fetcher.mock.calls.some(
+        ([input, init]) =>
+          String(input).endsWith("/environment_variables/HQBASE_EXPECTED_RELEASE_VERSION") &&
+          init?.method === "DELETE"
+      )
+    ).toBe(true);
   });
 });
+
+function updateEnvironment(): WorkerEnv {
+  const raw = vi.fn().mockResolvedValue([[JSON.stringify("mail.example.com")]]);
+  const db = {
+    prepare: vi.fn(() => ({ bind: vi.fn(() => ({ raw })) }))
+  } as unknown as D1Database;
+  return {
+    DB: db,
+    HQBASE_APP_VERSION: "0.0.9",
+    HQBASE_RELEASE_PUBLIC_KEY: publicKeyBase64,
+    HQBASE_WORKER_NAME: "hqbase"
+  } as WorkerEnv;
+}
+
+function cloudflareUpdateFetcher(
+  options: {
+    buildFails?: boolean;
+    deployCommand?: string;
+    rootDirectory?: string;
+    variables?: Record<string, { is_secret: boolean; value?: string | null }>;
+  } = {}
+) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.includes("github.com/HQBase/hqbase/releases")) return Response.json(envelope);
+    if (url.includes("/zones?")) {
+      return Response.json({
+        success: true,
+        result: [{ name: "example.com", account: { id: "account" } }]
+      });
+    }
+    if (url.endsWith("/workers/scripts")) {
+      return Response.json({ success: true, result: [{ id: "hqbase", tag: "worker-tag" }] });
+    }
+    if (url.endsWith("/triggers")) {
+      return Response.json({
+        success: true,
+        result: [
+          {
+            id: "trigger",
+            branch_includes: ["main"],
+            deploy_command: options.deployCommand ?? "pnpm deploy",
+            root_directory: options.rootDirectory ?? "/"
+          }
+        ]
+      });
+    }
+    if (url.endsWith("/environment_variables")) {
+      return Response.json({
+        success: true,
+        result: init?.method === "PATCH" ? {} : (options.variables ?? {})
+      });
+    }
+    if (url.endsWith("/builds") && options.buildFails) {
+      return Response.json(
+        { success: false, errors: [{ message: "Build could not start." }] },
+        { status: 502 }
+      );
+    }
+    return Response.json({
+      success: true,
+      result: { build_uuid: "build-id", status: "queued" }
+    });
+  });
+}

--- a/worker/features/updates/build-lock.ts
+++ b/worker/features/updates/build-lock.ts
@@ -1,0 +1,63 @@
+import { AppError } from "../../lib/errors";
+
+const updateBuildLockTtlMs = 5 * 60 * 1000;
+
+type UpdateBuildLock = {
+  key: string;
+  value: string;
+};
+
+export async function withUpdateBuildLock<T>(
+  db: D1Database,
+  triggerId: string,
+  task: () => Promise<T>,
+  now = new Date()
+): Promise<T> {
+  const lock = await claimUpdateBuildLock(db, triggerId, now);
+  try {
+    return await task();
+  } finally {
+    await releaseUpdateBuildLock(db, lock).catch(() => undefined);
+  }
+}
+
+async function claimUpdateBuildLock(
+  db: D1Database,
+  triggerId: string,
+  now: Date
+): Promise<UpdateBuildLock> {
+  const lock = {
+    key: `update_build_lock:${triggerId}`,
+    value: JSON.stringify({ token: crypto.randomUUID() })
+  };
+  const timestamp = now.toISOString();
+  const staleBefore = new Date(now.getTime() - updateBuildLockTtlMs).toISOString();
+  const claimed = await db
+    .prepare(
+      `INSERT INTO app_settings (key, value_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(key) DO UPDATE SET
+         value_json = excluded.value_json,
+         created_at = excluded.created_at,
+         updated_at = excluded.updated_at
+       WHERE app_settings.updated_at <= ?
+       RETURNING value_json`
+    )
+    .bind(lock.key, lock.value, timestamp, timestamp, staleBefore)
+    .first<{ value_json: string }>();
+  if (claimed?.value_json !== lock.value) {
+    throw new AppError(
+      "UPDATE_IN_PROGRESS",
+      "Another update is already starting. Wait a moment and check for updates again.",
+      409
+    );
+  }
+  return lock;
+}
+
+async function releaseUpdateBuildLock(db: D1Database, lock: UpdateBuildLock): Promise<void> {
+  await db
+    .prepare("DELETE FROM app_settings WHERE key = ? AND value_json = ?")
+    .bind(lock.key, lock.value)
+    .run();
+}

--- a/worker/features/updates/cloudflare.ts
+++ b/worker/features/updates/cloudflare.ts
@@ -1,0 +1,35 @@
+import { AppError } from "../../lib/errors";
+
+const cloudflareRequestTimeoutMs = 30_000;
+
+export async function cloudflare<T>(
+  url: string,
+  init: RequestInit,
+  fetcher: typeof fetch
+): Promise<T> {
+  const signal = init.signal ?? AbortSignal.timeout(cloudflareRequestTimeoutMs);
+  let response: Response;
+  try {
+    response = await fetcher(url, { ...init, signal });
+  } catch (error) {
+    if (signal.aborted) {
+      throw new AppError(
+        "UPDATE_CLOUDFLARE_TIMEOUT",
+        "Cloudflare did not respond before the update request timed out.",
+        504
+      );
+    }
+    throw error;
+  }
+  const body = (await response.json()) as {
+    success?: boolean;
+    errors?: Array<{ message?: string }>;
+  };
+  if (!response.ok || body.success === false)
+    throw new AppError(
+      "UPDATE_CLOUDFLARE_ERROR",
+      body.errors?.[0]?.message ?? "Cloudflare rejected the update request.",
+      response.status === 401 || response.status === 403 ? 403 : 502
+    );
+  return body as T;
+}

--- a/worker/features/updates/routes.ts
+++ b/worker/features/updates/routes.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import {
   isRecentSession,
   requireAuthContext,
@@ -6,6 +7,8 @@ import {
   requireRole
 } from "../../auth/session";
 import type { HonoApp } from "../../lib/env";
+import { readJson } from "../../lib/json";
+import { parseWith } from "../../lib/validation";
 import {
   clearRuntimeCloudflareGrantCookie,
   finishRuntimeCloudflareOAuth,
@@ -22,6 +25,9 @@ const updateOAuthFlow = {
   operation: "updates",
   settingsTab: "updates"
 } as const;
+const applyUpdateSchema = z.object({
+  expectedVersion: z.string().regex(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)
+});
 updateRoutes.get("/", async (c) => {
   const auth = await requireAuthContext(c.env, c.req.raw);
   requireRole(auth, ["owner", "admin"]);
@@ -42,9 +48,17 @@ updateRoutes.post("/apply", async (c) => {
   const auth = await requireAuthContext(c.env, c.req.raw);
   requireRole(auth, ["owner", "admin"]);
   requireRecentSession(auth);
+  const input = parseWith(applyUpdateSchema, await readJson(c.req.raw));
   const grant = await resolveRuntimeCloudflareGrant(c.req.raw, c.env);
-  const result = await triggerUpdate(c.env, grant);
-  await revokeRuntimeCloudflareGrant(grant, c.env);
-  c.header("set-cookie", clearRuntimeCloudflareGrantCookie());
+  let result: Awaited<ReturnType<typeof triggerUpdate>>;
+  try {
+    result = await triggerUpdate(c.env, grant, input.expectedVersion);
+  } finally {
+    try {
+      await revokeRuntimeCloudflareGrant(grant, c.env);
+    } finally {
+      c.header("set-cookie", clearRuntimeCloudflareGrantCookie());
+    }
+  }
   return c.json(result, 202);
 });

--- a/worker/features/updates/routes.ts
+++ b/worker/features/updates/routes.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 import {
   isRecentSession,
@@ -7,8 +8,10 @@ import {
   requireRole
 } from "../../auth/session";
 import type { HonoApp } from "../../lib/env";
+import { errorBody, toAppError } from "../../lib/errors";
 import { readJson } from "../../lib/json";
 import { parseWith } from "../../lib/validation";
+import { operationalLog } from "../../observability/log";
 import {
   clearRuntimeCloudflareGrantCookie,
   finishRuntimeCloudflareOAuth,
@@ -50,15 +53,25 @@ updateRoutes.post("/apply", async (c) => {
   requireRecentSession(auth);
   const input = parseWith(applyUpdateSchema, await readJson(c.req.raw));
   const grant = await resolveRuntimeCloudflareGrant(c.req.raw, c.env);
-  let result: Awaited<ReturnType<typeof triggerUpdate>>;
+  const outcome = await triggerUpdate(c.env, grant, input.expectedVersion).then(
+    (result) => ({ ok: true, result }) as const,
+    (error: unknown) => ({ error, ok: false }) as const
+  );
   try {
-    result = await triggerUpdate(c.env, grant, input.expectedVersion);
+    await revokeRuntimeCloudflareGrant(grant, c.env);
+  } catch (error) {
+    operationalLog("warn", "cloudflare_grant_revocation_failed", {
+      errorCode: toAppError(error).code
+    });
   } finally {
-    try {
-      await revokeRuntimeCloudflareGrant(grant, c.env);
-    } finally {
-      c.header("set-cookie", clearRuntimeCloudflareGrantCookie());
-    }
+    c.header("set-cookie", clearRuntimeCloudflareGrantCookie());
   }
-  return c.json(result, 202);
+  if (!outcome.ok) {
+    const appError = toAppError(outcome.error);
+    return c.json(
+      errorBody(appError.code, appError.message),
+      appError.status as ContentfulStatusCode
+    );
+  }
+  return c.json(outcome.result, 202);
 });

--- a/worker/features/updates/service.ts
+++ b/worker/features/updates/service.ts
@@ -4,6 +4,7 @@ import type { WorkerEnv } from "../../lib/env";
 import { AppError } from "../../lib/errors";
 import { hqbaseProductConfig } from "../../lib/product-config";
 import { withUpdateBuildLock } from "./build-lock";
+import { cloudflare } from "./cloudflare";
 import type { ReleaseManifest, UpdateStatus } from "./types";
 
 const expectedReleaseVariable = "HQBASE_EXPECTED_RELEASE_VERSION";
@@ -258,20 +259,6 @@ async function verifyEnvelope(
     decodeBase64UrlBytes(envelope.signature),
     decodeBase64UrlBytes(envelope.payload)
   );
-}
-async function cloudflare<T>(url: string, init: RequestInit, fetcher: typeof fetch): Promise<T> {
-  const response = await fetcher(url, init);
-  const body = (await response.json()) as {
-    success?: boolean;
-    errors?: Array<{ message?: string }>;
-  };
-  if (!response.ok || body.success === false)
-    throw new AppError(
-      "UPDATE_CLOUDFLARE_ERROR",
-      body.errors?.[0]?.message ?? "Cloudflare rejected the update request.",
-      response.status === 401 || response.status === 403 ? 403 : 502
-    );
-  return body as T;
 }
 export function compareVersions(left: string, right: string): number {
   const a = (left.split("-")[0] ?? "0").split(".").map(Number);

--- a/worker/features/updates/service.ts
+++ b/worker/features/updates/service.ts
@@ -3,6 +3,7 @@ import { getSetting } from "../../db/client";
 import type { WorkerEnv } from "../../lib/env";
 import { AppError } from "../../lib/errors";
 import { hqbaseProductConfig } from "../../lib/product-config";
+import { withUpdateBuildLock } from "./build-lock";
 import type { ReleaseManifest, UpdateStatus } from "./types";
 
 const expectedReleaseVariable = "HQBASE_EXPECTED_RELEASE_VERSION";
@@ -46,12 +47,6 @@ export async function getUpdateStatus(
   )
     throw new AppError("UPDATE_SIGNATURE_INVALID", "Release signature verification failed.", 503);
   const release = manifestSchema.parse(JSON.parse(decodeBase64Url(envelope.payload)));
-  if (release.product !== "hqbase")
-    throw new AppError(
-      "UPDATE_PRODUCT_INVALID",
-      "Release product does not match this installation.",
-      503
-    );
   return {
     product: "hqbase",
     installedVersion,
@@ -151,49 +146,51 @@ export async function triggerUpdate(
       "Cloudflare returned an invalid production build trigger.",
       502
     );
-  const variablesUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${triggerId}/environment_variables`;
-  const variables = await cloudflare<{
-    result: Record<string, { is_secret: boolean; value?: string | null }>;
-  }>(variablesUrl, { headers }, fetcher);
-  const sourceDeploy = variables.result[forceSourceDeployVariable];
-  if (sourceDeploy?.is_secret || sourceDeploy?.value?.trim() === "1") {
-    throw new AppError(
-      "UPDATE_TRIGGER_USES_SOURCE",
-      "Signed updates are disabled because this build trigger uses custom source. Use the custom-source deployment process instead.",
-      409
-    );
-  }
-  const previousPin = variables.result[expectedReleaseVariable];
-  if (previousPin?.is_secret) {
-    throw new AppError(
-      "UPDATE_TRIGGER_UNMANAGED",
-      "Signed updates require HQBASE_EXPECTED_RELEASE_VERSION to be a plain build variable.",
-      409
-    );
-  }
-  await setBuildVersionPin(variablesUrl, expectedVersion, headers, fetcher);
-  try {
-    const build = await cloudflare<{
-      result: { build_uuid?: string; id?: string; status?: string };
-    }>(
-      `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${triggerId}/builds`,
-      { method: "POST", headers, body: JSON.stringify({ branch: "main" }) },
-      fetcher
-    );
-    const buildId = build.result.build_uuid ?? build.result.id;
-    if (!buildId)
+  return withUpdateBuildLock(env.DB, triggerId, async () => {
+    const variablesUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${triggerId}/environment_variables`;
+    const variables = await cloudflare<{
+      result: Record<string, { is_secret: boolean; value?: string | null }>;
+    }>(variablesUrl, { headers }, fetcher);
+    const sourceDeploy = variables.result[forceSourceDeployVariable];
+    if (sourceDeploy?.is_secret || sourceDeploy?.value?.trim() === "1") {
       throw new AppError(
-        "UPDATE_TRIGGER_FAILED",
-        "Cloudflare did not return a build identifier.",
-        502
+        "UPDATE_TRIGGER_USES_SOURCE",
+        "Signed updates are disabled because this build trigger uses custom source. Use the custom-source deployment process instead.",
+        409
       );
-    return { buildId, status: build.result.status ?? "queued" };
-  } catch (error) {
-    await restoreBuildVersionPin(variablesUrl, previousPin, headers, fetcher).catch(
-      () => undefined
-    );
-    throw error;
-  }
+    }
+    const previousPin = variables.result[expectedReleaseVariable];
+    if (previousPin?.is_secret) {
+      throw new AppError(
+        "UPDATE_TRIGGER_UNMANAGED",
+        "Signed updates require HQBASE_EXPECTED_RELEASE_VERSION to be a plain build variable.",
+        409
+      );
+    }
+    await setBuildVersionPin(variablesUrl, expectedVersion, headers, fetcher);
+    try {
+      const build = await cloudflare<{
+        result: { build_uuid?: string; id?: string; status?: string };
+      }>(
+        `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${triggerId}/builds`,
+        { method: "POST", headers, body: JSON.stringify({ branch: "main" }) },
+        fetcher
+      );
+      const buildId = build.result.build_uuid ?? build.result.id;
+      if (!buildId)
+        throw new AppError(
+          "UPDATE_TRIGGER_FAILED",
+          "Cloudflare did not return a build identifier.",
+          502
+        );
+      return { buildId, status: build.result.status ?? "queued" };
+    } catch (error) {
+      await restoreBuildVersionPin(variablesUrl, previousPin, headers, fetcher).catch(
+        () => undefined
+      );
+      throw error;
+    }
+  });
 }
 
 function assertManagedTrigger(trigger: {

--- a/worker/features/updates/service.ts
+++ b/worker/features/updates/service.ts
@@ -5,8 +5,6 @@ import { AppError } from "../../lib/errors";
 import { hqbaseProductConfig } from "../../lib/product-config";
 import type { ReleaseManifest, UpdateStatus } from "./types";
 
-const product = "hqbase" as const;
-const installedSchemaVersion = 2;
 const expectedReleaseVariable = "HQBASE_EXPECTED_RELEASE_VERSION";
 const forceSourceDeployVariable = "HQBASE_FORCE_SOURCE_DEPLOY";
 const managedDeployCommands = new Set(["pnpm deploy", "pnpm run deploy"]);
@@ -48,16 +46,16 @@ export async function getUpdateStatus(
   )
     throw new AppError("UPDATE_SIGNATURE_INVALID", "Release signature verification failed.", 503);
   const release = manifestSchema.parse(JSON.parse(decodeBase64Url(envelope.payload)));
-  if (release.product !== product)
+  if (release.product !== "hqbase")
     throw new AppError(
       "UPDATE_PRODUCT_INVALID",
       "Release product does not match this installation.",
       503
     );
   return {
-    product,
+    product: "hqbase",
     installedVersion,
-    installedSchemaVersion,
+    installedSchemaVersion: 2,
     channel: "stable",
     checkedAt: new Date().toISOString(),
     available: compareVersions(release.version, installedVersion) > 0,
@@ -191,7 +189,9 @@ export async function triggerUpdate(
       );
     return { buildId, status: build.result.status ?? "queued" };
   } catch (error) {
-    await restoreBuildVersionPin(variablesUrl, previousPin, headers, fetcher);
+    await restoreBuildVersionPin(variablesUrl, previousPin, headers, fetcher).catch(
+      () => undefined
+    );
     throw error;
   }
 }

--- a/worker/features/updates/service.ts
+++ b/worker/features/updates/service.ts
@@ -7,6 +7,9 @@ import type { ReleaseManifest, UpdateStatus } from "./types";
 
 const product = "hqbase" as const;
 const installedSchemaVersion = 2;
+const expectedReleaseVariable = "HQBASE_EXPECTED_RELEASE_VERSION";
+const forceSourceDeployVariable = "HQBASE_FORCE_SOURCE_DEPLOY";
+const managedDeployCommands = new Set(["pnpm deploy", "pnpm run deploy"]);
 const envelopeSchema = z.object({ payload: z.string().min(1), signature: z.string().min(1) });
 const manifestSchema = z.object({
   format: z.literal("hqbase-release-v1"),
@@ -66,8 +69,27 @@ export async function getUpdateStatus(
 export async function triggerUpdate(
   env: WorkerEnv,
   apiToken: string,
+  expectedVersion: string,
   fetcher: typeof fetch = fetch
 ): Promise<{ buildId: string; status: string }> {
+  const update = await getUpdateStatus(env, fetcher);
+  if (update.release.version !== expectedVersion) {
+    throw new AppError(
+      "UPDATE_RELEASE_CHANGED",
+      "The signed release changed after you reviewed it. Check for updates again.",
+      409
+    );
+  }
+  if (!update.available) {
+    throw new AppError("UPDATE_NOT_AVAILABLE", "This release is already installed.", 409);
+  }
+  if (!update.compatible) {
+    throw new AppError(
+      "UPDATE_INCOMPATIBLE",
+      "This release cannot update directly from the installed version.",
+      409
+    );
+  }
   const domain =
     (await getSetting(env.DB, "portal_host", z.string())) ??
     (await getSetting(env.DB, "primary_domain", z.string()));
@@ -104,33 +126,121 @@ export async function triggerUpdate(
       404
     );
   const triggers = await cloudflare<{
-    result: Array<{ id?: string; trigger_uuid?: string; branch_includes?: string[] }>;
+    result: Array<{
+      id?: string;
+      trigger_uuid?: string;
+      branch_includes?: string[];
+      deploy_command?: string | null;
+      root_directory?: string | null;
+    }>;
   }>(
     `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/workers/${script.tag}/triggers`,
     { headers },
     fetcher
   );
-  const trigger =
-    triggers.result.find((item) => item.branch_includes?.includes("main")) ?? triggers.result[0];
+  const trigger = triggers.result.find((item) => item.branch_includes?.includes("main"));
   if (!trigger)
     throw new AppError(
       "UPDATE_TRIGGER_NOT_FOUND",
       "Connect this Worker to Workers Builds before updating.",
       409
     );
-  const build = await cloudflare<{ result: { build_uuid?: string; id?: string; status?: string } }>(
-    `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${trigger.trigger_uuid ?? trigger.id}/builds`,
-    { method: "POST", headers, body: JSON.stringify({ branch: "main" }) },
-    fetcher
-  );
-  const buildId = build.result.build_uuid ?? build.result.id;
-  if (!buildId)
+  assertManagedTrigger(trigger);
+  const triggerId = trigger.trigger_uuid ?? trigger.id;
+  if (!triggerId)
     throw new AppError(
-      "UPDATE_TRIGGER_FAILED",
-      "Cloudflare did not return a build identifier.",
+      "UPDATE_TRIGGER_INVALID",
+      "Cloudflare returned an invalid production build trigger.",
       502
     );
-  return { buildId, status: build.result.status ?? "queued" };
+  const variablesUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${triggerId}/environment_variables`;
+  const variables = await cloudflare<{
+    result: Record<string, { is_secret: boolean; value?: string | null }>;
+  }>(variablesUrl, { headers }, fetcher);
+  const sourceDeploy = variables.result[forceSourceDeployVariable];
+  if (sourceDeploy?.is_secret || sourceDeploy?.value?.trim() === "1") {
+    throw new AppError(
+      "UPDATE_TRIGGER_USES_SOURCE",
+      "Signed updates are disabled because this build trigger uses custom source. Use the custom-source deployment process instead.",
+      409
+    );
+  }
+  const previousPin = variables.result[expectedReleaseVariable];
+  if (previousPin?.is_secret) {
+    throw new AppError(
+      "UPDATE_TRIGGER_UNMANAGED",
+      "Signed updates require HQBASE_EXPECTED_RELEASE_VERSION to be a plain build variable.",
+      409
+    );
+  }
+  await setBuildVersionPin(variablesUrl, expectedVersion, headers, fetcher);
+  try {
+    const build = await cloudflare<{
+      result: { build_uuid?: string; id?: string; status?: string };
+    }>(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${triggerId}/builds`,
+      { method: "POST", headers, body: JSON.stringify({ branch: "main" }) },
+      fetcher
+    );
+    const buildId = build.result.build_uuid ?? build.result.id;
+    if (!buildId)
+      throw new AppError(
+        "UPDATE_TRIGGER_FAILED",
+        "Cloudflare did not return a build identifier.",
+        502
+      );
+    return { buildId, status: build.result.status ?? "queued" };
+  } catch (error) {
+    await restoreBuildVersionPin(variablesUrl, previousPin, headers, fetcher);
+    throw error;
+  }
+}
+
+function assertManagedTrigger(trigger: {
+  deploy_command?: string | null;
+  root_directory?: string | null;
+}): void {
+  const command = trigger.deploy_command?.trim().replace(/\s+/g, " ") ?? "";
+  const root = trigger.root_directory?.trim() ?? "";
+  if (!managedDeployCommands.has(command) || !["", "/", ".", "./"].includes(root)) {
+    throw new AppError(
+      "UPDATE_TRIGGER_UNMANAGED",
+      "Signed updates require a repository-root Workers Builds trigger that runs pnpm deploy. Use the custom-source deployment process instead.",
+      409
+    );
+  }
+}
+
+async function setBuildVersionPin(
+  url: string,
+  version: string,
+  headers: Record<string, string>,
+  fetcher: typeof fetch
+): Promise<void> {
+  await cloudflare(
+    url,
+    {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({
+        [expectedReleaseVariable]: { is_secret: false, value: version }
+      })
+    },
+    fetcher
+  );
+}
+
+async function restoreBuildVersionPin(
+  url: string,
+  previous: { is_secret: boolean; value?: string | null } | undefined,
+  headers: Record<string, string>,
+  fetcher: typeof fetch
+): Promise<void> {
+  if (typeof previous?.value === "string") {
+    await setBuildVersionPin(url, previous.value, headers, fetcher);
+    return;
+  }
+  await cloudflare(`${url}/${expectedReleaseVariable}`, { method: "DELETE", headers }, fetcher);
 }
 
 async function verifyEnvelope(

--- a/worker/features/updates/service.ts
+++ b/worker/features/updates/service.ts
@@ -168,8 +168,8 @@ export async function triggerUpdate(
         409
       );
     }
-    await setBuildVersionPin(variablesUrl, expectedVersion, headers, fetcher);
     try {
+      await setBuildVersionPin(variablesUrl, expectedVersion, headers, fetcher);
       const build = await cloudflare<{
         result: { build_uuid?: string; id?: string; status?: string };
       }>(


### PR DESCRIPTION
## Summary

- require the repository-root production trigger and managed `pnpm deploy` command
- reject explicit custom-source deployment from the signed update flow
- carry the reviewed release through OAuth and pin it as `HQBASE_EXPECTED_RELEASE_VERSION`
- serialize release-pin changes and bound Cloudflare requests within the update lease
- restore the prior version pin if the pin or build request fails
- revoke temporary Cloudflare access on both success and failure

Closes #33

Companion documentation: HQBase/hqbase-site#28

## Verification

- `CI=true pnpm check`
- 496 unit tests passed; 2 existing tests skipped
- 121 integration tests passed
- coverage, architecture, production build, and generated API artifact checks passed
- `CI=true pnpm deploy:dry-run`
- protected staging E2E passed for exact head `dd742bd` in run 32592648490, including disposable-resource cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updates verify that the reviewed release matches the release being deployed.
  * Deployment checks confirm release availability and compatibility before starting.
  * Concurrent update attempts are prevented from running simultaneously.
  * Cloud service requests now include timeout protection and clearer error reporting.

* **Bug Fixes**
  * Update authorization data is preserved and cleared securely during OAuth flows.
  * Failed deployments restore release settings when possible.
  * Invalid configurations and expired release details are rejected before deployment.
  * Permissions and session data are cleaned up reliably, including when cleanup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
