### PR TITLE
Pin Deploy Button to signed releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       contents: write
     outputs:
       artifact_name: ${{ steps.metadata.outputs.artifact_name }}
+      commit: ${{ steps.metadata.outputs.commit }}
       draft_created: ${{ steps.draft.outputs.created }}
       previous_tag: ${{ steps.metadata.outputs.previous_tag }}
       version: ${{ steps.metadata.outputs.version }}
@@ -79,6 +80,7 @@ jobs:
           artifact_name="hqbase-release-${release_version}-${GITHUB_SHA}"
           echo "HQBASE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
           echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+          echo "commit=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
           echo "previous_tag=$previous_tag" >> "$GITHUB_OUTPUT"
           echo "version=$release_version" >> "$GITHUB_OUTPUT"
       - run: pnpm install --frozen-lockfile
@@ -293,11 +295,41 @@ jobs:
       contents: write
     env:
       GH_TOKEN: ${{ github.token }}
+      RELEASE_COMMIT: ${{ needs.candidate.outputs.commit }}
       HQBASE_RELEASE_VERSION: ${{ needs.candidate.outputs.version }}
     steps:
       - uses: actions/checkout@v6
+      - name: Read current Deploy Button source
+        id: deploy_source
+        run: |
+          previous_commit="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/deploy" --jq .object.sha)"
+          test -n "$previous_commit"
+          echo "previous_commit=$previous_commit" >> "$GITHUB_OUTPUT"
+      - name: Advance Deploy Button source to validated candidate
+        id: advance_deploy
+        run: >-
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/heads/deploy"
+          -f sha="$RELEASE_COMMIT"
       - name: Publish the validated draft
+        id: publish_release
         run: gh release edit "v${HQBASE_RELEASE_VERSION}" --draft=false --latest
+      - name: Restore Deploy Button source after publication failure
+        if: ${{ failure() && steps.advance_deploy.outcome == 'success' && steps.publish_release.outcome == 'failure' }}
+        env:
+          PREVIOUS_DEPLOY_COMMIT: ${{ steps.deploy_source.outputs.previous_commit }}
+        run: |
+          if test "$(gh release view "v${HQBASE_RELEASE_VERSION}" --json isDraft --jq .isDraft)" != "true"; then
+            echo "::warning title=Deploy branch retained::The release is public, so the validated Deploy Button source was not rolled back."
+            exit 0
+          fi
+          current_commit="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/deploy" --jq .object.sha)"
+          if test "$current_commit" != "$RELEASE_COMMIT"; then
+            echo "Deploy branch moved after the candidate update; refusing to overwrite it." >&2
+            exit 1
+          fi
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/heads/deploy" \
+            -f sha="$PREVIOUS_DEPLOY_COMMIT" \
+            -F force=true
       - name: Verify public stable asset, signature, and digest
         run: |
           stable_url="https://github.com/HQBase/hqbase/releases/latest/download/stable.json"
@@ -310,6 +342,8 @@ jobs:
             test "$attempt" -lt 30
             sleep 2
           done
+          deploy_commit="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/deploy" --jq .object.sha)"
+          test "$deploy_commit" = "$RELEASE_COMMIT"
           node --input-type=module -e '
             import { createHash, createPublicKey, verify } from "node:crypto";
             import { readFileSync, statSync } from "node:fs";

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,6 +305,23 @@ jobs:
           previous_commit="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/deploy" --jq .object.sha)"
           test -n "$previous_commit"
           echo "previous_commit=$previous_commit" >> "$GITHUB_OUTPUT"
+      - name: Verify any existing release tag source
+        run: |
+          tag_name="v${HQBASE_RELEASE_VERSION}"
+          tag_ref="$(gh api "repos/$GITHUB_REPOSITORY/git/matching-refs/tags/$tag_name" \
+            --jq ".[] | select(.ref == \"refs/tags/$tag_name\") | [.object.type, .object.sha] | @tsv")"
+          if test -z "$tag_ref"; then
+            exit 0
+          fi
+          read -r tag_type tag_commit <<< "$tag_ref"
+          while test "$tag_type" = "tag"; do
+            read -r tag_type tag_commit < <(
+              gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_commit" \
+                --jq '[.object.type, .object.sha] | @tsv'
+            )
+          done
+          test "$tag_type" = "commit"
+          test "$tag_commit" = "$RELEASE_COMMIT"
       - name: Advance Deploy Button source to validated candidate
         id: advance_deploy
         run: >-
