### PR TITLE
fix: keep Mail API v1 compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@
 - Give every mailbox one email address. Existing additional addresses become separate mailboxes
   with the same access and retention settings. An address that could not both send and receive
   becomes a disabled mailbox.
-- Replace Mail API v1 with Mail API v2. Mailbox responses now contain one `address` and one
-  `mailDomainId`. OAuth clients must reconnect and approve the `/api/v2` resource. Open HQBase tabs
-  must reload after the upgrade.
+- Add Mail API v2 for the direct one-address mailbox model. Keep Mail API v1 paths, OAuth grants,
+  tokens, discovery, and response schemas available for existing clients. V1 represents each
+  separate mailbox with one primary item in its compatibility `addresses` list.
 
 ## 1.2.0
 

--- a/api/hqbase-mail-api-v1.openapi.json
+++ b/api/hqbase-mail-api-v1.openapi.json
@@ -1,0 +1,3415 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "HQBase Mail API",
+    "version": "1.0.0",
+    "description": "Supported v1 compatibility API for existing HQBase clients. Each mailbox contains one primary address backed by the one-address mailbox model."
+  },
+  "servers": [
+    {
+      "url": "{origin}",
+      "variables": {
+        "origin": {
+          "default": "https://mail.example.com",
+          "description": "HQBase origin"
+        }
+      }
+    }
+  ],
+  "tags": [
+    {
+      "name": "Mailboxes"
+    },
+    {
+      "name": "Messages"
+    },
+    {
+      "name": "Changes"
+    },
+    {
+      "name": "Conversations"
+    },
+    {
+      "name": "Drafts"
+    },
+    {
+      "name": "Sending"
+    },
+    {
+      "name": "Events"
+    }
+  ],
+  "paths": {
+    "/api/v1/mailboxes": {
+      "get": {
+        "summary": "List mailboxes",
+        "security": [
+          {
+            "oauth2": ["mail:read"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mailboxes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Mailbox"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Mailboxes"],
+        "operationId": "listMailboxes"
+      }
+    },
+    "/api/v1/events": {
+      "get": {
+        "summary": "Open change event WebSocket",
+        "description": "Opens an authenticated wake-only WebSocket. The server sends `changed` frames for messages, mailboxes, and permitted drafts. Frames contain no mail data or cursors. After a frame or reconnect, read the authoritative REST resources and change journals. OAuth tokens require `mail:read`; draft frames also require `mail:send`. The authorization decision at upgrade is an event-delivery lease for 10 minutes. Credential or session revocation does not close the current socket immediately. The server closes the socket when the lease ends, and reconnection must use current credentials and permissions.",
+        "security": [
+          {
+            "oauth2": ["mail:read"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Upgrade",
+            "in": "header",
+            "required": true,
+            "description": "WebSocket upgrade request.",
+            "schema": {
+              "type": "string",
+              "const": "websocket"
+            }
+          }
+        ],
+        "responses": {
+          "101": {
+            "description": "WebSocket established. Text frames use `{\"type\":\"changed\",\"topic\":\"messages|drafts|mailboxes\"}`."
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or invalid browser origin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "426": {
+            "description": "WebSocket upgrade required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Event connection unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Events"],
+        "operationId": "openMailEvents"
+      }
+    },
+    "/api/v1/changes": {
+      "get": {
+        "summary": "Read message changes",
+        "description": "Returns a bounded page of message upserts and deletion tombstones in journal order. A request without a cursor returns an empty checkpoint at the current high-water sequence.",
+        "security": [
+          {
+            "oauth2": ["mail:read"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A bounded page of message changes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageChangePage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. `INVALID_LIMIT` when limit is not an integer from 1 to 100. `INVALID_CHANGE_CURSOR` when the cursor is malformed, foreign, or beyond the current journal. `INVALID_CHANGE_FILTER` when a mailbox, folder, or search filter is supplied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "`CHANGE_CURSOR_EXPIRED` when future journal retention removes a required range. The client must start a new full bootstrap.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Changes"],
+        "operationId": "listMessageChanges",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 512
+            },
+            "description": "Opaque cursor from a checkpoint or previous changes page. Omit it only to create a new checkpoint."
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            },
+            "description": "Maximum number of journal entries read for this page."
+          }
+        ]
+      }
+    },
+    "/api/v1/messages": {
+      "get": {
+        "summary": "List or search messages",
+        "security": [
+          {
+            "oauth2": ["mail:read"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "One page of messages, newest activity first.",
+            "headers": {
+              "Link": {
+                "required": false,
+                "description": "RFC 8288 link to the next page, as `<url>; rel=\"next\"`. The header is absent on the last page.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MessageSummary"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. `INVALID_LIMIT` when limit is not an integer from 1 to 100. `INVALID_CURSOR` when the cursor is malformed or is not a message cursor.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Messages"],
+        "operationId": "listMessages",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "folder",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["inbox", "sent", "drafts", "archived", "trash", "catchall"]
+            },
+            "description": "Message folder to list. Drafts are separate resources, not message rows. Use `/api/v1/drafts` to list drafts."
+          },
+          {
+            "in": "query",
+            "name": "mailboxId",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 100
+            },
+            "description": "Limit results to one accessible mailbox."
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "description": "Search one literal substring in the subject, sender, To recipients, snippet, and plain-text body. The characters %, _, and \\ are ordinary text."
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            },
+            "description": "Maximum number of messages in the page."
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 512
+            },
+            "description": "Opaque cursor from the previous page. Read it from the Link header and send it unchanged."
+          }
+        ]
+      }
+    },
+    "/api/v1/messages/{id}": {
+      "get": {
+        "summary": "Get a message",
+        "security": [
+          {
+            "oauth2": ["mail:read"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageDetail"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Messages"],
+        "operationId": "getMessage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        ]
+      }
+    },
+    "/api/v1/messages/{id}/thread": {
+      "get": {
+        "summary": "Get a message thread",
+        "security": [
+          {
+            "oauth2": ["mail:read"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Accessible thread messages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MessageDetail"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Messages"],
+        "operationId": "getMessageThread",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        ]
+      }
+    },
+    "/api/v1/messages/{id}/html": {
+      "get": {
+        "summary": "Get sanitized message HTML",
+        "security": [
+          {
+            "oauth2": ["mail:read"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sanitized HTML",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageHtml"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Messages"],
+        "operationId": "getMessageHtml",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          },
+          {
+            "in": "query",
+            "name": "loadRemoteImages",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "enum": [1]
+            },
+            "description": "Load remote images for this response only."
+          }
+        ]
+      }
+    },
+    "/api/v1/messages/{id}/inline/{attachmentId}": {
+      "get": {
+        "summary": "Render a safe inline image",
+        "security": [
+          {
+            "oauth2": ["mail:read"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Inline image",
+            "content": {
+              "image/*": {
+                "schema": {
+                  "type": "string",
+                  "contentEncoding": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported inline media",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Messages"],
+        "operationId": "getInlineAttachment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          },
+          {
+            "in": "path",
+            "name": "attachmentId",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        ]
+      }
+    },
+    "/api/v1/attachments/{id}": {
+      "get": {
+        "summary": "Download an attachment",
+        "security": [
+          {
+            "oauth2": ["mail:read"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Attachment",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "contentEncoding": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Messages"],
+        "operationId": "getAttachment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        ]
+      }
+    },
+    "/api/v1/messages/{id}/remote-media/trust": {
+      "post": {
+        "summary": "Trust remote media from this sender",
+        "security": [
+          {
+            "oauth2": ["mail:write"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trust preference",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemoteMediaTrust"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Messages"],
+        "operationId": "trustRemoteMedia",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        ]
+      }
+    },
+    "/api/v1/messages/{id}/{action}": {
+      "post": {
+        "summary": "Update message state",
+        "security": [
+          {
+            "oauth2": ["mail:write"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageSummary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Messages"],
+        "operationId": "updateMessage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          },
+          {
+            "in": "path",
+            "name": "action",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "read",
+                "unread",
+                "star",
+                "unstar",
+                "archive",
+                "unarchive",
+                "trash",
+                "restore"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "/api/v1/conversations": {
+      "get": {
+        "summary": "List or search conversations",
+        "security": [
+          {
+            "oauth2": ["mail:read"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Conversation page",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationPage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Conversations"],
+        "operationId": "listConversations",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "folder",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["inbox", "sent", "starred", "archived", "trash", "catchall"]
+            },
+            "description": "Folder to list."
+          },
+          {
+            "in": "query",
+            "name": "mailboxId",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 100
+            },
+            "description": "Limit results to one accessible mailbox."
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "description": "Search one literal substring in the subject, sender, To recipients, snippet, and plain-text body. The characters %, _, and \\ are ordinary text."
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 512
+            },
+            "description": "Opaque cursor from the previous page."
+          }
+        ]
+      }
+    },
+    "/api/v1/conversations/{id}/{action}": {
+      "post": {
+        "summary": "Update conversation state",
+        "description": "Applies the action to the accessible part of the conversation identified by the message {id}.",
+        "security": [
+          {
+            "oauth2": ["mail:write"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationActionResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Conversations"],
+        "operationId": "updateConversation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "description": "Use ConversationSummary.id, the ID of the latest accessible message in the conversation. Do not use threadId. A thread ID does not identify a message and returns 403 MAILBOX_FORBIDDEN.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          },
+          {
+            "in": "path",
+            "name": "action",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "read",
+                "unread",
+                "star",
+                "unstar",
+                "archive",
+                "unarchive",
+                "trash",
+                "restore"
+              ]
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConversationActionInput"
+              },
+              "example": {
+                "folder": "inbox"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/drafts": {
+      "get": {
+        "summary": "List drafts",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "One page of drafts, newest update first.",
+            "headers": {
+              "Link": {
+                "required": false,
+                "description": "RFC 8288 link to the next page, as `<url>; rel=\"next\"`. The header is absent on the last page.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Draft"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. `INVALID_LIMIT` when limit is not an integer from 1 to 100. `INVALID_DRAFT_CURSOR` when the cursor is malformed or is not a draft-list cursor.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Drafts"],
+        "operationId": "listDrafts",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            },
+            "description": "Maximum number of draft rows read for this page. Live access filtering can make the returned array shorter."
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 512
+            },
+            "description": "Opaque cursor from the previous page. Read it from the Link header and send it unchanged."
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create a draft",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created draft",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Draft"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Drafts"],
+        "operationId": "createDraft",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DraftInput"
+              },
+              "example": {
+                "mailboxId": null,
+                "replyToMessageId": null,
+                "forwardOfMessageId": null,
+                "from": "",
+                "to": [],
+                "cc": [],
+                "bcc": [],
+                "subject": "",
+                "text": "",
+                "html": ""
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/drafts/changes": {
+      "get": {
+        "summary": "Read draft changes",
+        "description": "Returns a bounded page of private draft upserts and deletion tombstones in journal order. A request without a cursor returns an empty checkpoint at the current user-specific high-water sequence.",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A bounded page of draft changes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DraftChangePage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. `INVALID_LIMIT` when limit is not an integer from 1 to 100. `INVALID_DRAFT_CHANGE_CURSOR` when the cursor is malformed, foreign, or beyond the user's current journal. `INVALID_DRAFT_CHANGE_FILTER` when a mailbox, folder, search, or timestamp filter is supplied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "`DRAFT_CHANGE_CURSOR_EXPIRED` when future journal retention removes a required range. The client must start a new full draft bootstrap.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Drafts"],
+        "operationId": "listDraftChanges",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 512
+            },
+            "description": "Opaque cursor from a draft checkpoint or previous draft-changes page. Omit it only to create a new checkpoint."
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            },
+            "description": "Maximum number of draft journal entries read for this page."
+          }
+        ]
+      }
+    },
+    "/api/v1/drafts/{id}": {
+      "get": {
+        "summary": "Get a draft",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Draft",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Draft"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Drafts"],
+        "operationId": "getDraft",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        ]
+      },
+      "patch": {
+        "summary": "Update a draft",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated draft",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Draft"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Draft version conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Drafts"],
+        "operationId": "updateDraft",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DraftInput"
+              },
+              "example": {
+                "mailboxId": null,
+                "replyToMessageId": null,
+                "forwardOfMessageId": null,
+                "from": "",
+                "to": [],
+                "cc": [],
+                "bcc": [],
+                "subject": "Updated draft",
+                "text": "",
+                "html": "",
+                "version": 1
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a draft",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Draft deleted"
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Drafts"],
+        "operationId": "deleteDraft",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        ]
+      }
+    },
+    "/api/v1/drafts/{id}/attachments": {
+      "post": {
+        "summary": "Add a draft attachment",
+        "description": "Records the file part's Content-Type, or application/octet-stream when no type is present. One file and all files in one draft can each total at most 25 MiB; larger uploads return 413 ATTACHMENTS_TOO_LARGE.",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Added attachment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DraftAttachment"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "File or draft attachment total exceeds 25 MiB",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Drafts"],
+        "operationId": "addDraftAttachment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["file"],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "contentEncoding": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "file": {
+                  "contentType": "*/*"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/drafts/{draftId}/attachments/{id}": {
+      "delete": {
+        "summary": "Remove a draft attachment",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Attachment removed"
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Drafts"],
+        "operationId": "removeDraftAttachment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "draftId",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        ]
+      }
+    },
+    "/api/v1/send": {
+      "post": {
+        "summary": "Send a new message",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Sent message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageSummary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Sending"],
+        "operationId": "sendMessage",
+        "description": "Not idempotent. Do not retry blindly.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendInput"
+              },
+              "example": {
+                "from": "support@example.com",
+                "to": ["person@example.net"],
+                "cc": [],
+                "bcc": [],
+                "subject": "Hello",
+                "text": "Hello from HQBase",
+                "attachmentIds": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/reply": {
+      "post": {
+        "summary": "Reply to a message",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Sent reply",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageSummary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Sending"],
+        "operationId": "replyToMessage",
+        "description": "Not idempotent. Do not retry blindly.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReplyInput"
+              },
+              "example": {
+                "messageId": "msg_example",
+                "from": "support@example.com",
+                "cc": [],
+                "bcc": [],
+                "text": "Thanks for your message.",
+                "attachmentIds": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/forward": {
+      "post": {
+        "summary": "Forward a message",
+        "security": [
+          {
+            "oauth2": ["mail:send"]
+          },
+          {
+            "cookieSession": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Sent forward",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageSummary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient OAuth scope or mailbox access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found or not visible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Sending"],
+        "operationId": "forwardMessage",
+        "description": "Not idempotent. Do not retry blindly. Set includeOriginalAttachments to false to omit the source message's attachments.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ForwardInput"
+              },
+              "example": {
+                "messageId": "msg_example",
+                "from": "support@example.com",
+                "to": ["person@example.net"],
+                "cc": [],
+                "bcc": [],
+                "text": "Please review this message.",
+                "attachmentIds": [],
+                "includeOriginalAttachments": true
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2": {
+        "type": "oauth2",
+        "description": "Audience-bound OAuth token. Request resource={origin}/api/v1.",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "/api/auth/oauth2/authorize",
+            "tokenUrl": "/api/auth/oauth2/token",
+            "refreshUrl": "/api/auth/oauth2/token",
+            "scopes": {
+              "mail:read": "Read accessible mail",
+              "mail:write": "Organize accessible mail",
+              "mail:send": "Manage drafts and send mail",
+              "offline_access": "Request a refresh token"
+            }
+          }
+        }
+      },
+      "cookieSession": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "better-auth.session_token",
+        "description": "Same-origin HQBase web session. Secure deployments may prefix the cookie name."
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "message"],
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "Mailbox": {
+        "type": "object",
+        "required": [
+          "id",
+          "address",
+          "addresses",
+          "displayName",
+          "isActive",
+          "accessLevel",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string",
+            "format": "email"
+          },
+          "addresses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MailboxAddress"
+            },
+            "minItems": 1,
+            "maxItems": 1
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "accessLevel": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["read", "agent", "manager"]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "MessageSummary": {
+        "type": "object",
+        "required": [
+          "id",
+          "threadId",
+          "mailboxId",
+          "direction",
+          "folder",
+          "fromAddress",
+          "to",
+          "subject",
+          "snippet",
+          "receivedAt",
+          "sentAt",
+          "readAt",
+          "starredAt",
+          "hasAttachments",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "mailboxId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "direction": {
+            "type": "string",
+            "enum": ["inbound", "outbound"]
+          },
+          "folder": {
+            "type": "string",
+            "enum": ["inbox", "sent", "drafts", "archived", "trash", "catchall"],
+            "description": "Stored message folder. Drafts use the separate Draft schema and endpoints; current write paths do not produce message summaries with `folder: drafts`."
+          },
+          "fromAddress": {
+            "type": "string",
+            "format": "email"
+          },
+          "to": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subject": {
+            "type": "string"
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "receivedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sentAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "readAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "starredAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hasAttachments": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "MessageChangeUpsert": {
+        "type": "object",
+        "required": ["type", "message"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "upsert"
+          },
+          "message": {
+            "$ref": "#/components/schemas/MessageSummary"
+          }
+        }
+      },
+      "MessageChangeDelete": {
+        "type": "object",
+        "required": ["type", "messageId", "mailboxId"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "delete"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "mailboxId": {
+            "description": "The mailbox at deletion, or null for owner-only unassigned mail.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "MessageChange": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/MessageChangeUpsert"
+          },
+          {
+            "$ref": "#/components/schemas/MessageChangeDelete"
+          }
+        ]
+      },
+      "MessageChangePage": {
+        "type": "object",
+        "required": ["changes", "nextCursor", "hasMore"],
+        "properties": {
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MessageChange"
+            }
+          },
+          "nextCursor": {
+            "type": "string"
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Attachment": {
+        "type": "object",
+        "required": [
+          "id",
+          "messageId",
+          "filename",
+          "contentType",
+          "sizeBytes",
+          "contentId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "sizeBytes": {
+            "type": "integer"
+          },
+          "contentId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "MessageDetail": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/MessageSummary"
+          },
+          {
+            "type": "object",
+            "required": [
+              "cc",
+              "bcc",
+              "deliveredToAddress",
+              "textBody",
+              "htmlAvailable",
+              "messageId",
+              "inReplyTo",
+              "references",
+              "attachments"
+            ],
+            "properties": {
+              "cc": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "bcc": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deliveredToAddress": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "textBody": {
+                "type": "string"
+              },
+              "htmlAvailable": {
+                "type": "boolean"
+              },
+              "messageId": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "inReplyTo": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "references": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "attachments": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Attachment"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "MessageHtml": {
+        "type": "object",
+        "required": [
+          "afterQuotedHtml",
+          "hasRemoteImages",
+          "html",
+          "quotedHtml",
+          "remoteMediaTrusted"
+        ],
+        "properties": {
+          "afterQuotedHtml": {
+            "description": "Sanitized authored content that follows quoted reply history, or null when absent.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hasRemoteImages": {
+            "type": "boolean"
+          },
+          "html": {
+            "type": "string"
+          },
+          "quotedHtml": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "remoteMediaTrusted": {
+            "type": "boolean"
+          }
+        }
+      },
+      "RemoteMediaTrust": {
+        "type": "object",
+        "required": ["remoteMediaTrusted"],
+        "properties": {
+          "remoteMediaTrusted": {
+            "type": "boolean",
+            "const": true
+          }
+        }
+      },
+      "ConversationSummary": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/MessageSummary"
+          },
+          {
+            "type": "object",
+            "required": ["isStarred", "messageCount", "unreadCount"],
+            "properties": {
+              "isStarred": {
+                "type": "boolean"
+              },
+              "messageCount": {
+                "type": "integer"
+              },
+              "unreadCount": {
+                "type": "integer"
+              }
+            }
+          }
+        ]
+      },
+      "ConversationPage": {
+        "type": "object",
+        "required": ["conversations", "nextCursor", "totalCount"],
+        "properties": {
+          "conversations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConversationSummary"
+            }
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "totalCount": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "ConversationActionInput": {
+        "type": "object",
+        "required": ["folder"],
+        "properties": {
+          "folder": {
+            "type": "string",
+            "enum": ["inbox", "sent", "starred", "archived", "trash", "catchall"]
+          }
+        }
+      },
+      "ConversationActionResult": {
+        "type": "object",
+        "required": ["affected", "threadId"],
+        "properties": {
+          "affected": {
+            "type": "integer"
+          },
+          "threadId": {
+            "type": "string"
+          }
+        }
+      },
+      "DraftAttachment": {
+        "type": "object",
+        "required": ["id", "filename", "contentType", "sizeBytes"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "sizeBytes": {
+            "type": "integer"
+          }
+        }
+      },
+      "DraftInput": {
+        "type": "object",
+        "required": [
+          "mailboxId",
+          "replyToMessageId",
+          "forwardOfMessageId",
+          "from",
+          "to",
+          "cc",
+          "bcc",
+          "subject",
+          "text",
+          "html"
+        ],
+        "properties": {
+          "mailboxId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "replyToMessageId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "forwardOfMessageId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cc": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "bcc": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subject": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "text": {
+            "type": "string",
+            "maxLength": 100000
+          },
+          "html": {
+            "type": "string",
+            "maxLength": 200000
+          },
+          "version": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "Draft": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DraftInput"
+          },
+          {
+            "type": "object",
+            "required": ["id", "version", "updatedAt", "attachments"],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "version": {
+                "type": "integer"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "attachments": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DraftAttachment"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "DraftChangeUpsert": {
+        "type": "object",
+        "required": ["type", "draft"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "upsert"
+          },
+          "draft": {
+            "$ref": "#/components/schemas/Draft"
+          }
+        }
+      },
+      "DraftChangeDelete": {
+        "type": "object",
+        "required": ["type", "draftId"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "delete"
+          },
+          "draftId": {
+            "type": "string"
+          }
+        }
+      },
+      "DraftChange": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DraftChangeUpsert"
+          },
+          {
+            "$ref": "#/components/schemas/DraftChangeDelete"
+          }
+        ]
+      },
+      "DraftChangePage": {
+        "type": "object",
+        "required": ["changes", "nextCursor", "hasMore"],
+        "properties": {
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DraftChange"
+            }
+          },
+          "nextCursor": {
+            "type": "string"
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SendInput": {
+        "type": "object",
+        "required": ["from", "to", "subject", "text"],
+        "properties": {
+          "from": {
+            "type": "string",
+            "format": "email"
+          },
+          "to": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "maxItems": 50
+          },
+          "cc": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50
+          },
+          "bcc": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50
+          },
+          "subject": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100000
+          },
+          "html": {
+            "type": "string",
+            "maxLength": 200000
+          },
+          "attachmentIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 20
+          },
+          "draftId": {
+            "type": "string"
+          }
+        }
+      },
+      "ReplyInput": {
+        "type": "object",
+        "required": ["messageId", "from", "text"],
+        "properties": {
+          "messageId": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string",
+            "format": "email"
+          },
+          "to": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50
+          },
+          "cc": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50
+          },
+          "bcc": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100000
+          },
+          "html": {
+            "type": "string",
+            "maxLength": 200000
+          },
+          "attachmentIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 20
+          },
+          "draftId": {
+            "type": "string"
+          }
+        }
+      },
+      "ForwardInput": {
+        "type": "object",
+        "required": ["messageId", "from", "to"],
+        "properties": {
+          "messageId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "from": {
+            "type": "string",
+            "format": "email"
+          },
+          "to": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "minItems": 1,
+            "maxItems": 50
+          },
+          "cc": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "maxItems": 50,
+            "default": []
+          },
+          "bcc": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "maxItems": 50,
+            "default": []
+          },
+          "subject": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+          },
+          "text": {
+            "type": "string",
+            "maxLength": 100000,
+            "default": ""
+          },
+          "html": {
+            "type": "string",
+            "maxLength": 200000
+          },
+          "attachmentIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            },
+            "maxItems": 20,
+            "default": []
+          },
+          "includeOriginalAttachments": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "MailboxAddress": {
+        "type": "object",
+        "required": [
+          "id",
+          "mailboxId",
+          "mailDomainId",
+          "address",
+          "displayName",
+          "receiveEnabled",
+          "sendEnabled",
+          "isPrimary"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "mailboxId": {
+            "type": "string"
+          },
+          "mailDomainId": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string",
+            "format": "email"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "receiveEnabled": {
+            "type": "boolean"
+          },
+          "sendEnabled": {
+            "type": "boolean"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/hqbase-mail-api-v1.postman_collection.json
+++ b/api/hqbase-mail-api-v1.postman_collection.json
@@ -1,8 +1,8 @@
 {
   "info": {
-    "_postman_id": "72c6dbf4-835d-4a3f-87df-77b7ddcf2db2",
-    "name": "HQBase Mail API v2",
-    "description": "Generated from api/hqbase-mail-api-v2.openapi.json. For a tool acting for a person, set base_url, run Register public client, and use Postman's OAuth 2.0 Authorization Code flow with PKCE (S256). Auth URL: {{base_url}}/api/auth/oauth2/authorize. Token URL: {{base_url}}/api/auth/oauth2/token. Client ID: {{client_id}}. Scope: mail:read mail:write mail:send offline_access. Add authorization request parameter resource={{api_resource}}, then store the resulting token only in your local environment as access_token. For a mailbox agent, skip OAuth and set access_token to its one-time hqb_agent_ credential. Postman v2.1 HTTP collections cannot contain WebSocket requests. To receive change wakes, create a separate WebSocket request to {{ws_base_url}}/api/v2/events and add Authorization: Bearer {{access_token}}. Sending, replying, and forwarding are not idempotent.",
+    "_postman_id": "62c6dbf4-835d-4a3f-87df-77b7ddcf2db1",
+    "name": "HQBase Mail API v1",
+    "description": "Generated from api/hqbase-mail-api-v1.openapi.json. For a tool acting for a person, set base_url, run Register public client, and use Postman's OAuth 2.0 Authorization Code flow with PKCE (S256). Auth URL: {{base_url}}/api/auth/oauth2/authorize. Token URL: {{base_url}}/api/auth/oauth2/token. Client ID: {{client_id}}. Scope: mail:read mail:write mail:send offline_access. Add authorization request parameter resource={{api_resource}}, then store the resulting token only in your local environment as access_token. Postman v2.1 HTTP collections cannot contain WebSocket requests. To receive change wakes, create a separate WebSocket request to {{ws_base_url}}/api/v1/events and add Authorization: Bearer {{access_token}}. Sending, replying, and forwarding are not idempotent.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "auth": {
@@ -28,7 +28,7 @@
     },
     {
       "key": "api_resource",
-      "value": "{{base_url}}/api/v2",
+      "value": "{{base_url}}/api/v1",
       "type": "string"
     },
     {
@@ -89,7 +89,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/.well-known/oauth-protected-resource/api/v2"
+              "raw": "{{base_url}}/.well-known/oauth-protected-resource/api/v1"
             }
           },
           "response": []
@@ -146,7 +146,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/mailboxes",
+              "raw": "{{base_url}}/api/v1/mailboxes",
               "variable": []
             },
             "description": "List mailboxes"
@@ -164,7 +164,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/changes",
+              "raw": "{{base_url}}/api/v1/changes",
               "variable": [],
               "query": [
                 {
@@ -196,14 +196,14 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/messages",
+              "raw": "{{base_url}}/api/v1/messages",
               "variable": [],
               "query": [
                 {
                   "key": "folder",
                   "value": "inbox",
                   "disabled": false,
-                  "description": "Message folder to list. Drafts are separate resources, not message rows. Use `/api/v2/drafts` to list drafts."
+                  "description": "Message folder to list. Drafts are separate resources, not message rows. Use `/api/v1/drafts` to list drafts."
                 },
                 {
                   "key": "mailboxId",
@@ -241,7 +241,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/messages/:id",
+              "raw": "{{base_url}}/api/v1/messages/:id",
               "variable": [
                 {
                   "key": "id",
@@ -259,7 +259,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/messages/:id/thread",
+              "raw": "{{base_url}}/api/v1/messages/:id/thread",
               "variable": [
                 {
                   "key": "id",
@@ -277,7 +277,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/messages/:id/html",
+              "raw": "{{base_url}}/api/v1/messages/:id/html",
               "variable": [
                 {
                   "key": "id",
@@ -303,7 +303,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/messages/:id/inline/:attachmentId",
+              "raw": "{{base_url}}/api/v1/messages/:id/inline/:attachmentId",
               "variable": [
                 {
                   "key": "id",
@@ -325,7 +325,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/attachments/:id",
+              "raw": "{{base_url}}/api/v1/attachments/:id",
               "variable": [
                 {
                   "key": "id",
@@ -343,7 +343,7 @@
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/messages/:id/remote-media/trust",
+              "raw": "{{base_url}}/api/v1/messages/:id/remote-media/trust",
               "variable": [
                 {
                   "key": "id",
@@ -361,7 +361,7 @@
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/messages/:id/:action",
+              "raw": "{{base_url}}/api/v1/messages/:id/:action",
               "variable": [
                 {
                   "key": "id",
@@ -388,7 +388,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/conversations",
+              "raw": "{{base_url}}/api/v1/conversations",
               "variable": [],
               "query": [
                 {
@@ -432,7 +432,7 @@
               }
             ],
             "url": {
-              "raw": "{{base_url}}/api/v2/conversations/:id/:action",
+              "raw": "{{base_url}}/api/v1/conversations/:id/:action",
               "variable": [
                 {
                   "key": "id",
@@ -468,7 +468,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/drafts",
+              "raw": "{{base_url}}/api/v1/drafts",
               "variable": [],
               "query": [
                 {
@@ -500,7 +500,7 @@
               }
             ],
             "url": {
-              "raw": "{{base_url}}/api/v2/drafts",
+              "raw": "{{base_url}}/api/v1/drafts",
               "variable": []
             },
             "description": "Create a draft",
@@ -522,7 +522,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/drafts/changes",
+              "raw": "{{base_url}}/api/v1/drafts/changes",
               "variable": [],
               "query": [
                 {
@@ -549,7 +549,7 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/drafts/:id",
+              "raw": "{{base_url}}/api/v1/drafts/:id",
               "variable": [
                 {
                   "key": "id",
@@ -572,7 +572,7 @@
               }
             ],
             "url": {
-              "raw": "{{base_url}}/api/v2/drafts/:id",
+              "raw": "{{base_url}}/api/v1/drafts/:id",
               "variable": [
                 {
                   "key": "id",
@@ -599,7 +599,7 @@
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/drafts/:id",
+              "raw": "{{base_url}}/api/v1/drafts/:id",
               "variable": [
                 {
                   "key": "id",
@@ -617,7 +617,7 @@
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/drafts/:id/attachments",
+              "raw": "{{base_url}}/api/v1/drafts/:id/attachments",
               "variable": [
                 {
                   "key": "id",
@@ -645,7 +645,7 @@
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/v2/drafts/:draftId/attachments/:id",
+              "raw": "{{base_url}}/api/v1/drafts/:draftId/attachments/:id",
               "variable": [
                 {
                   "key": "draftId",
@@ -677,7 +677,7 @@
               }
             ],
             "url": {
-              "raw": "{{base_url}}/api/v2/send",
+              "raw": "{{base_url}}/api/v1/send",
               "variable": []
             },
             "description": "Not idempotent. Do not retry blindly.",
@@ -704,7 +704,7 @@
               }
             ],
             "url": {
-              "raw": "{{base_url}}/api/v2/reply",
+              "raw": "{{base_url}}/api/v1/reply",
               "variable": []
             },
             "description": "Not idempotent. Do not retry blindly.",
@@ -731,7 +731,7 @@
               }
             ],
             "url": {
-              "raw": "{{base_url}}/api/v2/forward",
+              "raw": "{{base_url}}/api/v1/forward",
               "variable": []
             },
             "description": "Not idempotent. Do not retry blindly. Set includeOriginalAttachments to false to omit the source message's attachments.",

--- a/api/hqbase-mail-api-v1.postman_environment.json
+++ b/api/hqbase-mail-api-v1.postman_environment.json
@@ -1,6 +1,6 @@
 {
-  "id": "1757b49e-e97e-4ef6-bef1-e3b5f06ac107",
-  "name": "HQBase Mail API v2 - local secrets",
+  "id": "0757b49e-e97e-4ef6-bef1-e3b5f06ac106",
+  "name": "HQBase Mail API v1 - local secrets",
   "values": [
     {
       "key": "base_url",
@@ -16,7 +16,7 @@
     },
     {
       "key": "api_resource",
-      "value": "{{base_url}}/api/v2",
+      "value": "{{base_url}}/api/v1",
       "enabled": true,
       "type": "default"
     },

--- a/migrations-after-deploy/0001_remove_mailbox_alias_storage.sql
+++ b/migrations-after-deploy/0001_remove_mailbox_alias_storage.sql
@@ -86,11 +86,6 @@ ALTER TABLE messages DROP COLUMN sent_from_address_id;
 DROP TABLE mailbox_addresses;
 DROP TABLE mailbox_address_migration;
 
--- Better Auth seeds resources in insert-only mode. Remove the retired v1 resource and its
--- per-client links. Existing clients can reconnect and approve the v2 audience.
-DELETE FROM oauthResource
-WHERE identifier LIKE '%/api/v1';
-
 UPDATE release_state
 SET installed_schema_version = 3,
     updated_at = datetime('now')

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:integration": "vitest run --config vitest.worker.config.ts",
     "test:coverage": "vitest run --config vitest.config.ts --coverage",
     "test:architecture": "node scripts/check-architecture.mjs",
-    "api:generate": "node scripts/generate-mail-api-artifacts.mjs --write && biome format --write api/hqbase-mail-api-v2.openapi.json api/hqbase-mail-api-v2.postman_collection.json api/hqbase-mail-api-v2.postman_environment.json",
+    "api:generate": "node scripts/generate-mail-api-artifacts.mjs --write && biome format --write api/hqbase-mail-api-v1.openapi.json api/hqbase-mail-api-v1.postman_collection.json api/hqbase-mail-api-v1.postman_environment.json api/hqbase-mail-api-v2.openapi.json api/hqbase-mail-api-v2.postman_collection.json api/hqbase-mail-api-v2.postman_environment.json",
     "api:check": "node scripts/generate-mail-api-artifacts.mjs --check",
     "test:pwa": "node scripts/test-pwa.mjs",
     "test:e2e:staging": "playwright test --config playwright.config.ts app-shell-smoke.spec.ts lifecycle.spec.ts",

--- a/scripts/generate-mail-api-artifacts.mjs
+++ b/scripts/generate-mail-api-artifacts.mjs
@@ -3,14 +3,19 @@ import path from "node:path";
 
 const outputDirectory = "api";
 const openApiLocation = path.join(outputDirectory, "hqbase-mail-api-v2.openapi.json");
-const openApiDocument = withAgentAuthentication(
+const v2OpenApiDocument = withAgentAuthentication(
   JSON.parse(await readFile(openApiLocation, "utf8"))
 );
-validateOpenApi(openApiDocument);
+const v1OpenApiDocument = withV1Compatibility(v2OpenApiDocument);
+validateOpenApi(v1OpenApiDocument, 1);
+validateOpenApi(v2OpenApiDocument, 2);
 const outputs = {
-  "hqbase-mail-api-v2.openapi.json": openApiDocument,
-  "hqbase-mail-api-v2.postman_collection.json": buildCollection(openApiDocument),
-  "hqbase-mail-api-v2.postman_environment.json": buildEnvironment()
+  "hqbase-mail-api-v1.openapi.json": v1OpenApiDocument,
+  "hqbase-mail-api-v1.postman_collection.json": buildCollection(v1OpenApiDocument, 1),
+  "hqbase-mail-api-v1.postman_environment.json": buildEnvironment(1),
+  "hqbase-mail-api-v2.openapi.json": v2OpenApiDocument,
+  "hqbase-mail-api-v2.postman_collection.json": buildCollection(v2OpenApiDocument, 2),
+  "hqbase-mail-api-v2.postman_environment.json": buildEnvironment(2)
 };
 const serialized = Object.fromEntries(
   Object.entries(outputs).map(([name, value]) => [name, `${JSON.stringify(value, null, 2)}\n`])
@@ -41,12 +46,13 @@ if (process.argv.includes("--write")) {
   console.log("Verified generated HQBase Mail API artifacts.");
 }
 
-function buildCollection(document) {
+function buildCollection(document, version) {
+  const apiBasePath = `/api/v${version}`;
   const folders = new Map();
   for (const [route, pathItem] of Object.entries(document.paths)) {
     // Postman v2.1 HTTP collections cannot contain a real WebSocket request.
     // Keep the socket in OpenAPI and provide manual connection details below.
-    if (route === "/api/v2/events") continue;
+    if (route === `${apiBasePath}/events`) continue;
     for (const method of ["get", "post", "patch", "delete"]) {
       const operation = pathItem[method];
       if (!operation) continue;
@@ -59,10 +65,12 @@ function buildCollection(document) {
 
   return {
     info: {
-      _postman_id: "62c6dbf4-835d-4a3f-87df-77b7ddcf2db1",
-      name: "HQBase Mail API v2",
-      description:
-        "Generated from api/hqbase-mail-api-v2.openapi.json. For a tool acting for a person, set base_url, run Register public client, and use Postman's OAuth 2.0 Authorization Code flow with PKCE (S256). Auth URL: {{base_url}}/api/auth/oauth2/authorize. Token URL: {{base_url}}/api/auth/oauth2/token. Client ID: {{client_id}}. Scope: mail:read mail:write mail:send offline_access. Add authorization request parameter resource={{api_resource}}, then store the resulting token only in your local environment as access_token. For a mailbox agent, skip OAuth and set access_token to its one-time hqb_agent_ credential. Postman v2.1 HTTP collections cannot contain WebSocket requests. To receive change wakes, create a separate WebSocket request to {{ws_base_url}}/api/v2/events and add Authorization: Bearer {{access_token}}. Sending, replying, and forwarding are not idempotent.",
+      _postman_id:
+        version === 1
+          ? "62c6dbf4-835d-4a3f-87df-77b7ddcf2db1"
+          : "72c6dbf4-835d-4a3f-87df-77b7ddcf2db2",
+      name: `HQBase Mail API v${version}`,
+      description: `Generated from api/hqbase-mail-api-v${version}.openapi.json. For a tool acting for a person, set base_url, run Register public client, and use Postman's OAuth 2.0 Authorization Code flow with PKCE (S256). Auth URL: {{base_url}}/api/auth/oauth2/authorize. Token URL: {{base_url}}/api/auth/oauth2/token. Client ID: {{client_id}}. Scope: mail:read mail:write mail:send offline_access. Add authorization request parameter resource={{api_resource}}, then store the resulting token only in your local environment as access_token.${version === 2 ? " For a mailbox agent, skip OAuth and set access_token to its one-time hqb_agent_ credential." : ""} Postman v2.1 HTTP collections cannot contain WebSocket requests. To receive change wakes, create a separate WebSocket request to {{ws_base_url}}${apiBasePath}/events and add Authorization: Bearer {{access_token}}. Sending, replying, and forwarding are not idempotent.`,
       schema: "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
     },
     auth: {
@@ -72,7 +80,7 @@ function buildCollection(document) {
     variable: [
       { key: "base_url", value: "https://mail.example.com", type: "string" },
       { key: "ws_base_url", value: "wss://mail.example.com", type: "string" },
-      { key: "api_resource", value: "{{base_url}}/api/v2", type: "string" },
+      { key: "api_resource", value: `{{base_url}}${apiBasePath}`, type: "string" },
       { key: "client_id", value: "", type: "string" },
       { key: "access_token", value: "", type: "string" },
       { key: "id", value: "msg_example", type: "string" },
@@ -80,8 +88,81 @@ function buildCollection(document) {
       { key: "draftId", value: "drf_example", type: "string" },
       { key: "action", value: "read", type: "string" }
     ],
-    item: [oauthSetupFolder(), ...folders.values()]
+    item: [oauthSetupFolder(version), ...folders.values()]
   };
+}
+
+function withV1Compatibility(document) {
+  const result = JSON.parse(JSON.stringify(document).replaceAll("/api/v2", "/api/v1"));
+  result.info.version = "1.0.0";
+  result.info.description =
+    "Supported v1 compatibility API for existing HQBase clients. Each mailbox contains one primary address backed by the one-address mailbox model.";
+
+  delete result.components.securitySchemes.agentBearer;
+  for (const pathItem of Object.values(result.paths ?? {})) {
+    for (const method of ["get", "post", "patch", "delete"]) {
+      const operation = pathItem[method];
+      if (!operation) continue;
+      operation.security = (operation.security ?? []).filter(
+        (requirement) => !("agentBearer" in requirement)
+      );
+      delete operation["x-hqbase-agent-capabilities"];
+    }
+  }
+
+  const current = result.components.schemas.Mailbox.properties;
+  result.components.schemas.Mailbox = {
+    type: "object",
+    required: [
+      "id",
+      "address",
+      "addresses",
+      "displayName",
+      "isActive",
+      "accessLevel",
+      "createdAt",
+      "updatedAt"
+    ],
+    properties: {
+      id: current.id,
+      address: current.address,
+      addresses: {
+        type: "array",
+        items: { $ref: "#/components/schemas/MailboxAddress" },
+        minItems: 1,
+        maxItems: 1
+      },
+      displayName: current.displayName,
+      isActive: current.isActive,
+      accessLevel: current.accessLevel,
+      createdAt: current.createdAt,
+      updatedAt: current.updatedAt
+    }
+  };
+  result.components.schemas.MailboxAddress = {
+    type: "object",
+    required: [
+      "id",
+      "mailboxId",
+      "mailDomainId",
+      "address",
+      "displayName",
+      "receiveEnabled",
+      "sendEnabled",
+      "isPrimary"
+    ],
+    properties: {
+      id: { type: "string" },
+      mailboxId: { type: "string" },
+      mailDomainId: { type: "string" },
+      address: { type: "string", format: "email" },
+      displayName: { type: "string" },
+      receiveEnabled: { type: "boolean" },
+      sendEnabled: { type: "boolean" },
+      isPrimary: { type: "boolean" }
+    }
+  };
+  return result;
 }
 
 function withAgentAuthentication(document) {
@@ -115,21 +196,22 @@ function withAgentAuthentication(document) {
   return result;
 }
 
-function validateOpenApi(document) {
-  if (document.openapi !== "3.1.0" || document.info?.version !== "2.0.0") {
-    throw new Error("The Mail API contract must remain an OpenAPI 3.1 v2 document.");
+function validateOpenApi(document, version) {
+  if (document.openapi !== "3.1.0" || document.info?.version !== `${version}.0.0`) {
+    throw new Error(`The Mail API v${version} contract must remain OpenAPI 3.1.`);
   }
+  const apiBasePath = `/api/v${version}`;
   const requiredPaths = [
-    "/api/v2/mailboxes",
-    "/api/v2/messages",
-    "/api/v2/changes",
-    "/api/v2/events",
-    "/api/v2/conversations",
-    "/api/v2/drafts",
-    "/api/v2/drafts/changes",
-    "/api/v2/send",
-    "/api/v2/reply",
-    "/api/v2/forward"
+    `${apiBasePath}/mailboxes`,
+    `${apiBasePath}/messages`,
+    `${apiBasePath}/changes`,
+    `${apiBasePath}/events`,
+    `${apiBasePath}/conversations`,
+    `${apiBasePath}/drafts`,
+    `${apiBasePath}/drafts/changes`,
+    `${apiBasePath}/send`,
+    `${apiBasePath}/reply`,
+    `${apiBasePath}/forward`
   ];
   for (const route of requiredPaths) {
     if (!document.paths?.[route]) throw new Error(`Mail API contract is missing ${route}.`);
@@ -139,7 +221,7 @@ function validateOpenApi(document) {
   }
 }
 
-function oauthSetupFolder() {
+function oauthSetupFolder(version) {
   return {
     name: "OAuth setup",
     item: [
@@ -151,7 +233,7 @@ function oauthSetupFolder() {
       simpleRequest(
         "Mail API protected-resource metadata",
         "GET",
-        "{{base_url}}/.well-known/oauth-protected-resource/api/v2"
+        `{{base_url}}/.well-known/oauth-protected-resource/api/v${version}`
       ),
       {
         name: "Register public client",
@@ -252,14 +334,22 @@ function postmanRequest(route, method, operation) {
   return { name: operation.summary, request, response: [] };
 }
 
-function buildEnvironment() {
+function buildEnvironment(version) {
   return {
-    id: "0757b49e-e97e-4ef6-bef1-e3b5f06ac106",
-    name: "HQBase Mail API v2 - local secrets",
+    id:
+      version === 1
+        ? "0757b49e-e97e-4ef6-bef1-e3b5f06ac106"
+        : "1757b49e-e97e-4ef6-bef1-e3b5f06ac107",
+    name: `HQBase Mail API v${version} - local secrets`,
     values: [
       { key: "base_url", value: "https://mail.example.com", enabled: true, type: "default" },
       { key: "ws_base_url", value: "wss://mail.example.com", enabled: true, type: "default" },
-      { key: "api_resource", value: "{{base_url}}/api/v2", enabled: true, type: "default" },
+      {
+        key: "api_resource",
+        value: `{{base_url}}/api/v${version}`,
+        enabled: true,
+        type: "default"
+      },
       { key: "client_id", value: "", enabled: true, type: "default" },
       { key: "access_token", value: "", enabled: true, type: "secret" }
     ],

--- a/test/e2e/staging/app-shell-smoke.spec.ts
+++ b/test/e2e/staging/app-shell-smoke.spec.ts
@@ -49,6 +49,22 @@ test("deployed HQBase publishes the v2 Mail API OAuth resource", async ({ reques
     scopes_supported: ["mail:read", "mail:write", "mail:send"]
   });
 
+  const v1Metadata = await getSuccessfulResponseBody(
+    request,
+    "/.well-known/oauth-protected-resource/api/v1"
+  );
+  expect(JSON.parse(v1Metadata)).toMatchObject({
+    resource: `${origin}/api/v1`,
+    authorization_servers: [`${origin}/api/auth`],
+    scopes_supported: ["mail:read", "mail:write", "mail:send"]
+  });
+
+  const v1OpenApi = await getSuccessfulResponseBody(request, "/api/v1/openapi.json");
+  expect(JSON.parse(v1OpenApi)).toMatchObject({
+    info: { version: "1.0.0" },
+    paths: { "/api/v1/mailboxes": expect.any(Object) }
+  });
+
   const authorization = await getSuccessfulResponseBody(
     request,
     "/.well-known/oauth-authorization-server/api/auth"

--- a/test/integration/worker/agent-mailboxes.test.ts
+++ b/test/integration/worker/agent-mailboxes.test.ts
@@ -89,6 +89,11 @@ describe("agent mailboxes", () => {
     });
     expect(messages.map(({ id }) => id)).toEqual(["msg_agent_support"]);
 
+    const v1Agent = await SELF.fetch(`${origin}/api/v1/mailboxes`, {
+      headers: { authorization: `Bearer ${requiredCredential(created)}` }
+    });
+    expect(v1Agent.status).toBe(401);
+
     const writeDenied = await SELF.fetch(`${origin}/api/v2/messages/msg_agent_support/archive`, {
       headers: { authorization: `Bearer ${requiredCredential(created)}` },
       method: "POST"

--- a/test/integration/worker/mail-api.test.ts
+++ b/test/integration/worker/mail-api.test.ts
@@ -7,7 +7,9 @@ import { tokenRow } from "./mail-api-token-fixture";
 
 const origin = "https://hqbase.test";
 const apiResource = `${origin}/api/v2`;
+const v1ApiResource = `${origin}/api/v1`;
 const readToken = "hqb_access_mail-api-read-token";
+const v1ReadToken = "hqb_access_mail-api-v1-read-token";
 const writeToken = "hqb_access_mail-api-write-token";
 const fullToken = "hqb_access_mail-api-full-token";
 const wrongAudienceToken = "hqb_access_mail-api-wrong-audience-token";
@@ -16,7 +18,7 @@ const scopes = ["mail:read", "mail:write", "mail:send"];
 let cookie = "";
 let userId = "";
 
-describe("HQBase Mail API v2", () => {
+describe("HQBase Mail API", () => {
   beforeAll(async () => {
     await applyCurrentMigrations();
 
@@ -59,6 +61,17 @@ describe("HQBase Mail API v2", () => {
         future,
         ["mail:read"],
         apiResource
+      ),
+      tokenRow(
+        env.DB,
+        "tok_api_v1_read",
+        v1ReadToken,
+        "client_mail_api_v1",
+        user.sessionId,
+        userId,
+        future,
+        ["mail:read"],
+        v1ApiResource
       ),
       tokenRow(
         env.DB,
@@ -140,6 +153,26 @@ describe("HQBase Mail API v2", () => {
         userId,
         JSON.stringify(scopes),
         JSON.stringify([apiResource]),
+        now.toISOString(),
+        now.toISOString()
+      ),
+      env.DB.prepare(
+        `INSERT INTO oauthClient
+         (id, clientId, disabled, redirectUris, public, requirePKCE, createdAt, updatedAt)
+         VALUES ('client_row_api_v1', 'client_mail_api_v1', 0, ?, 1, 1, ?, ?)`
+      ).bind(
+        JSON.stringify(["https://client.example/v1/callback"]),
+        now.toISOString(),
+        now.toISOString()
+      ),
+      env.DB.prepare(
+        `INSERT INTO oauthConsent
+         (id, clientId, userId, scopes, resources, createdAt, updatedAt)
+         VALUES ('consent_api_v1', 'client_mail_api_v1', ?, ?, ?, ?, ?)`
+      ).bind(
+        userId,
+        JSON.stringify(["mail:read"]),
+        JSON.stringify([v1ApiResource]),
         now.toISOString(),
         now.toISOString()
       ),
@@ -237,12 +270,12 @@ describe("HQBase Mail API v2", () => {
       resource_documentation: `${origin}/skills/hqbase-mail/SKILL.md`
     });
 
-    const retiredMetadata = await SELF.fetch(
-      `${origin}/.well-known/oauth-protected-resource/api/v1`
-    );
-    expect(retiredMetadata.status).toBe(404);
-    await expect(retiredMetadata.json()).resolves.toEqual({
-      error: { code: "NOT_FOUND", message: "Mail API v1 is no longer available." }
+    const v1Metadata = await SELF.fetch(`${origin}/.well-known/oauth-protected-resource/api/v1`);
+    expect(v1Metadata.status).toBe(200);
+    await expect(v1Metadata.json()).resolves.toMatchObject({
+      resource: v1ApiResource,
+      authorization_servers: [`${origin}/api/auth`],
+      scopes_supported: scopes
     });
 
     const rejected = await SELF.fetch(`${origin}/api/v2/messages`);
@@ -252,9 +285,15 @@ describe("HQBase Mail API v2", () => {
     );
     expect(rejected.headers.get("www-authenticate")).toContain('scope="mail:read"');
     expect(rejected.headers.get("x-request-id")).toBeTruthy();
+
+    const rejectedV1 = await SELF.fetch(`${origin}/api/v1/messages`);
+    expect(rejectedV1.status).toBe(401);
+    expect(rejectedV1.headers.get("www-authenticate")).toContain(
+      `resource_metadata="${origin}/.well-known/oauth-protected-resource/api/v1"`
+    );
   });
 
-  it("publishes separate connection skills, OpenAPI, and retirement notices", async () => {
+  it("publishes separate connection skills and versioned OpenAPI documents", async () => {
     const humanSkill = await SELF.fetch(`${origin}/skills/hqbase-mail/SKILL.md`);
     expect(humanSkill.status).toBe(200);
     expect(humanSkill.headers.get("content-type")).toContain("text/markdown");
@@ -356,6 +395,20 @@ describe("HQBase Mail API v2", () => {
       document.paths["/api/v2/messages/{id}/remote-media/trust"]?.post?.security
     ).not.toContainEqual({ agentBearer: [] });
 
+    const v1OpenApi = await SELF.fetch(`${origin}/api/v1/openapi.json`);
+    expect(v1OpenApi.status).toBe(200);
+    const v1Document = (await v1OpenApi.json()) as {
+      components: { schemas: Record<string, unknown>; securitySchemes: Record<string, unknown> };
+      info: { version: string };
+      paths: Record<string, unknown>;
+      servers: Array<{ url: string }>;
+    };
+    expect(v1Document.info.version).toBe("1.0.0");
+    expect(v1Document.servers).toEqual([{ url: origin, description: "This HQBase installation" }]);
+    expect(v1Document.paths["/api/v1/mailboxes"]).toBeDefined();
+    expect(v1Document.components.schemas.MailboxAddress).toBeDefined();
+    expect(v1Document.components.securitySchemes.agentBearer).toBeUndefined();
+
     for (const skillPath of [
       "/skills/hqbase-mail/SKILL.md",
       "/skills/hqbase-mailbox/SKILL.md",
@@ -378,15 +431,46 @@ describe("HQBase Mail API v2", () => {
     }
   });
 
-  it("accepts the web session on v2 while v1 is absent and legacy routes remain cookie-only", async () => {
+  it("keeps v1 compatible while v2 uses direct mailboxes and legacy routes remain cookie-only", async () => {
     const versioned = await SELF.fetch(`${origin}/api/v2/mailboxes`, { headers: { cookie } });
     expect(versioned.status, await versioned.clone().text()).toBe(200);
-    await expect(versioned.json()).resolves.toMatchObject([
-      { id: "mbx_api", accessLevel: "agent" }
+    const v2Mailboxes = (await versioned.json()) as Array<Record<string, unknown>>;
+    expect(v2Mailboxes).toMatchObject([{ id: "mbx_api", accessLevel: "agent" }]);
+    expect(v2Mailboxes[0]).not.toHaveProperty("addresses");
+
+    const v1Session = await SELF.fetch(`${origin}/api/v1/mailboxes`, { headers: { cookie } });
+    expect(v1Session.status, await v1Session.clone().text()).toBe(200);
+    await expect(v1Session.json()).resolves.toEqual([
+      {
+        id: "mbx_api",
+        address: "support@example.com",
+        addresses: [
+          {
+            id: "mbx_api",
+            mailboxId: "mbx_api",
+            mailDomainId: "dom_api",
+            address: "support@example.com",
+            displayName: "Support",
+            receiveEnabled: true,
+            sendEnabled: true,
+            isPrimary: true
+          }
+        ],
+        displayName: "Support",
+        isActive: true,
+        accessLevel: "agent",
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String)
+      }
     ]);
 
-    const retiredV1 = await SELF.fetch(`${origin}/api/v1/mailboxes`, { headers: { cookie } });
-    expect(retiredV1.status).toBe(404);
+    const v1Bearer = await apiFetch("/api/v1/mailboxes", v1ReadToken);
+    expect(v1Bearer.status, await v1Bearer.clone().text()).toBe(200);
+
+    const v1TokenOnV2 = await apiFetch("/api/v2/mailboxes", v1ReadToken);
+    expect(v1TokenOnV2.status).toBe(401);
+    const v2TokenOnV1 = await apiFetch("/api/v1/mailboxes", readToken);
+    expect(v2TokenOnV1.status).toBe(401);
 
     const legacyCookie = await SELF.fetch(`${origin}/api/messages`, { headers: { cookie } });
     expect(legacyCookie.status).toBe(200);
@@ -398,6 +482,16 @@ describe("HQBase Mail API v2", () => {
     const missingUpgrade = await apiFetch("/api/v2/events", readToken);
     expect(missingUpgrade.status).toBe(426);
     expect(missingUpgrade.headers.get("upgrade")).toBe("websocket");
+
+    const v1MissingUpgrade = await apiFetch("/api/v1/events", v1ReadToken);
+    expect(v1MissingUpgrade.status).toBe(426);
+    expect(v1MissingUpgrade.headers.get("upgrade")).toBe("websocket");
+
+    const v1Socket = await openEventSocket(
+      { authorization: `Bearer ${v1ReadToken}`, upgrade: "websocket" },
+      "/api/v1/events"
+    );
+    v1Socket.close(1000, "v1 compatibility verified");
 
     const insufficientScope = await apiFetch("/api/v2/events", writeToken, {
       headers: { upgrade: "websocket" }
@@ -1100,8 +1194,8 @@ function extractSessionCookie(response: Response): string {
   return match[1];
 }
 
-async function openEventSocket(headers: HeadersInit): Promise<WebSocket> {
-  const response = await SELF.fetch(`${origin}/api/v2/events`, { headers });
+async function openEventSocket(headers: HeadersInit, path = "/api/v2/events"): Promise<WebSocket> {
+  const response = await SELF.fetch(`${origin}${path}`, { headers });
   if (response.status !== 101) {
     throw new Error(`WebSocket upgrade failed (${response.status}): ${await response.text()}`);
   }

--- a/test/integration/worker/one-address-per-mailbox-migration.test.ts
+++ b/test/integration/worker/one-address-per-mailbox-migration.test.ts
@@ -323,7 +323,7 @@ describe("one address per mailbox migration", () => {
     ]);
   });
 
-  it("removes the alias schema and leaves valid foreign keys", async () => {
+  it("removes the alias schema, preserves v1 OAuth data, and leaves valid foreign keys", async () => {
     const tables = await env.DB.prepare(
       `SELECT name FROM sqlite_master
        WHERE type = 'table' AND name IN ('mailbox_addresses', 'mailbox_address_migration')`
@@ -340,13 +340,13 @@ describe("one address per mailbox migration", () => {
         `SELECT COUNT(*) AS count FROM oauthResource
          WHERE identifier = 'https://hqbase.test/api/v1'`
       ).first()
-    ).resolves.toEqual({ count: 0 });
+    ).resolves.toEqual({ count: 1 });
     await expect(
       env.DB.prepare(
         `SELECT COUNT(*) AS count FROM oauthClientResource
          WHERE clientId = 'legacy_alias_migration'`
       ).first()
-    ).resolves.toEqual({ count: 0 });
+    ).resolves.toEqual({ count: 1 });
     await expect(
       env.DB.prepare(
         "SELECT installed_schema_version FROM release_state WHERE singleton = 1"

--- a/test/unit/scripts/mail-api-artifacts.test.mjs
+++ b/test/unit/scripts/mail-api-artifacts.test.mjs
@@ -5,6 +5,10 @@ const openApi = JSON.parse(await readFile("api/hqbase-mail-api-v2.openapi.json",
 const postman = JSON.parse(
   await readFile("api/hqbase-mail-api-v2.postman_collection.json", "utf8")
 );
+const v1OpenApi = JSON.parse(await readFile("api/hqbase-mail-api-v1.openapi.json", "utf8"));
+const v1Postman = JSON.parse(
+  await readFile("api/hqbase-mail-api-v1.postman_collection.json", "utf8")
+);
 
 describe("Mail API public artifacts", () => {
   it("publishes the versioned endpoint and scope matrix without internal storage keys", () => {
@@ -72,6 +76,34 @@ describe("Mail API public artifacts", () => {
     expect(JSON.stringify(openApi)).not.toContain("r2Key");
   });
 
+  it("publishes the v1 mailbox schema without reviving alias storage", () => {
+    expect(v1OpenApi.openapi).toBe("3.1.0");
+    expect(v1OpenApi.info.version).toBe("1.0.0");
+    expect(Object.keys(v1OpenApi.paths).every((path) => path.startsWith("/api/v1/"))).toBe(true);
+    expect(v1OpenApi.components.securitySchemes.agentBearer).toBeUndefined();
+    expect(v1OpenApi.components.schemas.Mailbox.required).toEqual([
+      "id",
+      "address",
+      "addresses",
+      "displayName",
+      "isActive",
+      "accessLevel",
+      "createdAt",
+      "updatedAt"
+    ]);
+    expect(v1OpenApi.components.schemas.Mailbox.properties.kind).toBeUndefined();
+    expect(v1OpenApi.components.schemas.Mailbox.properties.deletedAt).toBeUndefined();
+    expect(v1OpenApi.components.schemas.Mailbox.properties.addresses).toMatchObject({
+      minItems: 1,
+      maxItems: 1,
+      items: { $ref: "#/components/schemas/MailboxAddress" }
+    });
+    expect(v1OpenApi.components.schemas.MailboxAddress).toBeDefined();
+    expect(JSON.stringify(v1OpenApi)).not.toContain("agentBearer");
+    expect(JSON.stringify(v1OpenApi)).not.toContain("x-hqbase-agent-capabilities");
+    expect(JSON.stringify(v1OpenApi)).not.toContain("r2Key");
+  });
+
   it("generates human-testable OAuth setup and every OpenAPI operation", () => {
     const serialized = JSON.stringify(postman);
     expect(serialized).not.toContain("/api/v1");
@@ -98,6 +130,20 @@ describe("Mail API public artifacts", () => {
     ]);
     for (const [route, pathItem] of Object.entries(openApi.paths)) {
       if (route === "/api/v2/events") continue;
+      for (const operation of Object.values(pathItem)) {
+        expect(serialized).toContain(operation.summary);
+      }
+    }
+  });
+
+  it("generates v1 OAuth and event setup for existing clients", () => {
+    const serialized = JSON.stringify(v1Postman);
+    expect(serialized).not.toContain("/api/v2");
+    expect(serialized).toContain("/.well-known/oauth-protected-resource/api/v1");
+    expect(serialized).toContain("{{ws_base_url}}/api/v1/events");
+    expect(serialized).not.toContain("hqb_agent_ credential");
+    for (const [route, pathItem] of Object.entries(v1OpenApi.paths)) {
+      if (route === "/api/v1/events") continue;
       for (const operation of Object.values(pathItem)) {
         expect(serialized).toContain(operation.summary);
       }

--- a/worker/auth/auth.ts
+++ b/worker/auth/auth.ts
@@ -33,6 +33,7 @@ export function createAuth(
   backgroundTaskHandler?: BackgroundTaskHandler
 ) {
   const baseURL = authOrigin(env, request);
+  const mailApiResources = [mailApiResource(env, request), mailApiV1Resource(env, request)];
 
   return betterAuth({
     appName: "HQBase",
@@ -120,7 +121,7 @@ export function createAuth(
         clientRegistrationAllowedResources: [
           mcpResource(env, request),
           mcpFullResource(env, request),
-          mailApiResource(env, request)
+          ...mailApiResources
         ],
         clientRegistrationAllowedScopes: ["mail:write", "mail:send", "offline_access"],
         clientRegistrationDefaultScopes: ["mail:read"],
@@ -136,11 +137,7 @@ export function createAuth(
         },
         scopes: ["mail:read", "mail:write", "mail:send", "offline_access"],
         storeTokens: { hash: hashOAuthToken },
-        resources: [
-          mcpResource(env, request),
-          mcpFullResource(env, request),
-          mailApiResource(env, request)
-        ],
+        resources: [mcpResource(env, request), mcpFullResource(env, request), ...mailApiResources],
         enforcePerClientResources: false
       }),
       oauthDeviceAuthorization({
@@ -170,4 +167,8 @@ export function mcpFullResource(env: WorkerEnv, request: Request): string {
 
 export function mailApiResource(env: WorkerEnv, request: Request): string {
   return `${authOrigin(env, request)}/api/v2`;
+}
+
+export function mailApiV1Resource(env: WorkerEnv, request: Request): string {
+  return `${authOrigin(env, request)}/api/v1`;
 }

--- a/worker/auth/mail-api.ts
+++ b/worker/auth/mail-api.ts
@@ -1,20 +1,19 @@
 import type { WorkerEnv } from "../lib/env";
-import { AppError, errorBody } from "../lib/errors";
+import { AppError } from "../lib/errors";
 
 import {
   AgentBearerError,
   agentCredentialPrefix,
   authenticateAgentBearer
 } from "./agent-credential";
-import { authOrigin, mailApiResource } from "./auth";
+import { authOrigin, mailApiResource, mailApiV1Resource } from "./auth";
 import { authenticateOAuthBearer, OAuthBearerError } from "./oauth-principal";
 import { type AgentPrincipal, type HumanPrincipal, humanPrincipal } from "./principal";
 import { type AuthContext, requireAuthContext } from "./session";
 
 const mailApiScopes = ["mail:read", "mail:write", "mail:send"] as const;
 export type MailApiScope = (typeof mailApiScopes)[number];
-const retiredMailApiMetadataPath = "/.well-known/oauth-protected-resource/api/v1";
-const mailApiMetadataPath = "/.well-known/oauth-protected-resource/api/v2";
+const mailApiMetadataPrefix = "/.well-known/oauth-protected-resource";
 const agentSkillPath = "/skills/hqbase-mail/SKILL.md";
 
 export type MailApiPrincipal =
@@ -103,7 +102,7 @@ export async function requireMailApiPrincipal(
     }
   }
 
-  if (isAgentBearer(request)) {
+  if (mailApiBasePath(request) === "/api/v2" && isAgentBearer(request)) {
     try {
       const result = await authenticateAgentBearer(request, env, {
         allowedScopes: mailApiScopes,
@@ -142,7 +141,7 @@ export async function requireMailApiPrincipal(
   try {
     const principal = await authenticateOAuthBearer(request, env, {
       allowedScopes: mailApiScopes,
-      resource: mailApiResource(env, request)
+      resource: mailApiResourceForRequest(env, request)
     });
     if (!principal.scopes.has(requiredScope)) {
       throw new MailApiAuthError(
@@ -194,8 +193,14 @@ function mailScopes(scopes: ReadonlySet<string>): ReadonlySet<MailApiScope> {
 }
 
 export function isVersionedMailApiRequest(request: Request): boolean {
+  return mailApiBasePath(request) !== null;
+}
+
+export function mailApiBasePath(request: Request): "/api/v1" | "/api/v2" | null {
   const pathname = new URL(request.url).pathname;
-  return pathname === "/api/v2" || pathname.startsWith("/api/v2/");
+  if (pathname === "/api/v1" || pathname.startsWith("/api/v1/")) return "/api/v1";
+  if (pathname === "/api/v2" || pathname.startsWith("/api/v2/")) return "/api/v2";
+  return null;
 }
 
 export function mailApiChallenge(
@@ -203,8 +208,9 @@ export function mailApiChallenge(
   request: Request,
   error: MailApiAuthError
 ): string {
+  const basePath = mailApiBasePath(request) ?? "/api/v2";
   const parameters = [
-    `resource_metadata="${authOrigin(env, request)}${mailApiMetadataPath}"`,
+    `resource_metadata="${authOrigin(env, request)}${mailApiMetadataPrefix}${basePath}"`,
     `scope="${error.requiredScope}"`
   ];
   if (error.authError) parameters.push(`error="${error.authError}"`);
@@ -213,21 +219,13 @@ export function mailApiChallenge(
 
 export function handleMailApiMetadata(request: Request, env: WorkerEnv): Response | null {
   const pathname = new URL(request.url).pathname;
-  if (pathname === retiredMailApiMetadataPath) {
-    return Response.json(errorBody("NOT_FOUND", "Mail API v1 is no longer available."), {
-      status: 404,
-      headers: {
-        "access-control-allow-origin": "*",
-        "cache-control": "no-store",
-        "x-content-type-options": "nosniff"
-      }
-    });
-  }
-  if (pathname !== mailApiMetadataPath) return null;
+  const basePath = pathname.slice(mailApiMetadataPrefix.length);
+  if (basePath !== "/api/v1" && basePath !== "/api/v2") return null;
   const origin = authOrigin(env, request);
   return Response.json(
     {
-      resource: mailApiResource(env, request),
+      resource:
+        basePath === "/api/v1" ? mailApiV1Resource(env, request) : mailApiResource(env, request),
       authorization_servers: [`${origin}/api/auth`],
       scopes_supported: mailApiScopes,
       bearer_methods_supported: ["header"],
@@ -242,4 +240,10 @@ export function handleMailApiMetadata(request: Request, env: WorkerEnv): Respons
       }
     }
   );
+}
+
+function mailApiResourceForRequest(env: WorkerEnv, request: Request): string {
+  return mailApiBasePath(request) === "/api/v1"
+    ? mailApiV1Resource(env, request)
+    : mailApiResource(env, request);
 }

--- a/worker/features/events/route.ts
+++ b/worker/features/events/route.ts
@@ -6,14 +6,14 @@ import { jsonResponse } from "../../lib/json";
 import { mailEventInternalHeaders } from "./durable-object";
 import type { MailEventTopic } from "./types";
 
-const eventPath = "/api/v2/events";
+const eventPaths = new Set(["/api/v1/events", "/api/v2/events"]);
 const workspaceHubName = "workspace";
 
 export async function handleMailEventRoute(
   request: Request,
   env: WorkerEnv
 ): Promise<Response | null> {
-  if (new URL(request.url).pathname !== eventPath) return null;
+  if (!eventPaths.has(new URL(request.url).pathname)) return null;
 
   const requestId = requestIdFor(request);
   try {

--- a/worker/features/mail-api/discovery.ts
+++ b/worker/features/mail-api/discovery.ts
@@ -1,3 +1,4 @@
+import mailApiV1DocumentSource from "../../../api/hqbase-mail-api-v1.openapi.json";
 import mailApiDocumentSource from "../../../api/hqbase-mail-api-v2.openapi.json";
 
 import { authOrigin } from "../../auth/auth";
@@ -7,6 +8,10 @@ const humanMailSkillPath = "/skills/hqbase-mail/SKILL.md";
 const mailboxAgentSkillPath = "/skills/hqbase-mailbox/SKILL.md";
 const provisionerSkillPath = "/skills/hqbase-provisioner/SKILL.md";
 const mailApiOpenApiPath = "/api/v2/openapi.json";
+const mailApiOpenApiDocuments: ReadonlyMap<string, object> = new Map<string, object>([
+  ["/api/v1/openapi.json", mailApiV1DocumentSource],
+  [mailApiOpenApiPath, mailApiDocumentSource]
+]);
 
 const retiredAgentInstructionPaths = new Set(["/AGENTS.md", "/agents.md"]);
 
@@ -15,20 +20,19 @@ const publicDiscoveryCacheControl = "public, max-age=300";
 export function handleMailApiDiscovery(request: Request, env: WorkerEnv): Response | null {
   const pathname = new URL(request.url).pathname;
   const isRetiredAgentInstructionPath = retiredAgentInstructionPaths.has(pathname);
+  const openApiDocument = mailApiOpenApiDocuments.get(pathname);
   if (
     pathname !== humanMailSkillPath &&
     pathname !== mailboxAgentSkillPath &&
     pathname !== provisionerSkillPath &&
-    pathname !== mailApiOpenApiPath &&
+    !openApiDocument &&
     !isRetiredAgentInstructionPath
   ) {
     return null;
   }
 
   const headers = publicDiscoveryHeaders(
-    pathname === mailApiOpenApiPath
-      ? "application/json; charset=utf-8"
-      : "text/markdown; charset=utf-8"
+    openApiDocument ? "application/json; charset=utf-8" : "text/markdown; charset=utf-8"
   );
   if (request.method !== "GET" && request.method !== "HEAD") {
     headers.set("allow", "GET, HEAD");
@@ -36,23 +40,22 @@ export function handleMailApiDiscovery(request: Request, env: WorkerEnv): Respon
   }
 
   const origin = authOrigin(env, request);
-  const responseBody =
-    pathname === mailApiOpenApiPath
-      ? buildInstanceOpenApi(origin)
-      : pathname === humanMailSkillPath
-        ? buildHumanMailSkill(origin)
-        : pathname === mailboxAgentSkillPath
-          ? buildMailboxAgentSkill(origin)
-          : pathname === provisionerSkillPath
-            ? buildProvisionerSkill(origin)
-            : buildRetirementNotice();
+  const responseBody = openApiDocument
+    ? buildInstanceOpenApi(openApiDocument, origin)
+    : pathname === humanMailSkillPath
+      ? buildHumanMailSkill(origin)
+      : pathname === mailboxAgentSkillPath
+        ? buildMailboxAgentSkill(origin)
+        : pathname === provisionerSkillPath
+          ? buildProvisionerSkill(origin)
+          : buildRetirementNotice();
   return new Response(request.method === "HEAD" ? null : responseBody, { headers });
 }
 
-function buildInstanceOpenApi(origin: string): string {
+function buildInstanceOpenApi(document: object, origin: string): string {
   return `${JSON.stringify(
     {
-      ...mailApiDocumentSource,
+      ...document,
       servers: [{ url: origin, description: "This HQBase installation" }],
       externalDocs: {
         description: "Connect through the HQBase Mail API with human approval",

--- a/worker/features/mailboxes/routes.ts
+++ b/worker/features/mailboxes/routes.ts
@@ -1,6 +1,6 @@
 import { type Context, Hono } from "hono";
 
-import { requireMailApiPrincipal } from "../../auth/mail-api";
+import { mailApiBasePath, requireMailApiPrincipal } from "../../auth/mail-api";
 import { requireAuthContext, requireRole } from "../../auth/session";
 import type { HonoApp } from "../../lib/env";
 import { readJson } from "../../lib/json";
@@ -18,7 +18,8 @@ export const mailboxReadRoutes = new Hono<HonoApp>();
 
 const listForUser = async (c: Context<HonoApp>) => {
   const auth = await requireMailApiPrincipal(c.env, c.req.raw, "mail:read");
-  return c.json(await listMailboxesForUser(c.env.DB, auth.principal.id, auth.principal.role));
+  const mailboxes = await listMailboxesForUser(c.env.DB, auth.principal.id, auth.principal.role);
+  return c.json(mailApiBasePath(c.req.raw) === "/api/v1" ? mailboxes.map(toV1Mailbox) : mailboxes);
 };
 
 mailboxRoutes.get("/", listForUser);
@@ -102,4 +103,30 @@ mailboxRoutes.post("/:id/restore", async (c) => {
 
 function scheduleMailboxEvent(c: Context<HonoApp>, mailboxId: string): void {
   c.executionCtx.waitUntil(ignoreMailEventFailure(publishMailboxMailEvent(c.env, mailboxId)));
+}
+
+type MailboxWithAccess = Awaited<ReturnType<typeof listMailboxesForUser>>[number];
+
+function toV1Mailbox(mailbox: MailboxWithAccess) {
+  return {
+    id: mailbox.id,
+    address: mailbox.address,
+    addresses: [
+      {
+        id: mailbox.id,
+        mailboxId: mailbox.id,
+        mailDomainId: mailbox.mailDomainId,
+        address: mailbox.address,
+        displayName: mailbox.displayName,
+        receiveEnabled: mailbox.isActive,
+        sendEnabled: mailbox.isActive,
+        isPrimary: true
+      }
+    ],
+    displayName: mailbox.displayName,
+    isActive: mailbox.isActive,
+    accessLevel: mailbox.accessLevel,
+    createdAt: mailbox.createdAt,
+    updatedAt: mailbox.updatedAt
+  };
 }

--- a/worker/features/messages/routes.ts
+++ b/worker/features/messages/routes.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { isVersionedMailApiRequest, requireMailApiPrincipal } from "../../auth/mail-api";
+import { mailApiBasePath, requireMailApiPrincipal } from "../../auth/mail-api";
 import { accessibleMessageScope } from "../../auth/mailbox-access";
 import type { HonoApp } from "../../lib/env";
 import { AppError } from "../../lib/errors";
@@ -126,7 +126,7 @@ messageRoutes.get("/:id/html", async (c) => {
     allowRemoteImages: trusted || c.req.query("loadRemoteImages") === "1",
     attachments: message.attachments,
     html: await object.text(),
-    inlineBasePath: isVersionedMailApiRequest(c.req.raw) ? "/api/v2/messages" : "/api/messages",
+    inlineBasePath: `${mailApiBasePath(c.req.raw) ?? "/api"}/messages`,
     messageId: message.id,
     origin: new URL(c.req.url).origin
   });

--- a/worker/routes/index.ts
+++ b/worker/routes/index.ts
@@ -78,6 +78,7 @@ apiRoutes.route("/api/attachments", attachmentRoutes);
 apiRoutes.route("/api/users", userRoutes);
 apiRoutes.route("/api/updates", updateRoutes);
 apiRoutes.route("/api", sendRoutes);
+apiRoutes.route("/api/v1", mailApiRoutes);
 apiRoutes.route("/api/v2", mailApiRoutes);
 apiRoutes.route("/management/v1/agents", agentManagementRoutes);
 


### PR DESCRIPTION
## Summary

- keep /api/v1 routes, OAuth discovery, audience validation, and existing v1 grants and tokens
- preserve the v1 mailbox response with one synthetic primary item in addresses, while v2 keeps the direct one-address schema
- publish separate v1 OpenAPI and Postman artifacts and support /api/v1/events
- keep mailbox-agent credentials and the generated Agent Skill on v2
- update the companion public specification in HQBase/hqbase-site#34

## Validation

- pnpm check
- pnpm deploy:dry-run
- hqbase-site pnpm check

The migration still removes alias storage, but it no longer deletes v1 OAuth resources or client-resource links.