### PR TITLE
Fix PWA update reload race

### DIFF
--- a/app/features/pwa/register.ts
+++ b/app/features/pwa/register.ts
@@ -27,9 +27,13 @@ export function registerPwa({
   let activeUpdateDeadline = 0;
 
   const activate = (): void => {
-    if (!registration?.waiting) return;
+    const waiting = registration?.waiting;
+    if (!waiting) {
+      window.location.reload();
+      return;
+    }
     refreshAfterActivation = true;
-    registration.waiting.postMessage({ type: "SKIP_WAITING" });
+    waiting.postMessage({ type: "SKIP_WAITING" });
   };
 
   const announceWaitingWorker = (): void => {

--- a/test/unit/app/pwa/register.test.ts
+++ b/test/unit/app/pwa/register.test.ts
@@ -7,6 +7,7 @@ import { UPDATE_STARTED_EVENT } from "@/features/updates/update-progress";
 describe("PWA registration", () => {
   afterEach(() => {
     document.documentElement.removeAttribute("data-hqbase-update-ready");
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -83,5 +84,38 @@ describe("PWA registration", () => {
 
     unregister();
     window.removeEventListener(PWA_UPDATE_READY_EVENT, readyListener);
+  });
+
+  it("reloads when the waiting worker activated before the click", async () => {
+    const onUpdateReady = vi.fn();
+    const reload = vi.spyOn(window.location, "reload").mockImplementation(() => undefined);
+    const registration: {
+      addEventListener: ReturnType<typeof vi.fn>;
+      installing: null;
+      update: ReturnType<typeof vi.fn>;
+      waiting: { postMessage: ReturnType<typeof vi.fn> } | null;
+    } = {
+      addEventListener: vi.fn(),
+      installing: null,
+      update: vi.fn().mockResolvedValue(undefined),
+      waiting: { postMessage: vi.fn() }
+    };
+    vi.stubGlobal("navigator", {
+      onLine: true,
+      serviceWorker: {
+        addEventListener: vi.fn(),
+        controller: {},
+        register: vi.fn().mockResolvedValue(registration),
+        removeEventListener: vi.fn()
+      }
+    });
+
+    const unregister = registerPwa({ onUpdateReady });
+    await Promise.resolve();
+    registration.waiting = null;
+    onUpdateReady.mock.calls[0]?.[0].activate();
+
+    expect(reload).toHaveBeenCalledOnce();
+    unregister();
   });
 });


### PR DESCRIPTION
## Summary

- reload when the waiting service worker activates before the user clicks Update PWA
- keep the existing skip-waiting path when a worker is still waiting
- add regression coverage for the activation race

## Validation

- CI=true pnpm check
- CI=true WRANGLER_LOG_PATH=/tmp/hqbase-pwa-reload-dry-run.log pnpm deploy:dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Progressive Web App updates by reloading the page immediately when no update is waiting.
  * Ensured updates activate and refresh correctly when an update becomes available during registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->