@@ -342,6 +359,19 @@ jobs:
             test "$attempt" -lt 30
             sleep 2
           done
+          tag_name="v${HQBASE_RELEASE_VERSION}"
+          read -r tag_type tag_commit < <(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag_name" \
+              --jq '[.object.type, .object.sha] | @tsv'
+          )
+          while test "$tag_type" = "tag"; do
+            read -r tag_type tag_commit < <(
+              gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_commit" \
+                --jq '[.object.type, .object.sha] | @tsv'
+            )
+          done
+          test "$tag_type" = "commit"
+          test "$tag_commit" = "$RELEASE_COMMIT"
           deploy_commit="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/deploy" --jq .object.sha)"
           test "$deploy_commit" = "$RELEASE_COMMIT"
           node --input-type=module -e '

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,9 +335,26 @@ jobs:
         env:
           PREVIOUS_DEPLOY_COMMIT: ${{ steps.deploy_source.outputs.previous_commit }}
         run: |
-          if test "$(gh release view "v${HQBASE_RELEASE_VERSION}" --json isDraft --jq .isDraft)" != "true"; then
+          release_lookup_succeeded=false
+          release_is_draft=""
+          for attempt in $(seq 1 5); do
+            if release_is_draft="$(gh release view "v${HQBASE_RELEASE_VERSION}" --json isDraft --jq .isDraft)"; then
+              release_lookup_succeeded=true
+              break
+            fi
+            sleep 2
+          done
+          if test "$release_lookup_succeeded" != "true"; then
+            echo "Could not determine whether the release is public; refusing to change the Deploy branch." >&2
+            exit 1
+          fi
+          if test "$release_is_draft" = "false"; then
             echo "::warning title=Deploy branch retained::The release is public, so the validated Deploy Button source was not rolled back."
             exit 0
+          fi
+          if test "$release_is_draft" != "true"; then
+            echo "GitHub returned an invalid release draft state: $release_is_draft" >&2
+            exit 1
           fi
           current_commit="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/deploy" --jq .object.sha)"
           if test "$current_commit" != "$RELEASE_COMMIT"; then

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 </p>
 
 <p align="center">
