### PR TITLE
docs: add Herald community client

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ and Cloudflare credentials in customer infrastructure. It includes:
 See the [product documentation](https://hqbase.io/docs/) for installation, daily use, architecture,
 and operations.
 
+## Made by the community
+
+We love seeing people build around HQBase. Independent clients give you more ways to use your
+workspace:
+
+- [Herald](https://github.com/awizemann/herald) — A native macOS email client for HQBase.
+
+HQBase has tested Herald for compatibility. It is made and maintained by independent community
+developers, so its releases, support, and behavior remain in their care rather than HQBase's.
+Please review the project and decide whether it is right for your workspace.
+
 ## Develop locally
 
 ### Start the application


### PR DESCRIPTION
## Summary

- add a welcoming **Made by the community** section to the repository README
- list Herald as a native macOS email client for HQBase
- explain that its independent community maintainers care for releases, support, and behavior

## Validation

- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-community-clients-pr-check.log pnpm check`
- `CI=true WRANGLER_LOG_PATH=/tmp/hqbase-community-clients-pr-dry-run.log pnpm deploy:dry-run`

## Paired change

- HQBase/hqbase-site#32


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Made by the community” section highlighting the independent Herald macOS client for HQBase.
  * Clarified its compatibility status and independent maintenance and support disclaimer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->