### PR TITLE
fix: match MCP Registry organization namespace

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.hqbase/hqbase",
+  "name": "io.github.HQBase/hqbase",
   "title": "HQBase",
   "description": "Connect AI agents to your self-hosted HQBase shared email workspace.",
   "repository": {


### PR DESCRIPTION
## Summary

- Match the MCP Registry server namespace to the exact `HQBase` GitHub organization login casing.
- Fix the Registry 403 caused by requesting `io.github.hqbase/hqbase` while GitHub OIDC grants `io.github.HQBase/*`.

## Verification

- `mcp-publisher validate server.json`
- `pnpm check`
- `pnpm deploy:dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the server identifier to use the correct capitalization for HQBase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->