-  <a href="https://deploy.workers.cloudflare.com/?url=https%3A%2F%2Fgithub.com%2FHQBase%2Fhqbase">
+  <a href="https://deploy.workers.cloudflare.com/?url=https%3A%2F%2Fgithub.com%2FHQBase%2Fhqbase%2Ftree%2Fdeploy">
     <img src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare">
   </a>
 </p>

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -72,6 +72,7 @@ describe("staging workflow lifecycle record", () => {
 
   it("moves the Deploy Button source before publication and verifies the exact commit", () => {
     const readSource = releaseWorkflow.indexOf("Read current Deploy Button source");
+    const verifyTag = releaseWorkflow.indexOf("Verify any existing release tag source");
     const advance = releaseWorkflow.indexOf("Advance Deploy Button source to validated candidate");
     const publish = releaseWorkflow.indexOf("Publish the validated draft");
     const restore = releaseWorkflow.indexOf(
@@ -80,15 +81,19 @@ describe("staging workflow lifecycle record", () => {
     const verify = releaseWorkflow.indexOf("Verify public stable asset, signature, and digest");
 
     expect(readSource).toBeGreaterThan(-1);
-    expect(advance).toBeGreaterThan(readSource);
+    expect(verifyTag).toBeGreaterThan(readSource);
+    expect(advance).toBeGreaterThan(verifyTag);
     expect(publish).toBeGreaterThan(advance);
     expect(restore).toBeGreaterThan(publish);
     expect(verify).toBeGreaterThan(restore);
     expect(releaseWorkflow).toContain("RELEASE_COMMIT: \u0024{{ needs.candidate.outputs.commit }}");
     expect(releaseWorkflow).toContain("git/refs/heads/deploy");
+    expect(releaseWorkflow).toContain("git/matching-refs/tags/$tag_name");
+    expect(releaseWorkflow).toContain("git/tags/$tag_commit");
     expect(releaseWorkflow).toContain("steps.publish_release.outcome == 'failure'");
     expect(releaseWorkflow).toContain("--json isDraft --jq .isDraft");
     expect(releaseWorkflow).toContain("-F force=true");
+    expect(releaseWorkflow).toContain('test "$tag_commit" = "$RELEASE_COMMIT"');
     expect(releaseWorkflow).toContain('test "$deploy_commit" = "$RELEASE_COMMIT"');
     expect(readme).toContain("HQBase%2Fhqbase%2Ftree%2Fdeploy");
   });

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -9,6 +9,7 @@ const releaseWorkflow = readFileSync(
   new URL("../../../.github/workflows/release.yml", import.meta.url),
   "utf8"
 );
+const readme = readFileSync(new URL("../../../README.md", import.meta.url), "utf8");
 
 describe("staging workflow lifecycle record", () => {
   it("tests a populated SQL migration upgrade before deployment", () => {
@@ -67,5 +68,28 @@ describe("staging workflow lifecycle record", () => {
     expect(waitStep).toContain('jq -e --arg version "$CANDIDATE_VERSION"');
     expect(waitStep).toContain(".version == $version");
     expect(waitStep).toContain("candidate=$CANDIDATE_VERSION&attempt=$attempt");
+  });
+
+  it("moves the Deploy Button source before publication and verifies the exact commit", () => {
+    const readSource = releaseWorkflow.indexOf("Read current Deploy Button source");
+    const advance = releaseWorkflow.indexOf("Advance Deploy Button source to validated candidate");
+    const publish = releaseWorkflow.indexOf("Publish the validated draft");
+    const restore = releaseWorkflow.indexOf(
+      "Restore Deploy Button source after publication failure"
+    );
+    const verify = releaseWorkflow.indexOf("Verify public stable asset, signature, and digest");
+
+    expect(readSource).toBeGreaterThan(-1);
+    expect(advance).toBeGreaterThan(readSource);
+    expect(publish).toBeGreaterThan(advance);
+    expect(restore).toBeGreaterThan(publish);
+    expect(verify).toBeGreaterThan(restore);
+    expect(releaseWorkflow).toContain("RELEASE_COMMIT: \u0024{{ needs.candidate.outputs.commit }}");
+    expect(releaseWorkflow).toContain("git/refs/heads/deploy");
+    expect(releaseWorkflow).toContain("steps.publish_release.outcome == 'failure'");
+    expect(releaseWorkflow).toContain("--json isDraft --jq .isDraft");
+    expect(releaseWorkflow).toContain("-F force=true");
+    expect(releaseWorkflow).toContain('test "$deploy_commit" = "$RELEASE_COMMIT"');
+    expect(readme).toContain("HQBase%2Fhqbase%2Ftree%2Fdeploy");
   });
 });

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -92,6 +92,9 @@ describe("staging workflow lifecycle record", () => {
     expect(releaseWorkflow).toContain("git/tags/$tag_commit");
     expect(releaseWorkflow).toContain("steps.publish_release.outcome == 'failure'");
     expect(releaseWorkflow).toContain("--json isDraft --jq .isDraft");
+    expect(releaseWorkflow).toContain("release_lookup_succeeded=false");
+    expect(releaseWorkflow).toContain('test "$release_lookup_succeeded" != "true"');
+    expect(releaseWorkflow).toContain('test "$release_is_draft" = "false"');
     expect(releaseWorkflow).toContain("-F force=true");
     expect(releaseWorkflow).toContain('test "$tag_commit" = "$RELEASE_COMMIT"');
     expect(releaseWorkflow).toContain('test "$deploy_commit" = "$RELEASE_COMMIT"');


### PR DESCRIPTION
## Summary

- point the official Deploy to Cloudflare button at the release-pinned `deploy` branch
- advance that branch only after the candidate passes the signed-release staging gates
- restore the prior branch commit when publication fails while the release is still a draft
- verify the branch, public release, and signed stable manifest identify the same candidate

## Validation

- `CI=true pnpm check`
- `CI=true pnpm deploy:dry-run`

Paired documentation change: HQBase/hqbase-site#30.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloudflare deployment links now open the repository’s deploy branch.
* **Bug Fixes**
  * Release publishing verifies that release tags point to the expected commit.
  * The deploy branch is updated before publishing and restored if a draft release fails.
  * Final checks confirm the release tag, deploy branch, and published commit remain aligned.
* **Tests**
  * Added coverage for deployment updates, failure recovery, release verification, publication status, and deploy-link configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->