### PR TITLE
fix: stabilize overlays and status switches

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -266,7 +266,7 @@ export function App(): React.ReactElement {
                 onDefaultFromMailboxChange={(defaultFromMailboxId) => {
                   setUser((current) => (current ? { ...current, defaultFromMailboxId } : current));
                 }}
-                onRefresh={() => void reload()}
+                onRefresh={reload}
                 onUpdateStarted={updateMonitor.start}
                 onUpdateStatusChange={updateMonitor.acceptStatus}
                 updateProgress={updateMonitor.progress}

--- a/app/components/ui/dialog.tsx
+++ b/app/components/ui/dialog.tsx
@@ -24,7 +24,7 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 export const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+>(({ className, children, onPointerDownOutside, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -33,6 +33,10 @@ export const DialogContent = React.forwardRef<
         className
       )}
       ref={ref}
+      onPointerDownOutside={(event) => {
+        onPointerDownOutside?.(event);
+        event.preventDefault();
+      }}
       {...props}
     >
       {children}

--- a/app/components/ui/switch.tsx
+++ b/app/components/ui/switch.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+
+import { cn } from "@/lib/cn";
+
+type SwitchProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "aria-checked" | "onClick" | "role" | "type"
+> & {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+};
+
+export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
+  ({ checked, className, onCheckedChange, ...props }, ref) => (
+    <button
+      aria-checked={checked}
+      className={cn(
+        "inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-input px-0.5 shadow-sm transition-[background-color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transition-none",
+        checked ? "bg-foreground/90" : "bg-muted",
+        className
+      )}
+      ref={ref}
+      role="switch"
+      type="button"
+      onClick={() => onCheckedChange(!checked)}
+      {...props}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "size-5 rounded-full bg-background shadow-sm transition-transform motion-reduce:transition-none",
+          checked ? "translate-x-5 bg-card" : "translate-x-0"
+        )}
+      />
+    </button>
+  )
+);
+Switch.displayName = "Switch";

