### PR TITLE
chore: add MCP Registry publishing

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -17,7 +17,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - name: Install the MCP publisher
         env:
           MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,36 @@
+name: Publish MCP Registry metadata
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcp-registry-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install the MCP publisher
+        env:
+          MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
+          MCP_PUBLISHER_VERSION: 1.8.1
+        run: |
+          curl --fail --location --silent --show-error \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
+            --output mcp-publisher.tar.gz
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum --check -
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+      - name: Validate the registry metadata
+        run: ./mcp-publisher validate server.json
+      - name: Authenticate with GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+      - name: Publish the registry metadata
+        run: ./mcp-publisher publish server.json

--- a/server.json
+++ b/server.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.hqbase/hqbase",
+  "title": "HQBase",
+  "description": "Connect AI agents to your self-hosted HQBase shared email workspace.",
+  "repository": {
+    "url": "https://github.com/HQBase/hqbase",
+    "source": "github",
+    "id": "1328183085"
+  },
+  "version": "1.0.0",
+  "websiteUrl": "https://hqbase.io/docs/mcp/",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://{installation_domain}/mcp",
+      "variables": {
+        "installation_domain": {
+          "description": "Your HQBase installation domain, without https:// (for example, mail.example.com).",
+          "isRequired": true,
+          "format": "string",
+          "placeholder": "mail.example.com"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

## Verification

- [ ] `pnpm check`

## Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP server manifest with HQBase metadata, documentation, repository links, version details, and a configurable remote endpoint.
  * Added a manually triggered publishing workflow to validate and publish the server listing to the MCP Registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->