--- a/app/features/domains/domain-settings.tsx
+++ b/app/features/domains/domain-settings.tsx
@@ -111,12 +111,14 @@ export function DomainSettings({
     setAuthorizationOperation({ action: "portal", zoneId: domain.zoneId, hostname });
   }
 
-  async function toggleDomain(domain: MailDomain) {
+  async function toggleDomain(domain: MailDomain, isEnabled: boolean) {
     setPendingDomainId(domain.id);
     try {
-      await updateDomain(domain.id, { isEnabled: !domain.isEnabled });
-      refresh();
-      toast.success(`${domain.name} ${domain.isEnabled ? "disabled" : "enabled"}.`);
+      const updatedDomain = await updateDomain(domain.id, { isEnabled });
+      setDomains((current) =>
+        current.map((item) => (item.id === updatedDomain.id ? updatedDomain : item))
+      );
+      toast.success(`${domain.name} ${isEnabled ? "enabled" : "disabled"}.`);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Domain could not be updated.");
     } finally {
@@ -155,7 +157,7 @@ export function DomainSettings({
       <DomainTable
         domains={domains}
         pendingDomainId={pendingDomainId}
-        onToggle={(domain) => void toggleDomain(domain)}
+        onToggle={(domain, isEnabled) => void toggleDomain(domain, isEnabled)}
       />
 
       <Separator />

--- a/app/features/domains/domain-table.tsx
+++ b/app/features/domains/domain-table.tsx
@@ -1,6 +1,5 @@
 import type * as React from "react";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import {
   Table,
   TableBody,
@@ -19,7 +18,7 @@ export function DomainTable({
 }: {
   domains: MailDomain[];
   pendingDomainId: string | null;
-  onToggle: (domain: MailDomain) => void;
+  onToggle: (domain: MailDomain, isEnabled: boolean) => void;
 }): React.ReactElement {
   return (
     <Table containerClassName="rounded-lg border">
@@ -29,16 +28,13 @@ export function DomainTable({
           <TableHead className="hidden w-28 sm:table-cell">Receive</TableHead>
           <TableHead className="hidden w-28 sm:table-cell">Send</TableHead>
           <TableHead className="hidden w-28 sm:table-cell">DNS</TableHead>
-          <TableHead className="w-28">Status</TableHead>
-          <TableHead className="w-px text-right">
-            <span className="sr-only">Actions</span>
-          </TableHead>
+          <TableHead className="w-20">Enabled</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {domains.length === 0 ? (
           <TableRow>
-            <TableCell className="h-24 text-center text-muted-foreground" colSpan={6}>
+            <TableCell className="h-24 text-center text-muted-foreground" colSpan={5}>
               No domains connected.
             </TableCell>
           </TableRow>
@@ -62,25 +58,12 @@ export function DomainTable({
               <ReadinessStatus status={domain.dnsStatus} />
             </TableCell>
             <TableCell>
-              <Badge variant={domain.isEnabled ? "secondary" : "outline"}>
-                {domain.isEnabled ? "Enabled" : "Disabled"}
-              </Badge>
-            </TableCell>
-            <TableCell className="text-right">
-              <Button
-                aria-label={`${domain.isEnabled ? "Disable" : "Enable"} ${domain.name}`}
-                disabled={pendingDomainId === domain.id}
-                size="sm"
-                type="button"
-                variant="outline"
-                onClick={() => onToggle(domain)}
-              >
-                {pendingDomainId === domain.id
-                  ? "Updating…"
-                  : domain.isEnabled
-                    ? "Disable"
-                    : "Enable"}
-              </Button>
+              <Switch
+                aria-label={`${domain.name} enabled`}
+                checked={domain.isEnabled}
+                disabled={pendingDomainId !== null}
+                onCheckedChange={(isEnabled) => onToggle(domain, isEnabled)}
+              />
             </TableCell>
           </TableRow>
         ))}

--- a/app/features/mailboxes/mailbox-details-sheet.tsx
+++ b/app/features/mailboxes/mailbox-details-sheet.tsx
@@ -19,8 +19,7 @@ export function MailboxDetailsSheet({
   onAddAddress,
   onManageAccess,
   onOpenChange,
-  onRemoveAddress,
-  onToggle
+  onRemoveAddress
 }: {
   canManage: boolean;
   mailbox: Mailbox | null;
@@ -30,7 +29,6 @@ export function MailboxDetailsSheet({
   onManageAccess: (mailbox: Mailbox) => void;
   onOpenChange: (open: boolean) => void;
   onRemoveAddress: (mailbox: Mailbox, addressId: string) => void;
-  onToggle: (mailbox: Mailbox) => void;
 }): React.ReactElement {
   const people = mailbox ? getMailboxAccessEntries(mailbox.id, policies.grants, users) : [];
   const additionalAddresses = mailbox?.addresses.filter((address) => !address.isPrimary) ?? [];
@@ -161,35 +159,6 @@ export function MailboxDetailsSheet({
                   </p>
                 )}
               </section>
-
-              <div className="border-t pt-4">
-                <div className="flex items-center justify-between gap-4">
-                  <div>
-                    <p className="text-sm font-medium">Mailbox status</p>
-                    <p className="mt-0.5 text-xs text-muted-foreground">
-                      {mailbox?.isActive
-                        ? "This mailbox can receive and send mail."
-                        : "This mailbox is currently disabled."}
-                    </p>
-                  </div>
-                  {mailbox ? (
-                    canManage ? (
-                      <Button
-                        size="sm"
-                        type="button"
-                        variant="outline"
-                        onClick={() => onToggle(mailbox)}
-                      >
-                        {mailbox.isActive ? "Disable" : "Enable"}
-                      </Button>
-                    ) : (
-                      <Badge variant={mailbox.isActive ? "secondary" : "outline"}>
-                        {mailbox.isActive ? "Active" : "Disabled"}
-                      </Badge>
-                    )
-                  ) : null}
-                </div>
-              </div>
             </div>
           </details>
         </div>

--- a/app/features/mailboxes/mailbox-settings.tsx
+++ b/app/features/mailboxes/mailbox-settings.tsx
@@ -41,7 +41,7 @@ type MailboxSettingsProps = {
   mailboxes: Mailbox[];
   users: WorkspaceUser[];
   onDefaultFromMailboxChange: (mailboxId: string) => void;
-  onChanged: () => void;
+  onChanged: () => Promise<void>;
 };
 
 export function MailboxSettings({
@@ -63,6 +63,7 @@ export function MailboxSettings({
   const [selectedMailboxIds, setSelectedMailboxIds] = React.useState<string[]>([]);
   const [aliasAddress, setAliasAddress] = React.useState("");
   const [pendingAction, setPendingAction] = React.useState<"mailbox" | "alias" | null>(null);
+  const [pendingMailboxId, setPendingMailboxId] = React.useState<string | null>(null);
   const accessPolicies = useMailboxAccessPolicies(canManage);
   const domains = mailboxDomains(mailboxes);
   const activeDomain = domains.includes(domainFilter) ? domainFilter : "all";
@@ -84,7 +85,7 @@ export function MailboxSettings({
       setDisplayName("");
       setCreateOpen(false);
       toast.success("Mailbox created.");
-      onChanged();
+      await onChanged();
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Mailbox creation failed.");
     } finally {
@@ -92,9 +93,17 @@ export function MailboxSettings({
     }
   }
 
-  async function handleToggle(mailbox: Mailbox) {
-    await updateMailbox(mailbox.id, { isActive: !mailbox.isActive });
-    onChanged();
+  async function handleToggle(mailbox: Mailbox, isActive: boolean) {
+    setPendingMailboxId(mailbox.id);
+    try {
+      await updateMailbox(mailbox.id, { isActive });
+      toast.success(`${mailbox.address} ${isActive ? "enabled" : "disabled"}.`);
+      await onChanged();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Mailbox could not be updated.");
+    } finally {
+      setPendingMailboxId(null);
+    }
   }
 
   async function handleAlias(event: React.FormEvent<HTMLFormElement>) {
@@ -109,7 +118,7 @@ export function MailboxSettings({
       setAliasAddress("");
       setAliasMailbox(null);
       toast.success("Email address added.");
-      onChanged();
+      await onChanged();
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Address creation failed.");
     } finally {
@@ -119,7 +128,7 @@ export function MailboxSettings({
 
   async function handleRemoveAlias(mailbox: Mailbox, addressId: string) {
     await removeMailboxAddress(mailbox.id, addressId);
-    onChanged();
+    await onChanged();
   }
 
   return (
@@ -220,11 +229,13 @@ export function MailboxSettings({
       <MailboxTable
         canManage={canManage}
         mailboxes={visibleMailboxes}
+        pendingMailboxId={pendingMailboxId}
         policies={accessPolicies}
         selectedIds={selectedMailboxIds}
         users={users}
         onOpenDetails={(mailbox) => setDetailsMailboxId(mailbox.id)}
         onSelectionChange={setSelectedMailboxIds}
+        onToggle={(mailbox, isActive) => void handleToggle(mailbox, isActive)}
       />
 
       <MailboxDetailsSheet
@@ -244,7 +255,6 @@ export function MailboxSettings({
           if (!open) setDetailsMailboxId(null);
         }}
         onRemoveAddress={(mailbox, addressId) => void handleRemoveAlias(mailbox, addressId)}
-        onToggle={(mailbox) => void handleToggle(mailbox)}
       />
 
       <MailboxAliasDialog

--- a/app/features/mailboxes/mailbox-settings.tsx
+++ b/app/features/mailboxes/mailbox-settings.tsx
@@ -127,8 +127,12 @@ export function MailboxSettings({
   }
 
   async function handleRemoveAlias(mailbox: Mailbox, addressId: string) {
-    await removeMailboxAddress(mailbox.id, addressId);
-    await onChanged();
+    try {
+      await removeMailboxAddress(mailbox.id, addressId);
+      await onChanged();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Address could not be removed.");
+    }
   }
 
   return (

--- a/app/features/mailboxes/mailbox-table.tsx
+++ b/app/features/mailboxes/mailbox-table.tsx
@@ -2,6 +2,7 @@ import type * as React from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Switch } from "@/components/ui/switch";
 import {
   Table,
   TableBody,
@@ -37,19 +38,23 @@ export function MailboxSelectionBar({
 export function MailboxTable({
   canManage,
   mailboxes,
+  pendingMailboxId,
   policies,
   selectedIds,
   users,
   onOpenDetails,
-  onSelectionChange
+  onSelectionChange,
+  onToggle
 }: {
   canManage: boolean;
   mailboxes: Mailbox[];
+  pendingMailboxId: string | null;
   policies: MailboxAccessPolicies;
   selectedIds: string[];
   users: WorkspaceUser[];
   onOpenDetails: (mailbox: Mailbox) => void;
   onSelectionChange: (selectedIds: string[]) => void;
+  onToggle: (mailbox: Mailbox, isActive: boolean) => void;
 }): React.ReactElement {
   const selected = new Set(selectedIds);
   const visibleIds = mailboxes.map((mailbox) => mailbox.id);
@@ -88,7 +93,7 @@ export function MailboxTable({
           ) : null}
           <TableHead>Address</TableHead>
           <TableHead className="hidden sm:table-cell">Name</TableHead>
-          <TableHead className="hidden w-28 md:table-cell">Status</TableHead>
+          <TableHead className="w-20">Status</TableHead>
           <TableHead className="w-32 sm:w-48">Access</TableHead>
         </TableRow>
       </TableHeader>
@@ -132,18 +137,21 @@ export function MailboxTable({
                 <span className="mt-0.5 block truncate text-xs text-muted-foreground sm:hidden">
                   {mailbox.displayName}
                 </span>
-                <Badge
-                  className="mt-1 md:hidden"
-                  variant={mailbox.isActive ? "secondary" : "outline"}
-                >
-                  {mailbox.isActive ? "Active" : "Disabled"}
-                </Badge>
               </TableCell>
               <TableCell className="hidden sm:table-cell">{mailbox.displayName}</TableCell>
-              <TableCell className="hidden md:table-cell">
-                <Badge variant={mailbox.isActive ? "secondary" : "outline"}>
-                  {mailbox.isActive ? "Active" : "Disabled"}
-                </Badge>
+              <TableCell onClick={canManage ? (event) => event.stopPropagation() : undefined}>
+                {canManage ? (
+                  <Switch
+                    aria-label={`${mailbox.address} status`}
+                    checked={mailbox.isActive}
+                    disabled={pendingMailboxId !== null}
+                    onCheckedChange={(isActive) => onToggle(mailbox, isActive)}
+                  />
+                ) : (
+                  <Badge variant={mailbox.isActive ? "secondary" : "outline"}>
+                    {mailbox.isActive ? "Active" : "Disabled"}
+                  </Badge>
+                )}
               </TableCell>
               <TableCell>
                 {canManage ? (

--- a/app/features/settings/interface-settings.tsx
+++ b/app/features/settings/interface-settings.tsx
@@ -1,8 +1,8 @@
 import type * as React from "react";
 
+import { Switch } from "@/components/ui/switch";
 import { SettingsSection } from "@/features/settings/settings-section";
 import { useTheme } from "@/features/theme/theme-provider";
-import { cn } from "@/lib/cn";
 
 export function InterfaceSettings(): React.ReactElement {
   const { setTheme, theme } = useTheme();
@@ -18,29 +18,11 @@ export function InterfaceSettings(): React.ReactElement {
               Toggle the theme. Stored locally in this browser.
             </p>
           </div>
-          <button
-            aria-checked={isDark}
-            aria-label={isDark ? "Dark mode on" : "Dark mode off"}
-            className="flex shrink-0 items-center gap-2"
-            role="switch"
-            type="button"
-            onClick={() => setTheme(isDark ? "light" : "dark")}
-          >
-            <span
-              aria-hidden="true"
-              className={cn(
-                "inline-flex h-6 w-11 items-center rounded-full border px-0.5 transition-colors",
-                isDark ? "border-input bg-foreground/90" : "border-input bg-muted"
-              )}
-            >
-              <span
-                className={cn(
-                  "size-5 rounded-full bg-background shadow-sm transition-transform",
-                  isDark ? "translate-x-5 bg-card" : "translate-x-0"
-                )}
-              />
-            </span>
-          </button>
+          <Switch
+            aria-label="Dark mode"
+            checked={isDark}
+            onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
+          />
         </div>
       </div>
     </SettingsSection>

--- a/app/features/settings/settings-page.tsx
+++ b/app/features/settings/settings-page.tsx
@@ -27,7 +27,7 @@ type SettingsPageProps = {
   setup: SetupStatus;
   users: WorkspaceUser[];
   onDefaultFromMailboxChange: (mailboxId: string) => void;
-  onRefresh: () => void;
+  onRefresh: () => Promise<void>;
   onUpdateStarted: (buildId: string) => void;
   onUpdateStatusChange: (status: UpdateStatus) => void;
   updateProgress: UpdateProgress | null;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -93,8 +93,8 @@ export default {
           to: { transform: "translateX(0)" }
         },
         "sheet-out-right": {
-          from: { transform: "translateX(100%)" },
-          to: { transform: "translateX(0)" }
+          from: { transform: "translateX(0)" },
+          to: { transform: "translateX(100%)" }
         }
       },
       animation: {

--- a/test/unit/app/settings/settings-presentation.test.tsx
+++ b/test/unit/app/settings/settings-presentation.test.tsx
@@ -108,7 +108,7 @@ describe("settings presentation", () => {
         defaultFromMailboxId={null}
         mailboxes={[]}
         users={[]}
-        onChanged={() => undefined}
+        onChanged={async () => undefined}
         onDefaultFromMailboxChange={() => undefined}
       />
     );
@@ -180,7 +180,7 @@ describe("settings presentation", () => {
         defaultFromMailboxId={mailbox.id}
         mailboxes={[mailbox]}
         users={[member]}
-        onChanged={() => undefined}
+        onChanged={async () => undefined}
         onDefaultFromMailboxChange={() => undefined}
       />
     );
@@ -196,6 +196,9 @@ describe("settings presentation", () => {
     expect(html).not.toContain(">Manage access<");
     expect(html).not.toContain("Apply to domain");
     expect(html).not.toContain("Set access by domain");
+    expect(html).toContain('aria-label="support@example.com status"');
+    expect(html).toContain('role="switch"');
+    expect(html).toContain('aria-checked="true"');
     expect(
       formatMailboxAccessSummary(
         mailbox.id,
@@ -221,7 +224,7 @@ describe("settings presentation", () => {
         defaultFromMailboxId={mailbox.id}
         mailboxes={[mailbox, secondDomainMailbox]}
         users={[member]}
-        onChanged={() => undefined}
+        onChanged={async () => undefined}
         onDefaultFromMailboxChange={() => undefined}
       />
     );
@@ -266,12 +269,14 @@ describe("settings presentation", () => {
     expect(html).toContain(">Receive<");
     expect(html).toContain(">Send<");
     expect(html).toContain(">DNS<");
-    expect(html).toContain(">Status<");
+    expect(html).toContain(">Enabled<");
     expect(html).toContain("example.com");
     expect(html).toContain("Ready");
     expect(html).toContain("Degraded");
     expect(html).toContain("Pending");
-    expect(html).toContain('aria-label="Disable example.com"');
+    expect(html).toContain('aria-label="example.com enabled"');
+    expect(html).toContain('role="switch"');
+    expect(html).toContain('aria-checked="true"');
   });
 
   it("replaces General and Upgrade with Debug as the final tab", () => {
@@ -295,7 +300,7 @@ describe("settings presentation", () => {
         updateStatus={null}
         users={[]}
         onDefaultFromMailboxChange={() => undefined}
-        onRefresh={() => undefined}
+        onRefresh={async () => undefined}
         onUpdateStarted={() => undefined}
         onUpdateStatusChange={() => undefined}
         updateProgress={null}

--- a/test/unit/app/settings/table-switches.test.tsx
+++ b/test/unit/app/settings/table-switches.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DomainTable } from "@/features/domains/domain-table";
+import type { MailDomain } from "@/features/domains/types";
+import type { MailboxAccessPolicies } from "@/features/mailbox-access/mailbox-access-policies";
+import { MailboxTable } from "@/features/mailboxes/mailbox-table";
+import type { Mailbox } from "@/features/mailboxes/types";
+import { flushHookEffects, renderComponent } from "../render-hook";
+
+const mailbox: Mailbox = {
+  id: "mailbox-1",
+  address: "support@example.com",
+  addresses: [],
+  displayName: "Support",
+  isActive: true,
+  accessLevel: "manager",
+  createdAt: "2026-08-23T00:00:00.000Z",
+  updatedAt: "2026-08-23T00:00:00.000Z"
+};
+
+const domain: MailDomain = {
+  id: "domain-1",
+  name: "example.com",
+  zoneId: "zone-1",
+  accountId: "account-1",
+  receivingStatus: "ready",
+  sendingStatus: "ready",
+  dnsStatus: "ready",
+  catchAllPolicy: "reject",
+  catchAllMailboxId: null,
+  isEnabled: true,
+  updatedAt: "2026-08-23T00:00:00.000Z"
+};
+
+const policies: MailboxAccessPolicies = {
+  grants: [],
+  busy: null,
+  loading: false,
+  applyMany: async () => false,
+  change: async () => undefined
+};
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("settings table switches", () => {
+  it("toggles a mailbox without opening its details sheet and disables pending changes", async () => {
+    const onOpenDetails = vi.fn();
+    const onToggle = vi.fn();
+    const table = (pendingMailboxId: string | null) => (
+      <MailboxTable
+        canManage
+        mailboxes={[mailbox]}
+        pendingMailboxId={pendingMailboxId}
+        policies={policies}
+        selectedIds={[]}
+        users={[]}
+        onOpenDetails={onOpenDetails}
+        onSelectionChange={() => undefined}
+        onToggle={onToggle}
+      />
+    );
+    const view = await renderComponent(table(null));
+    const control = view.container.querySelector<HTMLButtonElement>(
+      '[aria-label="support@example.com status"]'
+    );
+
+    expect(control?.getAttribute("role")).toBe("switch");
+    expect(control?.getAttribute("aria-checked")).toBe("true");
+    await flushHookEffects(() => control?.click());
+    expect(onToggle).toHaveBeenCalledOnce();
+    expect(onToggle).toHaveBeenCalledWith(mailbox, false);
+    expect(onOpenDetails).not.toHaveBeenCalled();
+
+    onToggle.mockClear();
+    await view.rerender(table("mailbox-2"));
+    const pendingControl = view.container.querySelector<HTMLButtonElement>(
+      '[aria-label="support@example.com status"]'
+    );
+    expect(pendingControl?.disabled).toBe(true);
+    await flushHookEffects(() => pendingControl?.click());
+    expect(onToggle).not.toHaveBeenCalled();
+    await view.unmount();
+  });
+
+  it("passes the requested domain state and disables a pending row", async () => {
+    const onToggle = vi.fn();
+    const table = (pendingDomainId: string | null) => (
+      <DomainTable domains={[domain]} pendingDomainId={pendingDomainId} onToggle={onToggle} />
+    );
+    const view = await renderComponent(table(null));
+    const control = view.container.querySelector<HTMLButtonElement>(
+      '[aria-label="example.com enabled"]'
+    );
+
+    expect(control?.getAttribute("role")).toBe("switch");
+    expect(control?.getAttribute("aria-checked")).toBe("true");
+    await flushHookEffects(() => control?.click());
+    expect(onToggle).toHaveBeenCalledWith(domain, false);
+
+    await view.rerender(table("domain-2"));
+    expect(
+      view.container.querySelector<HTMLButtonElement>('[aria-label="example.com enabled"]')
+        ?.disabled
+    ).toBe(true);
+    await view.unmount();
+  });
+});

--- a/test/unit/app/ui/dialog-interactions.test.tsx
+++ b/test/unit/app/ui/dialog-interactions.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import * as React from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { Dialog, DialogClose, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
@@ -16,24 +16,66 @@ afterEach(() => {
   document.body.replaceChildren();
 });
 
-async function openDialog() {
+type OutsideHandler = NonNullable<
+  React.ComponentProps<typeof DialogContent>["onPointerDownOutside"]
+>;
+
+async function settleOutsideListeners(): Promise<void> {
+  const tick = () =>
+    flushHookEffects(() => new Promise<void>((resolve) => window.setTimeout(resolve, 0)));
+  await tick();
+  await tick();
+}
+
+function pointerClick(target: Element): void {
+  target.dispatchEvent(
+    new PointerEvent("pointerdown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      composed: true,
+      pointerId: 1,
+      pointerType: "mouse"
+    })
+  );
+  target.dispatchEvent(
+    new MouseEvent("click", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      composed: true
+    })
+  );
+}
+
+function dialogOverlay(): HTMLElement | undefined {
+  return [...document.body.querySelectorAll<HTMLElement>('[data-state="open"]')].find((element) =>
+    element.className.includes("fixed inset-0")
+  );
+}
+
+async function openDialog(onPointerDownOutside?: OutsideHandler) {
   const view = await renderComponent(
     <Dialog defaultOpen>
-      <DialogContent>
+      <DialogContent {...(onPointerDownOutside ? { onPointerDownOutside } : {})}>
         <DialogTitle>Test dialog</DialogTitle>
         <DialogClose aria-label="Close test dialog">Close</DialogClose>
       </DialogContent>
     </Dialog>
   );
-  await flushHookEffects(() => new Promise((resolve) => setTimeout(resolve, 0)));
+  await settleOutsideListeners();
   return view;
 }
 
-function DialogWithOpenSelect(): React.ReactElement {
+function DialogWithOpenSelect({
+  onPointerDownOutside
+}: {
+  onPointerDownOutside: OutsideHandler;
+}): React.ReactElement {
   const [selectOpen, setSelectOpen] = React.useState(true);
   return (
     <Dialog defaultOpen>
-      <DialogContent>
+      <DialogContent onPointerDownOutside={onPointerDownOutside}>
         <DialogTitle>Dialog with dropdown</DialogTitle>
         <Select open={selectOpen} value="first" onOpenChange={setSelectOpen}>
           <SelectTrigger aria-label="Test dropdown">
@@ -44,9 +86,6 @@ function DialogWithOpenSelect(): React.ReactElement {
             <SelectItem value="second">Second</SelectItem>
           </SelectContent>
         </Select>
-        <button data-dialog-control type="button">
-          Another dialog control
-        </button>
         <output data-select-state>{selectOpen ? "open" : "closed"}</output>
       </DialogContent>
     </Dialog>
@@ -54,64 +93,50 @@ function DialogWithOpenSelect(): React.ReactElement {
 }
 
 describe("dialog interactions", () => {
-  it("ignores a backdrop pointer down", async () => {
-    const view = await openDialog();
-    const overlay = document.body.querySelector<HTMLElement>(
-      '[data-state="open"]:not([role="dialog"])'
-    );
+  it("ignores a backdrop click after Radix reports it", async () => {
+    const outside = vi.fn();
+    const view = await openDialog(outside);
+    const overlay = dialogOverlay();
 
-    expect(overlay).not.toBeNull();
-    await flushHookEffects(() =>
-      overlay?.dispatchEvent(
-        new PointerEvent("pointerdown", {
-          bubbles: true,
-          button: 0,
-          composed: true,
-          pointerType: "mouse"
-        })
-      )
-    );
+    expect(overlay).toBeDefined();
+    await flushHookEffects(() => pointerClick(overlay as HTMLElement));
 
+    expect(outside).toHaveBeenCalledOnce();
     expect(document.body.querySelector('[role="dialog"]')?.getAttribute("data-state")).toBe("open");
     await view.unmount();
   });
 
   it("closes a nested dropdown without closing its dialog", async () => {
-    const view = await renderComponent(<DialogWithOpenSelect />);
-    await flushHookEffects(() => new Promise((resolve) => setTimeout(resolve, 0)));
-    const dialogControl = document.body.querySelector<HTMLElement>("[data-dialog-control]");
+    const outside = vi.fn();
+    const view = await renderComponent(<DialogWithOpenSelect onPointerDownOutside={outside} />);
+    await settleOutsideListeners();
+    const overlay = dialogOverlay();
 
     expect(document.body.querySelector("[data-select-state]")?.textContent).toBe("open");
-    expect(dialogControl).not.toBeNull();
-    await flushHookEffects(() =>
-      dialogControl?.dispatchEvent(
-        new PointerEvent("pointerdown", {
-          bubbles: true,
-          button: 0,
-          composed: true,
-          pointerType: "mouse"
-        })
-      )
-    );
+    expect(overlay).toBeDefined();
+    await flushHookEffects(() => pointerClick(overlay as HTMLElement));
 
     expect(document.body.querySelector("[data-select-state]")?.textContent).toBe("closed");
+    expect(outside).toHaveBeenCalledOnce();
     expect(document.body.querySelector('[role="dialog"]')?.getAttribute("data-state")).toBe("open");
     await view.unmount();
   });
 
-  it("still closes through Escape and an explicit close control", async () => {
-    const escapeView = await openDialog();
+  it("still closes through Escape", async () => {
+    const view = await openDialog();
     await flushHookEffects(() =>
       document.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }))
     );
     expect(document.body.querySelector('[role="dialog"]')).toBeNull();
-    await escapeView.unmount();
+    await view.unmount();
+  });
 
-    const closeView = await openDialog();
+  it("still closes through an explicit close control", async () => {
+    const view = await openDialog();
     await flushHookEffects(() =>
       document.body.querySelector<HTMLButtonElement>('[aria-label="Close test dialog"]')?.click()
     );
     expect(document.body.querySelector('[role="dialog"]')).toBeNull();
-    await closeView.unmount();
+    await view.unmount();
   });
 });

--- a/test/unit/app/ui/dialog-interactions.test.tsx
+++ b/test/unit/app/ui/dialog-interactions.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+import * as React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Dialog, DialogClose, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import { flushHookEffects, renderComponent } from "../render-hook";
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+async function openDialog() {
+  const view = await renderComponent(
+    <Dialog defaultOpen>
+      <DialogContent>
+        <DialogTitle>Test dialog</DialogTitle>
+        <DialogClose aria-label="Close test dialog">Close</DialogClose>
+      </DialogContent>
+    </Dialog>
+  );
+  await flushHookEffects(() => new Promise((resolve) => setTimeout(resolve, 0)));
+  return view;
+}
+
+function DialogWithOpenSelect(): React.ReactElement {
+  const [selectOpen, setSelectOpen] = React.useState(true);
+  return (
+    <Dialog defaultOpen>
+      <DialogContent>
+        <DialogTitle>Dialog with dropdown</DialogTitle>
+        <Select open={selectOpen} value="first" onOpenChange={setSelectOpen}>
+          <SelectTrigger aria-label="Test dropdown">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="first">First</SelectItem>
+            <SelectItem value="second">Second</SelectItem>
+          </SelectContent>
+        </Select>
+        <button data-dialog-control type="button">
+          Another dialog control
+        </button>
+        <output data-select-state>{selectOpen ? "open" : "closed"}</output>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+describe("dialog interactions", () => {
+  it("ignores a backdrop pointer down", async () => {
+    const view = await openDialog();
+    const overlay = document.body.querySelector<HTMLElement>(
+      '[data-state="open"]:not([role="dialog"])'
+    );
+
+    expect(overlay).not.toBeNull();
+    await flushHookEffects(() =>
+      overlay?.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          composed: true,
+          pointerType: "mouse"
+        })
+      )
+    );
+
+    expect(document.body.querySelector('[role="dialog"]')?.getAttribute("data-state")).toBe("open");
+    await view.unmount();
+  });
+
+  it("closes a nested dropdown without closing its dialog", async () => {
+    const view = await renderComponent(<DialogWithOpenSelect />);
+    await flushHookEffects(() => new Promise((resolve) => setTimeout(resolve, 0)));
+    const dialogControl = document.body.querySelector<HTMLElement>("[data-dialog-control]");
+
+    expect(document.body.querySelector("[data-select-state]")?.textContent).toBe("open");
+    expect(dialogControl).not.toBeNull();
+    await flushHookEffects(() =>
+      dialogControl?.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          composed: true,
+          pointerType: "mouse"
+        })
+      )
+    );
+
+    expect(document.body.querySelector("[data-select-state]")?.textContent).toBe("closed");
+    expect(document.body.querySelector('[role="dialog"]')?.getAttribute("data-state")).toBe("open");
+    await view.unmount();
+  });
+
+  it("still closes through Escape and an explicit close control", async () => {
+    const escapeView = await openDialog();
+    await flushHookEffects(() =>
+      document.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }))
+    );
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+    await escapeView.unmount();
+
+    const closeView = await openDialog();
+    await flushHookEffects(() =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Close test dialog"]')?.click()
+    );
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+    await closeView.unmount();
+  });
+});

--- a/test/unit/app/ui/overlay-behavior.test.ts
+++ b/test/unit/app/ui/overlay-behavior.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const mailboxDetails = readFileSync(
+  new URL("../../../../app/features/mailboxes/mailbox-details-sheet.tsx", import.meta.url),
+  "utf8"
+);
+const tailwind = readFileSync(new URL("../../../../tailwind.config.ts", import.meta.url), "utf8");
+
+describe("overlay behavior", () => {
+  it("moves right sheets off-screen once when they close", () => {
+    expect(tailwind).toMatch(
+      /"sheet-out-right": \{\s*from: \{ transform: "translateX\(0\)" \},\s*to: \{ transform: "translateX\(100%\)" \}/
+    );
+  });
+
+  it("keeps mailbox status changes out of the details sheet", () => {
+    expect(mailboxDetails).not.toContain("Mailbox status");
+    expect(mailboxDetails).not.toContain("onToggle");
+  });
+});


### PR DESCRIPTION
Summary

- Keep dialogs open on backdrop clicks and when nested dropdowns dismiss; preserve Escape and explicit close controls.
- Correct the shared right-side drawer exit animation so drawers close once toward their edge.
- Add a shared accessible switch and use it for mailbox and domain status in their tables.
- Move mailbox enable and disable out of the details drawer, serialize row updates, and wait for refreshed state.

Canonical specification

- HQBase/hqbase-site#33

Verification

- CI=true pnpm check
- CI=true WRANGLER_LOG_PATH=/tmp/hqbase-ui-overlay-switches.log pnpm deploy:dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added enabled/disabled switches for domains and mailboxes.
  - Switches show current status, support accessibility, and are temporarily disabled while changes are saving.
  - Added success and error feedback for mailbox status updates.
  - Replaced the theme toggle with a consistent switch control.

- **Bug Fixes**
  - Prevented dialogs from closing when interacting with nested controls or the backdrop.
  - Corrected the closing animation for right-side panels.
  - Removed mailbox status controls from the mailbox details view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->