### PR TITLE
Merge next into main for v1.3.0 candidate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,11 @@ jobs:
           }
           release_version="$(node --input-type=module -e '
             import { readFileSync } from "node:fs";
+            import { assertStableReleaseVersion } from "./scripts/release/version.mjs";
             const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
-            if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(packageJson.version)) {
-              throw new Error("package.json version must be semantic.");
-            }
-            process.stdout.write(packageJson.version);
+            process.stdout.write(
+              assertStableReleaseVersion(packageJson.version, "package.json version")
+            );
           ')"
           previous_tag="$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // ""')"
           if gh release view "v${release_version}" >/dev/null 2>&1; then

--- a/app/components/layout/account-menu.tsx
+++ b/app/components/layout/account-menu.tsx
@@ -72,12 +72,7 @@ export function AccountMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-52" side="top">
-        <DropdownMenuLabel>
-          <div className="flex flex-col gap-1">
-            <span>{user.name}</span>
-            <span className="text-xs font-normal text-muted-foreground">{user.role}</span>
-          </div>
-        </DropdownMenuLabel>
+        <DropdownMenuLabel>{user.name}</DropdownMenuLabel>
         <DropdownMenuItem className="gap-2" onSelect={() => void handleSignOut()}>
           <PiSignOut aria-hidden="true" className="pointer-events-none size-4" />
           Sign out

--- a/app/components/ui/dropdown-select.tsx
+++ b/app/components/ui/dropdown-select.tsx
@@ -63,6 +63,7 @@ export function DropdownSelect({
             className
           )}
           data-size={size}
+          data-slot="dropdown-select"
           disabled={disabled}
           id={id}
           type="button"

--- a/app/features/auth/device-authorization-view.tsx
+++ b/app/features/auth/device-authorization-view.tsx
@@ -119,7 +119,7 @@ export function DeviceCodeEntry({
               <Input
                 autoCapitalize="characters"
                 autoComplete="one-time-code"
-                className="bg-background font-mono uppercase tracking-widest shadow-none focus-visible:ring-1"
+                className="bg-background font-mono uppercase tracking-widest shadow-none"
                 id="device-code"
                 maxLength={12}
                 onChange={(event) => onInputCodeChange(event.target.value)}

--- a/app/features/auth/login-page.tsx
+++ b/app/features/auth/login-page.tsx
@@ -64,7 +64,7 @@ export function LoginPage({ onLogin }: LoginPageProps): React.ReactElement {
               Login email
               <Input
                 autoComplete="email"
-                className="bg-background shadow-none focus-visible:ring-1"
+                className="bg-background shadow-none"
                 id="login-email"
                 onChange={(event) => setEmail(event.target.value)}
                 required
@@ -84,7 +84,7 @@ export function LoginPage({ onLogin }: LoginPageProps): React.ReactElement {
               </div>
               <Input
                 autoComplete="current-password"
-                className="bg-background shadow-none focus-visible:ring-1"
+                className="bg-background shadow-none"
                 id="login-password"
                 onChange={(event) => setPassword(event.target.value)}
                 required

--- a/app/features/compose/attachment-list.tsx
+++ b/app/features/compose/attachment-list.tsx
@@ -1,37 +1,58 @@
 import { PiPaperclip, PiX } from "react-icons/pi";
 import { Button } from "@/components/ui/button";
 import type { DraftAttachment } from "@/features/drafts/types";
+import type { MessageDetail } from "@/features/messages/types";
 export function AttachmentList({
   attachments,
+  includedAttachments = [],
   onRemove
 }: {
   attachments: DraftAttachment[];
+  includedAttachments?: MessageDetail["attachments"];
   onRemove: (item: DraftAttachment) => void;
 }) {
   const visibleAttachments = attachments.filter((attachment) => !attachment.inline);
-  if (!visibleAttachments.length) return null;
+  const visibleIncludedAttachments = includedAttachments.filter(
+    (attachment) => attachment.disposition === "attachment"
+  );
+  if (!visibleAttachments.length && !visibleIncludedAttachments.length) return null;
   return (
-    <div className="flex flex-wrap gap-2 border-t px-5 py-3">
-      {visibleAttachments.map((item) => (
-        <div
-          className="flex items-center gap-2 rounded-md border bg-background px-3 py-1.5 text-xs"
-          key={item.id}
-        >
-          <PiPaperclip aria-hidden="true" className="pointer-events-none" />
-          <span className="max-w-48 truncate">{item.filename}</span>
-          <span className="text-muted-foreground">{formatBytes(item.sizeBytes)}</span>
-          <Button
-            aria-label={`Remove ${item.filename}`}
-            className="size-10 min-h-10 min-w-10"
-            size="icon"
-            type="button"
-            variant="ghost"
-            onClick={() => onRemove(item)}
+    <div className="space-y-2 border-t px-5 py-3">
+      {visibleIncludedAttachments.length ? (
+        <p className="text-xs font-medium text-muted-foreground">Included from original message</p>
+      ) : null}
+      <div className="flex flex-wrap gap-2">
+        {visibleIncludedAttachments.map((item) => (
+          <div
+            className="flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-1.5 text-xs"
+            key={`included-${item.id}`}
           >
-            <PiX aria-hidden="true" className="pointer-events-none" />
-          </Button>
-        </div>
-      ))}
+            <PiPaperclip aria-hidden="true" className="pointer-events-none" />
+            <span className="max-w-48 truncate">{item.filename}</span>
+            <span className="text-muted-foreground">{formatBytes(item.sizeBytes)}</span>
+          </div>
+        ))}
+        {visibleAttachments.map((item) => (
+          <div
+            className="flex items-center gap-2 rounded-md border bg-background px-3 py-1.5 text-xs"
+            key={item.id}
+          >
+            <PiPaperclip aria-hidden="true" className="pointer-events-none" />
+            <span className="max-w-48 truncate">{item.filename}</span>
+            <span className="text-muted-foreground">{formatBytes(item.sizeBytes)}</span>
+            <Button
+              aria-label={`Remove ${item.filename}`}
+              className="size-10 min-h-10 min-w-10"
+              size="icon"
+              type="button"
+              variant="ghost"
+              onClick={() => onRemove(item)}
+            >
+              <PiX aria-hidden="true" className="pointer-events-none" />
+            </Button>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/app/features/compose/compose-dialog.tsx
+++ b/app/features/compose/compose-dialog.tsx
@@ -326,6 +326,7 @@ export function ComposeDialog({
       fromDisabled={isSignaturePending}
       html={html}
       identities={identities}
+      includedAttachments={mode === "forward" ? (message?.attachments ?? []) : []}
       isPending={isPending}
       mode={mode}
       presentation={presentation}

--- a/app/features/compose/compose-form.tsx
+++ b/app/features/compose/compose-form.tsx
@@ -26,6 +26,7 @@ type ComposeFormProps = {
   fromDisabled: boolean;
   html: string;
   identities: SendingIdentity[];
+  includedAttachments: MessageDetail["attachments"];
   isPending: boolean;
   mode: ComposeMode;
   presentation: "window" | "thread";
@@ -115,7 +116,11 @@ export function ComposeForm(props: ComposeFormProps): React.ReactElement {
           {props.replyMessage ? (
             <ReplyQuotePreview messages={props.replyMessages} target={props.replyMessage} />
           ) : null}
-          <AttachmentList attachments={props.attachments} onRemove={props.onRemoveAttachment} />
+          <AttachmentList
+            attachments={props.attachments}
+            includedAttachments={props.includedAttachments}
+            onRemove={props.onRemoveAttachment}
+          />
           <footer
             className={cn(
               "flex items-center justify-between gap-2 border-t bg-background/50 px-5 py-3",

--- a/app/features/compose/compose-window.tsx
+++ b/app/features/compose/compose-window.tsx
@@ -133,7 +133,7 @@ export function ComposeWindow({
       aria-labelledby={titleId}
       aria-modal="false"
       className={cn(
-        "fixed inset-0 z-[60] flex h-[100dvh] w-full flex-col overflow-hidden bg-card pt-[env(safe-area-inset-top)] shadow-2xl outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring lg:inset-auto lg:bottom-0 lg:right-4 lg:z-[60] lg:h-[min(42rem,calc(100vh-5rem))] lg:max-h-[calc(100vh-1rem)] lg:min-h-96 lg:w-[min(42rem,calc(100vw-2rem))] lg:max-w-[calc(100vw-2rem)] lg:min-w-96 lg:rounded-t-lg lg:border lg:pt-0",
+        "fixed inset-0 z-[60] flex h-[100dvh] w-full flex-col overflow-hidden bg-card pt-[env(safe-area-inset-top)] shadow-2xl outline-none lg:inset-auto lg:bottom-0 lg:right-4 lg:z-[60] lg:h-[min(34rem,calc(100vh-5rem))] lg:max-h-[calc(100vh-1rem)] lg:min-h-96 lg:w-[min(42rem,calc(100vw-2rem))] lg:max-w-[calc(100vw-2rem)] lg:min-w-96 lg:rounded-t-lg lg:border lg:pt-0",
         !minimized && "lg:resize",
         minimized &&
           "lg:h-auto lg:min-h-0 lg:w-80 lg:min-w-0 lg:shrink-0 lg:resize-none lg:translate-x-0 lg:rounded-b-none lg:rounded-t-lg",

--- a/app/features/compose/rich-email-editor.tsx
+++ b/app/features/compose/rich-email-editor.tsx
@@ -164,7 +164,7 @@ export function RichEmailEditor({
       editorProps: {
         attributes: {
           class: cn(
-            "prose prose-sm min-h-60 max-w-none px-5 py-4 text-sm outline-none",
+            "prose prose-sm min-h-48 max-w-none px-5 py-4 text-sm outline-none",
             "[&_a]:text-primary [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:pl-3 [&_p]:my-2",
             "[&_img]:h-auto [&_img]:max-w-full [&_[data-resize-container]]:max-w-full",
             "[&_[data-resize-handle]]:hidden [&_[data-resize-handle]]:touch-none",
@@ -265,18 +265,15 @@ export function RichEmailEditor({
     if (editor && editor.getHTML() !== html)
       editor.commands.setContent(html || "<p></p>", { emitUpdate: false });
   }, [editor, html]);
-  if (!editor) return <div className="min-h-60" />;
+  if (!editor) return <div className="min-h-48" />;
   const link = () => {
     const href = window.prompt("Link URL", editor.getAttributes("link").href ?? "https://");
     if (href === null) return;
     if (!href) editor.chain().focus().unsetLink().run();
     else editor.chain().focus().extendMarkRange("link").setLink({ href }).run();
   };
-  const rootClass = cn(
-    contained && "min-h-0 flex-1 overflow-auto",
-    fill && "flex min-h-0 flex-1 flex-col"
-  );
-  const editorClass = cn(fill && "min-h-60 flex-1 [&_.ProseMirror]:!min-h-full");
+  const rootClass = cn(contained && "min-h-0 flex-1 overflow-auto", fill && "flex flex-1 flex-col");
+  const editorClass = cn(fill && "min-h-48 flex-1 [&_.ProseMirror]:!min-h-full");
   return (
     <div className={rootClass}>
       <div

--- a/app/features/contacts/contact-views.tsx
+++ b/app/features/contacts/contact-views.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { PiArrowLeft, PiEnvelopeSimple, PiNotePencil, PiTrash } from "react-icons/pi";
+import { PiArrowLeft, PiCaretDown, PiEnvelopeSimple, PiNotePencil, PiTrash } from "react-icons/pi";
 import { toast } from "sonner";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -247,11 +247,17 @@ export function ContactDetailView({
                 New email
               </Button>
             </div>
-            <section>
-              <div className="flex items-center gap-2">
-                <PiNotePencil aria-hidden="true" className="text-muted-foreground" />
-                <h2 className="text-sm font-medium">Private contact details</h2>
-              </div>
+            <details className="group">
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-3 rounded-md py-1 text-left [&::-webkit-details-marker]:hidden">
+                <span className="flex items-center gap-2">
+                  <PiNotePencil aria-hidden="true" className="text-muted-foreground" />
+                  <h2 className="text-sm font-medium">Private contact details</h2>
+                </span>
+                <PiCaretDown
+                  aria-hidden="true"
+                  className="size-4 text-muted-foreground transition-transform duration-200 group-open:rotate-180 motion-reduce:transition-none"
+                />
+              </summary>
               <FieldGroup className="mt-4 gap-4">
                 <Field>
                   <FieldLabel htmlFor="contact-name">Name</FieldLabel>
@@ -296,7 +302,7 @@ export function ContactDetailView({
                   ) : null}
                 </div>
               </FieldGroup>
-            </section>
+            </details>
             <section>
               <h2 className="text-sm font-medium">Email exchanges</h2>
               {detail.conversations.length === 0 ? (

--- a/app/features/inbox/inbox-page.tsx
+++ b/app/features/inbox/inbox-page.tsx
@@ -75,6 +75,9 @@ export function InboxPage({
   const [thread, setThread] = React.useState<MessageDetailType[]>([]);
   const [detailError, setDetailError] = React.useState<string | null>(null);
   const [detailLoading, setDetailLoading] = React.useState(false);
+  const threadLoadRequestRef = React.useRef(0);
+  const threadContextRef = React.useRef("");
+  threadContextRef.current = `${activeFolder}:${selectedId ?? ""}`;
   const onRefreshRef = React.useRef(onRefresh);
   const onMessageRouteChangeRef = React.useRef(onMessageRouteChange);
   React.useEffect(() => {
@@ -86,7 +89,12 @@ export function InboxPage({
 
   const loadThread = React.useCallback(
     async (messageId: string) => {
+      const requestId = ++threadLoadRequestRef.current;
+      const context = threadContextRef.current;
       const messages = visibleThreadMessages(await getMessageThread(messageId), activeFolder);
+      if (requestId !== threadLoadRequestRef.current || context !== threadContextRef.current) {
+        return null;
+      }
       setThread(messages);
       return messages;
     },
@@ -255,7 +263,7 @@ export function InboxPage({
               await runMessageAction(message.id, action);
               await onRefresh();
               const visibleMessages = await loadThread(selectedId);
-              if (visibleMessages.length === 0) onMessageRouteChange(activeFolder, null);
+              if (visibleMessages?.length === 0) onMessageRouteChange(activeFolder, null);
             }}
             onBack={() => onMessageRouteChange(activeFolder, null)}
             {...(onDraftsChange ? { onDraftsChange } : {})}

--- a/app/features/inbox/inbox-page.tsx
+++ b/app/features/inbox/inbox-page.tsx
@@ -76,10 +76,12 @@ export function InboxPage({
   const [detailError, setDetailError] = React.useState<string | null>(null);
   const [detailLoading, setDetailLoading] = React.useState(false);
   const threadLoadRequestRef = React.useRef(0);
-  const threadContextRef = React.useRef("");
-  threadContextRef.current = `${activeFolder}:${selectedId ?? ""}`;
+  const committedThreadContextRef = React.useRef({ activeFolder, selectedId });
   const onRefreshRef = React.useRef(onRefresh);
   const onMessageRouteChangeRef = React.useRef(onMessageRouteChange);
+  React.useLayoutEffect(() => {
+    committedThreadContextRef.current = { activeFolder, selectedId };
+  }, [activeFolder, selectedId]);
   React.useEffect(() => {
     onRefreshRef.current = onRefresh;
   }, [onRefresh]);
@@ -90,9 +92,12 @@ export function InboxPage({
   const loadThread = React.useCallback(
     async (messageId: string) => {
       const requestId = ++threadLoadRequestRef.current;
-      const context = threadContextRef.current;
+      const context = committedThreadContextRef.current;
       const messages = visibleThreadMessages(await getMessageThread(messageId), activeFolder);
-      if (requestId !== threadLoadRequestRef.current || context !== threadContextRef.current) {
+      if (
+        requestId !== threadLoadRequestRef.current ||
+        context !== committedThreadContextRef.current
+      ) {
         return null;
       }
       setThread(messages);

--- a/app/features/inbox/inbox-page.tsx
+++ b/app/features/inbox/inbox-page.tsx
@@ -6,7 +6,7 @@ import { setConversationLabel } from "@/features/labels/api";
 import { LabelFilter } from "@/features/labels/label-filter";
 import type { MailLabel } from "@/features/labels/types";
 import type { Mailbox } from "@/features/mailboxes/types";
-import { getMessageThread, runConversationAction } from "@/features/messages/api";
+import { getMessageThread, runConversationAction, runMessageAction } from "@/features/messages/api";
 import { MailListHeader } from "@/features/messages/mail-list-layout";
 import { MessageDetail } from "@/features/messages/message-detail";
 import { MessageList } from "@/features/messages/message-list";
@@ -236,6 +236,11 @@ export function InboxPage({
             selectedId={readerSelectedId}
             showBack
             onAction={handleAction}
+            onMessageAction={async (message, action) => {
+              await runMessageAction(message.id, action);
+              await onRefresh();
+              if (selectedId) await loadThread(selectedId);
+            }}
             onBack={() => onMessageRouteChange(activeFolder, null)}
             {...(onDraftsChange ? { onDraftsChange } : {})}
             onRefresh={async () => {

--- a/app/features/inbox/inbox-page.tsx
+++ b/app/features/inbox/inbox-page.tsx
@@ -76,14 +76,22 @@ export function InboxPage({
   const [detailError, setDetailError] = React.useState<string | null>(null);
   const [detailLoading, setDetailLoading] = React.useState(false);
   const onRefreshRef = React.useRef(onRefresh);
+  const onMessageRouteChangeRef = React.useRef(onMessageRouteChange);
   React.useEffect(() => {
     onRefreshRef.current = onRefresh;
   }, [onRefresh]);
+  React.useEffect(() => {
+    onMessageRouteChangeRef.current = onMessageRouteChange;
+  }, [onMessageRouteChange]);
 
-  const loadThread = React.useCallback(async (messageId: string) => {
-    const messages = await getMessageThread(messageId);
-    setThread(messages);
-  }, []);
+  const loadThread = React.useCallback(
+    async (messageId: string) => {
+      const messages = visibleThreadMessages(await getMessageThread(messageId), activeFolder);
+      setThread(messages);
+      return messages;
+    },
+    [activeFolder]
+  );
 
   React.useEffect(() => {
     if (!selectedId) {
@@ -99,9 +107,16 @@ export function InboxPage({
     void getMessageThread(selectedId)
       .then((messages) => {
         if (cancelled) return;
-        setThread(messages);
+        const visibleMessages = visibleThreadMessages(messages, activeFolder);
+        setThread(visibleMessages);
+        if (visibleMessages.length === 0) {
+          onMessageRouteChangeRef.current(activeFolder, null);
+          return;
+        }
         if (
-          messages.some((message) => message.direction === "inbound" && message.readAt === null)
+          visibleMessages.some(
+            (message) => message.direction === "inbound" && message.readAt === null
+          )
         ) {
           void runConversationAction(selectedId, "read", activeFolder)
             .then((updated) => {
@@ -239,7 +254,8 @@ export function InboxPage({
             onMessageAction={async (message, action) => {
               await runMessageAction(message.id, action);
               await onRefresh();
-              if (selectedId) await loadThread(selectedId);
+              const visibleMessages = await loadThread(selectedId);
+              if (visibleMessages.length === 0) onMessageRouteChange(activeFolder, null);
             }}
             onBack={() => onMessageRouteChange(activeFolder, null)}
             {...(onDraftsChange ? { onDraftsChange } : {})}
@@ -300,4 +316,12 @@ export function InboxPage({
       </div>
     </div>
   );
+}
+
+function visibleThreadMessages(
+  messages: MessageDetailType[],
+  activeFolder: MailFolderId
+): MessageDetailType[] {
+  const showsTrash = activeFolder === "trash";
+  return messages.filter((message) => (message.folder === "trash") === showsTrash);
 }

--- a/app/features/messages/api.ts
+++ b/app/features/messages/api.ts
@@ -1,6 +1,13 @@
 import { apiGet, apiPost } from "@/lib/api-client";
 import type { MailFolderId } from "@/lib/routes";
-import type { ConversationAction, ConversationPage, MessageDetail, MessageHtml } from "./types";
+import type {
+  ConversationAction,
+  ConversationPage,
+  MessageDetail,
+  MessageFolderAction,
+  MessageHtml,
+  MessageSummary
+} from "./types";
 
 export type MessageListParams = {
   cursor?: string | undefined;
@@ -42,4 +49,11 @@ export async function runConversationAction(
   folder: MailFolderId
 ): Promise<{ affected: number; threadId: string }> {
   return apiPost(`/api/v2/conversations/${id}/${action}`, { folder });
+}
+
+export async function runMessageAction(
+  id: string,
+  action: MessageFolderAction
+): Promise<MessageSummary> {
+  return apiPost(`/api/v2/messages/${id}/${action}`);
 }

--- a/app/features/messages/conversation-messages.tsx
+++ b/app/features/messages/conversation-messages.tsx
@@ -44,7 +44,8 @@ export function ConversationMessages({
   const [expandedThreadId, setExpandedThreadId] = React.useState<string | null>(null);
   const previousThreadId = React.useRef(threadId);
   const showMiddle = threadId !== null && expandedThreadId === threadId;
-  const [pendingMessageId, setPendingMessageId] = React.useState<string | null>(null);
+  const [pendingMessageIds, setPendingMessageIds] = React.useState<Set<string>>(() => new Set());
+  const pendingMessageIdsRef = React.useRef(new Set<string>());
   React.useEffect(() => {
     if (previousThreadId.current === threadId) return;
     previousThreadId.current = threadId;
@@ -181,13 +182,16 @@ export function ConversationMessages({
               <MessageActions
                 isLast={isLast}
                 message={message}
-                pending={pendingMessageId !== null}
+                pending={pendingMessageIds.has(message.id)}
                 onAction={async (action) => {
-                  setPendingMessageId(message.id);
+                  if (pendingMessageIdsRef.current.has(message.id)) return;
+                  pendingMessageIdsRef.current.add(message.id);
+                  setPendingMessageIds(new Set(pendingMessageIdsRef.current));
                   try {
                     await onMessageAction(message, action);
                   } finally {
-                    setPendingMessageId(null);
+                    pendingMessageIdsRef.current.delete(message.id);
+                    setPendingMessageIds(new Set(pendingMessageIdsRef.current));
                   }
                 }}
               />

--- a/app/features/messages/conversation-messages.tsx
+++ b/app/features/messages/conversation-messages.tsx
@@ -265,7 +265,7 @@ function MessageActions({
               onSelect={() => void onAction("trash")}
             >
               <PiTrash aria-hidden="true" className="size-4" />
-              Move message to Trash
+              Move to trash
             </DropdownMenuItem>
           ) : null}
         </DropdownMenuGroup>

--- a/app/features/messages/conversation-messages.tsx
+++ b/app/features/messages/conversation-messages.tsx
@@ -1,34 +1,50 @@
 import * as React from "react";
 import {
+  PiArchive,
   PiArrowBendUpLeft,
   PiArrowBendUpRight,
+  PiArrowCounterClockwise,
   PiArrowDownBold,
   PiArrowUpBold,
-  PiDownloadSimple
+  PiDotsThree,
+  PiDownloadSimple,
+  PiTrash
 } from "react-icons/pi";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/cn";
 import { formatDateTime } from "@/lib/format";
 import { MessageHtml, PlainTextMessage } from "./message-html";
-import type { MessageDetail } from "./types";
+import type { MessageDetail, MessageFolderAction } from "./types";
 
 export function ConversationMessages({
   compact = false,
   messages,
-  onCompose
+  onCompose,
+  onMessageAction
 }: {
   compact?: boolean;
   messages: MessageDetail[];
   onCompose?: (message: MessageDetail, mode: "reply" | "forward") => void;
+  onMessageAction?:
+    | ((message: MessageDetail, action: MessageFolderAction) => Promise<void> | void)
+    | undefined;
 }): React.ReactElement {
   const hiddenCount = Math.max(0, messages.length - 2);
   const threadId = messages[0]?.threadId ?? null;
   const [expandedThreadId, setExpandedThreadId] = React.useState<string | null>(null);
   const previousThreadId = React.useRef(threadId);
   const showMiddle = threadId !== null && expandedThreadId === threadId;
+  const [pendingMessageId, setPendingMessageId] = React.useState<string | null>(null);
   React.useEffect(() => {
     if (previousThreadId.current === threadId) return;
     previousThreadId.current = threadId;
@@ -123,39 +139,139 @@ export function ConversationMessages({
             </>
           ) : null}
         </div>
-        {onCompose && isLast ? (
+        {onCompose || onMessageAction ? (
           <footer className="mt-5 flex flex-wrap items-center gap-2">
-            <Button
-              aria-label={`Reply to message from ${message.fromAddress}`}
-              className="h-9 min-w-24 rounded-full px-4"
-              data-compose-action="reply"
-              data-compose-message-id={message.id}
-              onClick={() => onCompose(message, "reply")}
-              size="sm"
-              type="button"
-              variant="outline"
-            >
-              <PiArrowBendUpLeft />
-              Reply
-            </Button>
-            <Button
-              aria-label={`Forward message from ${message.fromAddress}`}
-              className="h-9 min-w-24 rounded-full px-4"
-              data-compose-action="forward"
-              data-compose-message-id={message.id}
-              onClick={() => onCompose(message, "forward")}
-              size="sm"
-              type="button"
-              variant="outline"
-            >
-              <PiArrowBendUpRight />
-              Forward
-            </Button>
+            {onCompose ? (
+              <>
+                <Button
+                  aria-label={`Reply to message from ${message.fromAddress}`}
+                  className={cn(
+                    "rounded-full",
+                    isLast ? "h-9 min-w-24 px-4" : "h-8 min-w-0 px-3 text-xs"
+                  )}
+                  data-compose-action="reply"
+                  data-compose-message-id={message.id}
+                  onClick={() => onCompose(message, "reply")}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  <PiArrowBendUpLeft />
+                  Reply
+                </Button>
+                <Button
+                  aria-label={`Forward message from ${message.fromAddress}`}
+                  className={cn(
+                    "rounded-full",
+                    isLast ? "h-9 min-w-24 px-4" : "h-8 min-w-0 px-3 text-xs"
+                  )}
+                  data-compose-action="forward"
+                  data-compose-message-id={message.id}
+                  onClick={() => onCompose(message, "forward")}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  <PiArrowBendUpRight />
+                  Forward
+                </Button>
+              </>
+            ) : null}
+            {onMessageAction ? (
+              <MessageActions
+                isLast={isLast}
+                message={message}
+                pending={pendingMessageId !== null}
+                onAction={async (action) => {
+                  setPendingMessageId(message.id);
+                  try {
+                    await onMessageAction(message, action);
+                  } finally {
+                    setPendingMessageId(null);
+                  }
+                }}
+              />
+            ) : null}
           </footer>
         ) : null}
       </article>
     );
   }
+}
+
+function MessageActions({
+  isLast,
+  message,
+  pending,
+  onAction
+}: {
+  isLast: boolean;
+  message: MessageDetail;
+  pending: boolean;
+  onAction: (action: MessageFolderAction) => Promise<void> | void;
+}): React.ReactElement {
+  const restoreAction = message.folder === "trash" ? "restore" : "unarchive";
+  const restoreLabel = message.folder === "trash" ? "Restore message" : "Unarchive message";
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          aria-label={`More actions for message from ${message.fromAddress}`}
+          className={cn(
+            "rounded-full",
+            isLast ? "size-9 min-h-9 min-w-9" : "size-8 min-h-8 min-w-8"
+          )}
+          data-message-actions-id={message.id}
+          disabled={pending}
+          size="icon"
+          type="button"
+          variant="outline"
+        >
+          <PiDotsThree aria-hidden="true" className="pointer-events-none" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        className="w-52 p-1 text-sm"
+        data-message-actions-menu={message.id}
+      >
+        <DropdownMenuGroup>
+          {message.folder === "archived" || message.folder === "trash" ? (
+            <DropdownMenuItem
+              className="min-h-10 gap-2"
+              data-message-action={restoreAction}
+              data-message-id={message.id}
+              onSelect={() => void onAction(restoreAction)}
+            >
+              <PiArrowCounterClockwise aria-hidden="true" className="size-4" />
+              {restoreLabel}
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              className="min-h-10 gap-2"
+              data-message-action="archive"
+              data-message-id={message.id}
+              onSelect={() => void onAction("archive")}
+            >
+              <PiArchive aria-hidden="true" className="size-4" />
+              Archive message
+            </DropdownMenuItem>
+          )}
+          {message.folder !== "trash" ? (
+            <DropdownMenuItem
+              className="min-h-10 gap-2"
+              data-message-action="trash"
+              data-message-id={message.id}
+              onSelect={() => void onAction("trash")}
+            >
+              <PiTrash aria-hidden="true" className="size-4" />
+              Move message to Trash
+            </DropdownMenuItem>
+          ) : null}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 }
 
 function ThreadMessagesDivider({

--- a/app/features/messages/message-detail.tsx
+++ b/app/features/messages/message-detail.tsx
@@ -28,7 +28,7 @@ import { cn } from "@/lib/cn";
 import type { MailFolderId } from "@/lib/routes";
 import { ConversationMessages } from "./conversation-messages";
 import { IconButton, MessageReaderStatus } from "./message-reader-primitives";
-import type { MessageDetail as MessageDetailType } from "./types";
+import type { MessageDetail as MessageDetailType, MessageFolderAction } from "./types";
 
 type MessageDetailProps = {
   activeFolder?: MailFolderId;
@@ -47,6 +47,9 @@ type MessageDetailProps = {
   onBack: () => void;
   onDraftsChange?: () => void;
   onLabelsChanged?: (() => Promise<void>) | undefined;
+  onMessageAction?:
+    | ((message: MessageDetailType, action: MessageFolderAction) => Promise<void> | void)
+    | undefined;
   onRefresh: () => Promise<void> | void;
   onSent: () => void;
   onToggleLabel?: (label: MailLabel, assigned: boolean) => Promise<void> | void;
@@ -76,6 +79,7 @@ export function MessageDetail({
   onAction,
   onBack,
   onLabelsChanged,
+  onMessageAction,
   onRefresh,
   onSent,
   onToggleLabel
@@ -111,6 +115,18 @@ export function MessageDetail({
       if (successMessage) toast.success(successMessage);
     } catch {
       toast.error("The conversation could not be updated. Try again.");
+    }
+  }
+  async function applyMessageAction(
+    message: MessageDetailType,
+    action: MessageFolderAction
+  ): Promise<void> {
+    if (!onMessageAction) return;
+    try {
+      await onMessageAction(message, action);
+      toast.success(messageActionSuccess(action));
+    } catch {
+      toast.error("The message could not be updated. Try again.");
     }
   }
   function renderReaderLabels(placement: "desktop" | "mobile"): React.ReactElement | null {
@@ -320,6 +336,7 @@ export function MessageDetail({
         {renderReaderLabels("mobile")}
         <ConversationMessages
           messages={messages}
+          {...(onMessageAction ? { onMessageAction: applyMessageAction } : {})}
           onCompose={(message, mode) => {
             const folder = activeFolder ?? message.folder;
             const messageId = routeMessageId ?? selectedId ?? message.id;
@@ -341,6 +358,13 @@ export function MessageDetail({
       </PullToRefresh>
     </article>
   );
+}
+
+function messageActionSuccess(action: MessageFolderAction): string {
+  if (action === "archive") return "Message archived.";
+  if (action === "unarchive") return "Message unarchived.";
+  if (action === "trash") return "Message moved to Trash.";
+  return "Message restored.";
 }
 
 function mergeMessageLabels(messages: MessageDetailType[]): MailLabel[] {

--- a/app/features/messages/message-html.tsx
+++ b/app/features/messages/message-html.tsx
@@ -323,7 +323,7 @@ export function RemoteImagesAlert({
     <Alert className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-2 gap-y-1 rounded-md border-border/60 bg-muted/50 px-2.5 py-1.5 text-xs sm:grid-cols-[auto_minmax(0,1fr)_auto] [&>svg]:static [&>svg]:size-3.5 [&>svg]:text-muted-foreground [&>svg~*]:pl-0">
       <PiImageBroken />
       <AlertTitle className="mb-0 min-w-0 line-clamp-2 text-[11px] font-semibold leading-[14px] tracking-normal">
-        Remote images are hidden. Loading them may reveal that you opened this email.
+        Some remote images are hidden. Loading them may reveal that you opened this email.
       </AlertTitle>
       <AlertDescription className="col-start-2 row-start-2 flex flex-wrap gap-1 pt-0.5 sm:col-start-3 sm:row-start-1 sm:flex-nowrap sm:pt-0">
         <Button

--- a/app/features/messages/types.ts
+++ b/app/features/messages/types.ts
@@ -44,6 +44,11 @@ export type ConversationAction =
   | "trash"
   | "restore";
 
+export type MessageFolderAction = Extract<
+  ConversationAction,
+  "archive" | "unarchive" | "trash" | "restore"
+>;
+
 export type MessageDetail = MessageSummary & {
   cc: string[];
   bcc: string[];

--- a/app/features/search/global-search.tsx
+++ b/app/features/search/global-search.tsx
@@ -143,7 +143,7 @@ export function GlobalSearch({
         aria-expanded={listOpen}
         aria-label="Search HQBase"
         autoComplete="off"
-        className="border-transparent bg-muted/70 pl-8 pr-9 text-xs shadow-none focus-visible:border-input focus-visible:ring-1"
+        className="border-transparent bg-muted/70 pl-8 pr-9 text-xs shadow-none"
         maxLength={200}
         placeholder="Search HQBase"
         role="combobox"
@@ -166,7 +166,7 @@ export function GlobalSearch({
       {query.length > 0 ? (
         <button
           aria-label="Clear search"
-          className="absolute right-0.5 top-px z-10 grid size-7 place-items-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          className="absolute right-0.5 top-px z-10 grid size-7 place-items-center rounded-md text-muted-foreground transition-colors hover:text-foreground"
           title="Clear search"
           type="button"
           onClick={() => {

--- a/app/features/signatures/compose-signature.tsx
+++ b/app/features/signatures/compose-signature.tsx
@@ -111,7 +111,7 @@ export function ComposeSignature({
   }
 
   return (
-    <div className="px-5 pb-3">
+    <div className="shrink-0 px-5 pb-3">
       <SignaturePreview signature={signature} />
       <div className="mt-1.5 flex max-w-full items-center gap-2">
         <span className="text-xs text-muted-foreground">Signature</span>

--- a/app/features/users/role-select.tsx
+++ b/app/features/users/role-select.tsx
@@ -17,7 +17,7 @@ export function RoleSelect({
   return (
     <DropdownSelect
       ariaLabel={ariaLabel}
-      className="w-32 px-2.5 text-[13px] shadow-none focus-visible:ring-1"
+      className="w-32 px-2.5 text-[13px] shadow-none"
       disabled={disabled}
       options={roles.map((role) => ({ label: role, value: role }))}
       size="sm"

--- a/app/styles.css
+++ b/app/styles.css
@@ -64,7 +64,7 @@
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 88%;
     --input: 0 0% 82%;
-    --ring: 0 0% 35%;
+    --focus-border: 0 0% 48%;
     --surface-rail: 240 4% 96%;
     --surface-sidebar: 240 5% 99%;
     --surface-toolbar: 240 5% 100%;
@@ -98,7 +98,7 @@
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 15%;
     --input: 0 0% 18%;
-    --ring: 0 0% 55%;
+    --focus-border: 0 0% 38%;
     --surface-rail: 240 5% 4%;
     --surface-sidebar: 240 5% 7%;
     --surface-toolbar: 240 5% 8%;
@@ -272,25 +272,32 @@
   [role="option"],
   [tabindex]:not([tabindex="-1"])
 ):focus-visible {
-  --tw-ring-offset-shadow: 0 0 #0000;
-  --tw-ring-shadow: 0 0 #0000;
-  outline: 1px solid hsl(var(--ring));
-  outline-offset: 1px;
+  --tw-ring-offset-shadow: 0 0 #0000 !important;
+  --tw-ring-shadow: 0 0 #0000 !important;
+  outline: 1px solid hsl(var(--focus-border)) !important;
+  outline-offset: 1px !important;
 }
 
 :where(input:not([type="checkbox"]):not([type="radio"]), textarea, select):focus-visible {
-  --tw-ring-offset-shadow: 0 0 #0000;
-  --tw-ring-shadow: 0 0 #0000;
-  border-color: hsl(var(--ring));
-  box-shadow: none;
-  outline: none;
+  border-color: hsl(var(--focus-border)) !important;
+  box-shadow: none !important;
+  outline: none !important;
 }
 
-[data-slot="input-group"]:focus-within {
-  --tw-ring-offset-shadow: 0 0 #0000;
-  --tw-ring-shadow: 0 0 #0000;
-  border-color: hsl(var(--ring));
-  box-shadow: none;
+:where([contenteditable="true"][data-compose-autofocus]):focus-visible {
+  outline: none !important;
+}
+
+[data-slot="input-group"]:focus-within,
+[data-slot="dropdown-select"]:focus-visible {
+  border-color: hsl(var(--focus-border)) !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+:where(input, textarea, select)[aria-invalid="true"]:focus-visible,
+[data-slot="input-group"][data-invalid="true"]:focus-within {
+  border-color: hsl(var(--destructive)) !important;
 }
 
 * {

--- a/scripts/release/deploy.mjs
+++ b/scripts/release/deploy.mjs
@@ -64,7 +64,8 @@ export async function deploy(options = {}) {
     const config = normalizeConfig(
       JSON.parse(readFileSync(configFile, "utf8")),
       manifest.version,
-      manifest.artifact.sha256
+      manifest.artifact.sha256,
+      JSON.parse(readFileSync(resolve(source, "wrangler.jsonc"), "utf8"))
     );
     const recordWorkerDeployed = () => recordWorkerDeployedForConfig(configFile, config.name);
     writeFileSync(resolve(source, "wrangler.jsonc"), `${JSON.stringify(config, null, 2)}\n`);

--- a/scripts/release/manifest.mjs
+++ b/scripts/release/manifest.mjs
@@ -98,8 +98,8 @@ export function compareVersions(left, right) {
   return 0;
 }
 
-export function normalizeConfig(config, version, artifactSha256) {
-  return {
+export function normalizeConfig(config, version, artifactSha256, releaseConfig = config) {
+  const normalized = {
     ...config,
     $schema: "./node_modules/wrangler/config-schema.json",
     main: "worker/index.ts",
@@ -131,6 +131,18 @@ export function normalizeConfig(config, version, artifactSha256) {
       return normalized;
     })
   };
+
+  if (releaseConfig.durable_objects) {
+    normalized.durable_objects = releaseConfig.durable_objects;
+  } else {
+    delete normalized.durable_objects;
+  }
+  if (releaseConfig.migrations) {
+    normalized.migrations = releaseConfig.migrations;
+  } else {
+    delete normalized.migrations;
+  }
+  return normalized;
 }
 
 export function hqbaseReleaseTag(version, artifactSha256) {

--- a/scripts/release/package.mjs
+++ b/scripts/release/package.mjs
@@ -6,6 +6,7 @@ import { resolve } from "node:path";
 import { gzipSync } from "node:zlib";
 
 import { extractReleaseNotes, releaseNoteItems } from "./notes.mjs";
+import { assertStableReleaseVersion } from "./version.mjs";
 
 const root = resolve(import.meta.dirname, "../..");
 const product = "hqbase";
@@ -13,6 +14,7 @@ const schemaVersion = 3;
 const packageJson = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
 const version = process.env.HQBASE_RELEASE_VERSION ?? packageJson.version;
 const minVersion = process.env.HQBASE_MIN_VERSION || packageJson.hqbaseRelease?.minimumVersion;
+assertStableReleaseVersion(version);
 const changelog = readFileSync(resolve(root, "CHANGELOG.md"), "utf8");
 const notes = releaseNoteItems(extractReleaseNotes(changelog, version));
 const privateKeyValue = process.env.HQBASE_RELEASE_PRIVATE_KEY_FILE
@@ -20,8 +22,6 @@ const privateKeyValue = process.env.HQBASE_RELEASE_PRIVATE_KEY_FILE
   : process.env.HQBASE_RELEASE_PRIVATE_KEY;
 
 if (!privateKeyValue) throw new Error("HQBASE_RELEASE_PRIVATE_KEY is required.");
-if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version))
-  throw new Error("Release version must be semantic.");
 if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(minVersion ?? ""))
   throw new Error("Minimum release version must be semantic.");
 const output = resolve(root, "release");

--- a/scripts/release/version.mjs
+++ b/scripts/release/version.mjs
@@ -1,0 +1,8 @@
+const stableVersionPattern = /^\d+\.\d+\.\d+$/;
+
+export function assertStableReleaseVersion(value, label = "Release version") {
+  if (!stableVersionPattern.test(value)) {
+    throw new Error(`${label} must be a stable semantic version.`);
+  }
+  return value;
+}

--- a/scripts/release/version.mjs
+++ b/scripts/release/version.mjs
@@ -1,4 +1,4 @@
-const stableVersionPattern = /^\d+\.\d+\.\d+$/;
+const stableVersionPattern = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
 
 export function assertStableReleaseVersion(value, label = "Release version") {
   if (!stableVersionPattern.test(value)) {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,7 +8,7 @@ export default {
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
+        ring: "hsl(var(--focus-border))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
         primary: {

--- a/test/integration/worker/conversations.test.ts
+++ b/test/integration/worker/conversations.test.ts
@@ -173,6 +173,22 @@ describe("conversation persistence", () => {
       })
     ).resolves.toMatchObject({ affected: 1 });
 
+    const inboxAfterTrash = await listConversations(env.DB, filters);
+    const trashAfterTrash = await listConversations(env.DB, {
+      folder: "trash",
+      scope: { includeUnassigned: false, mailboxIds: ["mbx_conversations"] }
+    });
+    expect(
+      inboxAfterTrash.find((conversation) => conversation.threadId === alice?.threadId)
+    ).toMatchObject({
+      id: "msg_root_a",
+      messageCount: 1,
+      unreadCount: 0
+    });
+    expect(trashAfterTrash).toEqual([
+      expect.objectContaining({ id: "msg_reply_a", messageCount: 1, unreadCount: 0 })
+    ]);
+
     await expect(
       updateConversationAction(env.DB, {
         action: "restore",

--- a/test/unit/app/compose/attachment-list.test.tsx
+++ b/test/unit/app/compose/attachment-list.test.tsx
@@ -30,4 +30,27 @@ describe("compose attachment list", () => {
     expect(html).not.toContain("logo.png");
     expect(html).toContain("report.pdf");
   });
+
+  it("shows original files as included without a remove action", () => {
+    const html = renderToStaticMarkup(
+      <AttachmentList
+        attachments={[]}
+        includedAttachments={[
+          {
+            id: "original-file",
+            filename: "original.pdf",
+            contentType: "application/pdf",
+            sizeBytes: 2048,
+            contentId: null,
+            disposition: "attachment"
+          }
+        ]}
+        onRemove={() => undefined}
+      />
+    );
+
+    expect(html).toContain("Included from original message");
+    expect(html).toContain("original.pdf");
+    expect(html).not.toContain("Remove original.pdf");
+  });
 });

--- a/test/unit/app/compose/compose-form.test.tsx
+++ b/test/unit/app/compose/compose-form.test.tsx
@@ -32,6 +32,7 @@ describe("compose form", () => {
         identities={[
           { address: "support@example.com", displayName: "Support", mailboxId: "mailbox-1" }
         ]}
+        includedAttachments={[]}
         isPending={false}
         mode="new"
         presentation="window"

--- a/test/unit/app/compose/compose-window.test.tsx
+++ b/test/unit/app/compose/compose-window.test.tsx
@@ -58,6 +58,8 @@ describe("compose window", () => {
     expect(dialog?.style.bottom).toBe("0px");
     expect(dialog?.style.right).toBe("16px");
     expect(dialog?.className).toContain("lg:resize");
+    expect(dialog?.className).toContain("lg:h-[min(34rem,calc(100vh-5rem))]");
+    expect(dialog?.className).not.toContain("lg:h-[min(42rem,calc(100vh-5rem))]");
     expect(document.body.textContent).not.toContain("Expand compose");
 
     Object.assign(header ?? {}, {

--- a/test/unit/app/compose/rich-email-editor.test.tsx
+++ b/test/unit/app/compose/rich-email-editor.test.tsx
@@ -11,6 +11,31 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+describe("rich email editor layout", () => {
+  it("uses a compact height and keeps filled content from shrinking through the signature", async () => {
+    const view = await renderComponent(
+      <RichEmailEditor
+        contained={false}
+        fill
+        html="<p>Hello</p>"
+        onChange={() => undefined}
+        onImages={async () => []}
+      />
+    );
+    document.body.appendChild(view.container);
+
+    const editor = view.container.querySelector<HTMLElement>(".ProseMirror");
+    const editorContent = editor?.parentElement;
+    const editorRoot = editorContent?.parentElement;
+    expect(editor?.className).toContain("min-h-48");
+    expect(editor?.className).not.toContain("min-h-60");
+    expect(editorContent?.className).toContain("min-h-48");
+    expect(editorRoot?.className).toContain("flex-1");
+    expect(editorRoot?.className).not.toContain("min-h-0");
+    await view.unmount();
+  });
+});
+
 describe("rich email editor images", () => {
   it("uploads an image and shows one resize control only after selection", async () => {
     const onChange = vi.fn();

--- a/test/unit/app/contacts/contacts-page.test.tsx
+++ b/test/unit/app/contacts/contacts-page.test.tsx
@@ -113,7 +113,7 @@ describe("contacts page", () => {
     const privateDetails = privateHeading?.closest("details");
     expect(privateDetails).toBeDefined();
     expect(privateDetails?.open).toBe(false);
-    expect(privateHeading?.closest("summary")).toBeDefined();
+    expect(privateHeading?.closest("summary")).toBeTruthy();
     expect(privateDetails?.className).not.toContain("rounded-xl");
     expect(privateDetails?.className).not.toContain("bg-background");
 

--- a/test/unit/app/contacts/contacts-page.test.tsx
+++ b/test/unit/app/contacts/contacts-page.test.tsx
@@ -110,8 +110,12 @@ describe("contacts page", () => {
     const privateHeading = [...view.container.querySelectorAll("h2")].find(
       (heading) => heading.textContent === "Private contact details"
     );
-    expect(privateHeading?.closest("section")?.className).not.toContain("rounded-xl");
-    expect(privateHeading?.closest("section")?.className).not.toContain("bg-background");
+    const privateDetails = privateHeading?.closest("details");
+    expect(privateDetails).toBeDefined();
+    expect(privateDetails?.open).toBe(false);
+    expect(privateHeading?.closest("summary")).toBeDefined();
+    expect(privateDetails?.className).not.toContain("rounded-xl");
+    expect(privateDetails?.className).not.toContain("bg-background");
 
     const newEmail = Array.from(view.container.querySelectorAll("button")).find((button) =>
       button.textContent?.includes("New email")

--- a/test/unit/app/layout/mobile-shell.test.ts
+++ b/test/unit/app/layout/mobile-shell.test.ts
@@ -177,8 +177,13 @@ describe("mobile application shell", () => {
 
   it("uses quiet focus treatments and compact trackless scrollbars", () => {
     expect(styles).toContain('input:not([type="checkbox"]):not([type="radio"])');
-    expect(styles).toContain("border-color: hsl(var(--ring))");
-    expect(styles).toContain("box-shadow: none");
+    expect(styles).toContain("--focus-border: 0 0% 48%");
+    expect(styles).toContain("--focus-border: 0 0% 38%");
+    expect(styles).toContain("border-color: hsl(var(--focus-border)) !important");
+    expect(styles).toContain("--tw-ring-shadow: 0 0 #0000 !important");
+    expect(styles).toContain("box-shadow: none !important");
+    expect(styles).toContain('[data-slot="dropdown-select"]:focus-visible');
+    expect(styles).toContain('[contenteditable="true"][data-compose-autofocus]');
     expect(styles).toContain("*::-webkit-scrollbar");
     expect(styles).toContain("width: 6px");
     expect(styles).toContain("scrollbar-width: thin");

--- a/test/unit/app/messages/conversation-message-actions.test.tsx
+++ b/test/unit/app/messages/conversation-message-actions.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ConversationMessages } from "@/features/messages/conversation-messages";
 import type { MessageDetail } from "@/features/messages/types";
@@ -50,15 +50,26 @@ const secondMessage: MessageDetail = {
   createdAt: "2026-07-27T14:05:00.000Z"
 };
 
-describe("conversation message actions", () => {
-  it("replies to and forwards the latest message", async () => {
-    const onCompose = vi.fn();
-    const view = await renderComponent(
-      <ConversationMessages messages={[firstMessage, secondMessage]} onCompose={onCompose} />
-    );
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
 
-    const reply = view.container.querySelector<HTMLButtonElement>(
-      '[data-compose-action="reply"][data-compose-message-id="msg_2"]'
+describe("conversation message actions", () => {
+  it("targets every expanded message for compose and folder actions", async () => {
+    const onCompose = vi.fn();
+    const onMessageAction = vi.fn().mockResolvedValue(undefined);
+    const view = await renderComponent(
+      <ConversationMessages
+        messages={[firstMessage, secondMessage]}
+        onCompose={onCompose}
+        onMessageAction={onMessageAction}
+      />
+    );
+    document.body.appendChild(view.container);
+
+    const firstReply = view.container.querySelector<HTMLButtonElement>(
+      '[data-compose-action="reply"][data-compose-message-id="msg_1"]'
     );
     const lastForward = view.container.querySelector<HTMLButtonElement>(
       '[data-compose-action="forward"][data-compose-message-id="msg_2"]'
@@ -69,11 +80,59 @@ describe("conversation message actions", () => {
     expect(
       view.container.querySelector<HTMLElement>('[data-thread-message-id="msg_2"]')?.className
     ).toContain("pt-5");
-    await flushHookEffects(() => reply?.click());
+    expect(firstReply?.className).toContain("h-8");
+    expect(lastForward?.className).toContain("h-9");
+    await flushHookEffects(() => firstReply?.click());
     await flushHookEffects(() => lastForward?.click());
 
-    expect(onCompose).toHaveBeenNthCalledWith(1, secondMessage, "reply");
+    expect(onCompose).toHaveBeenNthCalledWith(1, firstMessage, "reply");
     expect(onCompose).toHaveBeenNthCalledWith(2, secondMessage, "forward");
+
+    const messageActions = view.container.querySelector<HTMLButtonElement>(
+      '[data-message-actions-id="msg_1"]'
+    );
+    await flushHookEffects(() => {
+      messageActions?.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerType: "mouse" })
+      );
+      messageActions?.click();
+    });
+    const menu = document.body.querySelector<HTMLElement>('[data-message-actions-menu="msg_1"]');
+    expect(menu?.textContent).toContain("Archive message");
+    expect(menu?.textContent).toContain("Move message to Trash");
+    await flushHookEffects(() =>
+      menu?.querySelector<HTMLElement>('[data-message-action="archive"]')?.click()
+    );
+    expect(onMessageAction).toHaveBeenCalledWith(firstMessage, "archive");
+
+    await view.unmount();
+  });
+
+  it("offers Restore instead of Archive or Trash for one trashed message", async () => {
+    const trashedMessage = { ...firstMessage, folder: "trash" as const };
+    const onMessageAction = vi.fn().mockResolvedValue(undefined);
+    const view = await renderComponent(
+      <ConversationMessages messages={[trashedMessage]} onMessageAction={onMessageAction} />
+    );
+    document.body.appendChild(view.container);
+
+    const trigger = view.container.querySelector<HTMLButtonElement>(
+      '[data-message-actions-id="msg_1"]'
+    );
+    await flushHookEffects(() => {
+      trigger?.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerType: "mouse" })
+      );
+      trigger?.click();
+    });
+    const menu = document.body.querySelector<HTMLElement>('[data-message-actions-menu="msg_1"]');
+    expect(menu?.textContent).toContain("Restore message");
+    expect(menu?.textContent).not.toContain("Archive message");
+    expect(menu?.textContent).not.toContain("Move message to Trash");
+    await flushHookEffects(() =>
+      menu?.querySelector<HTMLElement>('[data-message-action="restore"]')?.click()
+    );
+    expect(onMessageAction).toHaveBeenCalledWith(trashedMessage, "restore");
 
     await view.unmount();
   });

--- a/test/unit/app/messages/conversation-message-actions.test.tsx
+++ b/test/unit/app/messages/conversation-message-actions.test.tsx
@@ -99,7 +99,7 @@ describe("conversation message actions", () => {
     });
     const menu = document.body.querySelector<HTMLElement>('[data-message-actions-menu="msg_1"]');
     expect(menu?.textContent).toContain("Archive message");
-    expect(menu?.textContent).toContain("Move message to Trash");
+    expect(menu?.textContent).toContain("Move to trash");
     await flushHookEffects(() =>
       menu?.querySelector<HTMLElement>('[data-message-action="archive"]')?.click()
     );
@@ -128,7 +128,7 @@ describe("conversation message actions", () => {
     const menu = document.body.querySelector<HTMLElement>('[data-message-actions-menu="msg_1"]');
     expect(menu?.textContent).toContain("Restore message");
     expect(menu?.textContent).not.toContain("Archive message");
-    expect(menu?.textContent).not.toContain("Move message to Trash");
+    expect(menu?.textContent).not.toContain("Move to trash");
     await flushHookEffects(() =>
       menu?.querySelector<HTMLElement>('[data-message-action="restore"]')?.click()
     );

--- a/test/unit/app/messages/conversation-message-actions.test.tsx
+++ b/test/unit/app/messages/conversation-message-actions.test.tsx
@@ -137,6 +137,39 @@ describe("conversation message actions", () => {
     await view.unmount();
   });
 
+  it("tracks pending actions for each message independently", async () => {
+    const resolvers = new Map<string, () => void>();
+    const onMessageAction = vi.fn(
+      (message: MessageDetail) =>
+        new Promise<void>((resolve) => {
+          resolvers.set(message.id, resolve);
+        })
+    );
+    const view = await renderComponent(
+      <ConversationMessages
+        messages={[firstMessage, secondMessage]}
+        onMessageAction={onMessageAction}
+      />
+    );
+    document.body.appendChild(view.container);
+
+    await selectArchive(view.container, firstMessage.id);
+    expect(messageActionTrigger(view.container, firstMessage.id)?.disabled).toBe(true);
+    expect(messageActionTrigger(view.container, secondMessage.id)?.disabled).toBe(false);
+
+    await selectArchive(view.container, secondMessage.id);
+    expect(onMessageAction).toHaveBeenCalledTimes(2);
+    expect(messageActionTrigger(view.container, secondMessage.id)?.disabled).toBe(true);
+
+    await flushHookEffects(() => resolvers.get(firstMessage.id)?.());
+    expect(messageActionTrigger(view.container, firstMessage.id)?.disabled).toBe(false);
+    expect(messageActionTrigger(view.container, secondMessage.id)?.disabled).toBe(true);
+
+    await flushHookEffects(() => resolvers.get(secondMessage.id)?.());
+    expect(messageActionTrigger(view.container, secondMessage.id)?.disabled).toBe(false);
+    await view.unmount();
+  });
+
   it("removes the counted thread control after it reveals the hidden messages", async () => {
     const messages = Array.from({ length: 4 }, (_, index) => ({
       ...firstMessage,
@@ -206,3 +239,24 @@ describe("conversation message actions", () => {
     await view.unmount();
   });
 });
+
+function messageActionTrigger(container: HTMLElement, messageId: string): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>(`[data-message-actions-id="${messageId}"]`);
+}
+
+async function selectArchive(container: HTMLElement, messageId: string): Promise<void> {
+  const trigger = messageActionTrigger(container, messageId);
+  await flushHookEffects(() => {
+    trigger?.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerType: "mouse" })
+    );
+    trigger?.click();
+  });
+  await flushHookEffects(() =>
+    document.body
+      .querySelector<HTMLElement>(
+        `[data-message-actions-menu="${messageId}"] [data-message-action="archive"]`
+      )
+      ?.click()
+  );
+}

--- a/test/unit/app/messages/conversation-reader.test.tsx
+++ b/test/unit/app/messages/conversation-reader.test.tsx
@@ -66,7 +66,7 @@ const conversation: ConversationSummary = {
 };
 
 describe("conversation reader", () => {
-  it("renders Reply and Forward under the last message", () => {
+  it("renders Reply and Forward under every expanded message", () => {
     const html = renderToStaticMarkup(
       <MessageDetail
         defaultFromMailboxId="mbx_1"
@@ -82,9 +82,9 @@ describe("conversation reader", () => {
 
     expect(html.indexOf("I cannot sign in.")).toBeLessThan(html.indexOf("We can help."));
     expect(html.indexOf("We can help.")).toBeLessThan(html.lastIndexOf(">Reply<"));
-    expect(html.match(/>Reply</g)).toHaveLength(1);
-    expect(html.match(/>Forward</g)).toHaveLength(1);
-    expect(html).not.toContain('data-compose-message-id="msg_1"');
+    expect(html.match(/>Reply</g)).toHaveLength(2);
+    expect(html.match(/>Forward</g)).toHaveLength(2);
+    expect(html.match(/data-compose-message-id="msg_1"/g)).toHaveLength(2);
     expect(html.match(/data-compose-message-id="msg_2"/g)).toHaveLength(2);
     expectReaderBackLayout(html);
     expect(html).toContain('aria-label="Archive conversation"');

--- a/test/unit/app/messages/inbox-message-visibility.test.tsx
+++ b/test/unit/app/messages/inbox-message-visibility.test.tsx
@@ -181,7 +181,7 @@ describe("Inbox message visibility", () => {
     await view.unmount();
   });
 
-  it("ignores a stale refresh after another thread opens", async () => {
+  it("keeps the committed thread current across suspended and completed navigation", async () => {
     const secondThreadMessage = {
       ...firstMessage,
       id: "msg_other",
@@ -190,14 +190,27 @@ describe("Inbox message visibility", () => {
       textBody: "Other conversation body"
     };
     let delayFirstThread = false;
-    let resolveFirstThread: ((messages: MessageDetailType[]) => void) | undefined;
+    const pendingFirstThreadLoads: Array<(messages: MessageDetailType[]) => void> = [];
+    let navigationReleased = false;
+    let releaseNavigation: (() => void) | undefined;
+    const navigation = new Promise<void>((resolve) => {
+      releaseNavigation = () => {
+        navigationReleased = true;
+        resolve();
+      };
+    });
     mocks.getMessageThread.mockImplementation((messageId: string) => {
       if (messageId === secondThreadMessage.id) return Promise.resolve([secondThreadMessage]);
       if (!delayFirstThread) return Promise.resolve([firstMessage]);
       return new Promise<MessageDetailType[]>((resolve) => {
-        resolveFirstThread = resolve;
+        pendingFirstThreadLoads.push(resolve);
       });
     });
+
+    function SuspendNavigation({ active }: { active: boolean }) {
+      if (active && !navigationReleased) throw navigation;
+      return null;
+    }
 
     function Harness() {
       const [selectedId, setSelectedId] = React.useState<string | null>(firstMessage.id);
@@ -205,34 +218,37 @@ describe("Inbox message visibility", () => {
         <>
           <button
             data-select-other
-            onClick={() => setSelectedId(secondThreadMessage.id)}
+            onClick={() => React.startTransition(() => setSelectedId(secondThreadMessage.id))}
             type="button"
           >
             Select other
           </button>
-          <InboxPage
-            activeFolder="inbox"
-            conversations={[
-              {
-                ...firstMessage,
-                isStarred: false,
-                messageCount: 1,
-                unreadCount: 0
-              }
-            ]}
-            defaultFromMailboxId="mbx_1"
-            hasMore={false}
-            isLoadingMore={false}
-            loadMoreError={null}
-            mailboxes={[]}
-            selectedId={selectedId}
-            totalCount={1}
-            onConversationAction={() => undefined}
-            onLoadMore={() => undefined}
-            onMessageRouteChange={(_folder, messageId) => setSelectedId(messageId)}
-            onRefresh={() => undefined}
-            onSelect={() => undefined}
-          />
+          <React.Suspense fallback={null}>
+            <InboxPage
+              activeFolder="inbox"
+              conversations={[
+                {
+                  ...firstMessage,
+                  isStarred: false,
+                  messageCount: 1,
+                  unreadCount: 0
+                }
+              ]}
+              defaultFromMailboxId="mbx_1"
+              hasMore={false}
+              isLoadingMore={false}
+              loadMoreError={null}
+              mailboxes={[]}
+              selectedId={selectedId}
+              totalCount={1}
+              onConversationAction={() => undefined}
+              onLoadMore={() => undefined}
+              onMessageRouteChange={(_folder, messageId) => setSelectedId(messageId)}
+              onRefresh={() => undefined}
+              onSelect={() => undefined}
+            />
+            <SuspendNavigation active={selectedId === secondThreadMessage.id} />
+          </React.Suspense>
         </>
       );
     }
@@ -246,9 +262,18 @@ describe("Inbox message visibility", () => {
     await flushHookEffects(() =>
       view.container.querySelector<HTMLButtonElement>("[data-select-other]")?.click()
     );
+    expect(visibleMessageIds(view.container)).toBe(firstMessage.id);
+
+    await flushHookEffects(() => pendingFirstThreadLoads.shift()?.([firstMessage, sentMessage]));
+    expect(visibleMessageIds(view.container)).toBe(`${firstMessage.id},${sentMessage.id}`);
+
+    await flushHookEffects(() =>
+      view.container.querySelector<HTMLButtonElement>("[data-refresh-thread]")?.click()
+    );
+    await flushHookEffects(() => releaseNavigation?.());
     expect(visibleMessageIds(view.container)).toBe(secondThreadMessage.id);
 
-    await flushHookEffects(() => resolveFirstThread?.([firstMessage]));
+    await flushHookEffects(() => pendingFirstThreadLoads.shift()?.([firstMessage, sentMessage]));
     expect(visibleMessageIds(view.container)).toBe(secondThreadMessage.id);
     await view.unmount();
   });

--- a/test/unit/app/messages/inbox-message-visibility.test.tsx
+++ b/test/unit/app/messages/inbox-message-visibility.test.tsx
@@ -25,17 +25,22 @@ vi.mock("@/features/messages/api", async (importOriginal) => ({
 vi.mock("@/features/messages/message-detail", () => ({
   MessageDetail: ({
     messages,
-    onMessageAction
+    onMessageAction,
+    onRefresh
   }: {
     messages: MessageDetailType[];
     onMessageAction: (
       message: MessageDetailType,
       action: MessageFolderAction
     ) => Promise<void> | void;
+    onRefresh: () => Promise<void> | void;
   }) => {
     const firstMessage = messages[0];
     return (
       <div data-visible-message-ids={messages.map((message) => message.id).join(",")}>
+        <button data-refresh-thread onClick={() => void onRefresh()} type="button">
+          Refresh thread
+        </button>
         {firstMessage ? (
           <button
             data-trash-message={firstMessage.id}
@@ -173,6 +178,78 @@ describe("Inbox message visibility", () => {
     );
 
     expect(visibleMessageIds(view.container)).toBe("msg_1");
+    await view.unmount();
+  });
+
+  it("ignores a stale refresh after another thread opens", async () => {
+    const secondThreadMessage = {
+      ...firstMessage,
+      id: "msg_other",
+      threadId: "thr_other",
+      subject: "Other conversation",
+      textBody: "Other conversation body"
+    };
+    let delayFirstThread = false;
+    let resolveFirstThread: ((messages: MessageDetailType[]) => void) | undefined;
+    mocks.getMessageThread.mockImplementation((messageId: string) => {
+      if (messageId === secondThreadMessage.id) return Promise.resolve([secondThreadMessage]);
+      if (!delayFirstThread) return Promise.resolve([firstMessage]);
+      return new Promise<MessageDetailType[]>((resolve) => {
+        resolveFirstThread = resolve;
+      });
+    });
+
+    function Harness() {
+      const [selectedId, setSelectedId] = React.useState<string | null>(firstMessage.id);
+      return (
+        <>
+          <button
+            data-select-other
+            onClick={() => setSelectedId(secondThreadMessage.id)}
+            type="button"
+          >
+            Select other
+          </button>
+          <InboxPage
+            activeFolder="inbox"
+            conversations={[
+              {
+                ...firstMessage,
+                isStarred: false,
+                messageCount: 1,
+                unreadCount: 0
+              }
+            ]}
+            defaultFromMailboxId="mbx_1"
+            hasMore={false}
+            isLoadingMore={false}
+            loadMoreError={null}
+            mailboxes={[]}
+            selectedId={selectedId}
+            totalCount={1}
+            onConversationAction={() => undefined}
+            onLoadMore={() => undefined}
+            onMessageRouteChange={(_folder, messageId) => setSelectedId(messageId)}
+            onRefresh={() => undefined}
+            onSelect={() => undefined}
+          />
+        </>
+      );
+    }
+
+    const view = await renderComponent(<Harness />);
+    await flushHookEffects();
+    delayFirstThread = true;
+    await flushHookEffects(() =>
+      view.container.querySelector<HTMLButtonElement>("[data-refresh-thread]")?.click()
+    );
+    await flushHookEffects(() =>
+      view.container.querySelector<HTMLButtonElement>("[data-select-other]")?.click()
+    );
+    expect(visibleMessageIds(view.container)).toBe(secondThreadMessage.id);
+
+    await flushHookEffects(() => resolveFirstThread?.([firstMessage]));
+    expect(visibleMessageIds(view.container)).toBe(secondThreadMessage.id);
     await view.unmount();
   });
 });

--- a/test/unit/app/messages/inbox-message-visibility.test.tsx
+++ b/test/unit/app/messages/inbox-message-visibility.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment happy-dom
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ConversationSummary,
+  MessageDetail as MessageDetailType,
+  MessageFolderAction
+} from "@/features/messages/types";
+import type { MailFolderId } from "@/lib/routes";
+
+const mocks = vi.hoisted(() => ({
+  getMessageThread: vi.fn(),
+  runConversationAction: vi.fn(),
+  runMessageAction: vi.fn()
+}));
+
+vi.mock("@/features/messages/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/features/messages/api")>()),
+  getMessageThread: mocks.getMessageThread,
+  runConversationAction: mocks.runConversationAction,
+  runMessageAction: mocks.runMessageAction
+}));
+
+vi.mock("@/features/messages/message-detail", () => ({
+  MessageDetail: ({
+    messages,
+    onMessageAction
+  }: {
+    messages: MessageDetailType[];
+    onMessageAction: (
+      message: MessageDetailType,
+      action: MessageFolderAction
+    ) => Promise<void> | void;
+  }) => {
+    const firstMessage = messages[0];
+    return (
+      <div data-visible-message-ids={messages.map((message) => message.id).join(",")}>
+        {firstMessage ? (
+          <button
+            data-trash-message={firstMessage.id}
+            onClick={() => void onMessageAction(firstMessage, "trash")}
+            type="button"
+          >
+            Trash message
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+}));
+
+import { InboxPage } from "@/features/inbox/inbox-page";
+import { flushHookEffects, renderComponent } from "../render-hook";
+
+const firstMessage: MessageDetailType = {
+  id: "msg_1",
+  threadId: "thr_1",
+  mailboxId: "mbx_1",
+  direction: "inbound",
+  folder: "inbox",
+  fromAddress: "customer@example.com",
+  to: ["support@example.com"],
+  cc: [],
+  bcc: [],
+  deliveredToAddress: "support@example.com",
+  subject: "Account access",
+  snippet: "Please help",
+  textBody: "Please help.",
+  htmlAvailable: false,
+  messageId: "<first@example.com>",
+  inReplyTo: null,
+  references: [],
+  attachments: [],
+  receivedAt: "2026-08-30T14:00:00.000Z",
+  sentAt: null,
+  readAt: "2026-08-30T14:01:00.000Z",
+  starredAt: null,
+  hasAttachments: false,
+  createdAt: "2026-08-30T14:00:00.000Z"
+};
+
+const sentMessage: MessageDetailType = {
+  ...firstMessage,
+  id: "msg_2",
+  direction: "outbound",
+  folder: "sent",
+  fromAddress: "support@example.com",
+  to: ["customer@example.com"],
+  snippet: "We can help",
+  textBody: "We can help.",
+  messageId: "<second@example.com>",
+  inReplyTo: "<first@example.com>",
+  references: ["<first@example.com>"],
+  receivedAt: null,
+  sentAt: "2026-08-30T14:05:00.000Z",
+  createdAt: "2026-08-30T14:05:00.000Z"
+};
+
+const conversation: ConversationSummary = {
+  ...sentMessage,
+  isStarred: false,
+  messageCount: 2,
+  unreadCount: 0
+};
+
+beforeEach(() => {
+  mocks.getMessageThread.mockReset();
+  mocks.runConversationAction.mockReset();
+  mocks.runMessageAction.mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
+describe("Inbox message visibility", () => {
+  it("removes one trashed message but keeps the remaining conversation open", async () => {
+    const onMessageRouteChange = vi.fn();
+    let messages = [firstMessage, sentMessage];
+    mocks.getMessageThread.mockImplementation(async () => messages);
+    mocks.runMessageAction.mockImplementation(async () => {
+      messages = [{ ...firstMessage, folder: "trash" }, sentMessage];
+    });
+    const view = await renderInbox(onMessageRouteChange);
+
+    expect(visibleMessageIds(view.container)).toBe("msg_1,msg_2");
+    await flushHookEffects(() =>
+      view.container.querySelector<HTMLButtonElement>('[data-trash-message="msg_1"]')?.click()
+    );
+
+    expect(mocks.runMessageAction).toHaveBeenCalledWith("msg_1", "trash");
+    expect(visibleMessageIds(view.container)).toBe("msg_2");
+    expect(onMessageRouteChange).not.toHaveBeenCalled();
+    await view.unmount();
+  });
+
+  it("returns to the folder when the trashed message was the last visible message", async () => {
+    const onMessageRouteChange = vi.fn();
+    let messages = [firstMessage];
+    mocks.getMessageThread.mockImplementation(async () => messages);
+    mocks.runMessageAction.mockImplementation(async () => {
+      messages = [{ ...firstMessage, folder: "trash" }];
+    });
+    const view = await renderInbox(onMessageRouteChange, {
+      ...firstMessage,
+      isStarred: false,
+      messageCount: 1,
+      unreadCount: 0
+    });
+
+    await flushHookEffects(() =>
+      view.container.querySelector<HTMLButtonElement>('[data-trash-message="msg_1"]')?.click()
+    );
+
+    expect(onMessageRouteChange).toHaveBeenCalledWith("inbox", null);
+    await view.unmount();
+  });
+
+  it("shows only trashed messages when the reader opens from Trash", async () => {
+    const trashedMessage = { ...firstMessage, folder: "trash" as const };
+    mocks.getMessageThread.mockResolvedValue([trashedMessage, sentMessage]);
+    const view = await renderInbox(
+      vi.fn(),
+      {
+        ...trashedMessage,
+        isStarred: false,
+        messageCount: 1,
+        unreadCount: 0
+      },
+      "trash"
+    );
+
+    expect(visibleMessageIds(view.container)).toBe("msg_1");
+    await view.unmount();
+  });
+});
+
+async function renderInbox(
+  onMessageRouteChange: (folder: MailFolderId, messageId: string | null) => void,
+  selectedConversation: ConversationSummary = conversation,
+  activeFolder: "inbox" | "trash" = "inbox"
+) {
+  function Harness() {
+    const [selectedId, setSelectedId] = React.useState<string | null>(selectedConversation.id);
+    return (
+      <InboxPage
+        activeFolder={activeFolder}
+        conversations={[selectedConversation]}
+        defaultFromMailboxId="mbx_1"
+        hasMore={false}
+        isLoadingMore={false}
+        loadMoreError={null}
+        mailboxes={[]}
+        selectedId={selectedId}
+        totalCount={1}
+        onConversationAction={() => undefined}
+        onLoadMore={() => undefined}
+        onMessageRouteChange={(folder, messageId) => {
+          onMessageRouteChange(folder, messageId);
+          setSelectedId(messageId);
+        }}
+        onRefresh={() => undefined}
+        onSelect={() => undefined}
+      />
+    );
+  }
+  const view = await renderComponent(<Harness />);
+  await flushHookEffects();
+  return view;
+}
+
+function visibleMessageIds(container: HTMLElement): string | null {
+  return (
+    container.querySelector<HTMLElement>("[data-visible-message-ids]")?.dataset.visibleMessageIds ??
+    null
+  );
+}

--- a/test/unit/app/messages/message-action-feedback.test.tsx
+++ b/test/unit/app/messages/message-action-feedback.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   error: vi.fn(),
@@ -49,6 +49,7 @@ const customerLabel: MailLabel = {
 };
 
 beforeEach(() => vi.clearAllMocks());
+afterEach(() => document.body.replaceChildren());
 
 describe("conversation action feedback", () => {
   it("keeps thread labels in the responsive reader controls", async () => {
@@ -319,6 +320,42 @@ describe("conversation action feedback", () => {
 
     await flushHookEffects(() => resolveAction?.());
     expect(mocks.success).toHaveBeenCalledWith("Conversation archived.");
+    expect(mocks.error).not.toHaveBeenCalled();
+    await view.unmount();
+  });
+
+  it("reports success for an exact-message action", async () => {
+    const onMessageAction = vi.fn().mockResolvedValue(undefined);
+    const view = await renderComponent(
+      <MessageDetail
+        defaultFromMailboxId="mbx_1"
+        mailboxes={[]}
+        messages={[message]}
+        selectedId={message.id}
+        onAction={() => undefined}
+        onBack={() => undefined}
+        onMessageAction={onMessageAction}
+        onRefresh={() => undefined}
+        onSent={() => undefined}
+      />
+    );
+    document.body.appendChild(view.container);
+
+    const trigger = view.container.querySelector<HTMLButtonElement>(
+      '[data-message-actions-id="msg_1"]'
+    );
+    await flushHookEffects(() => {
+      trigger?.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerType: "mouse" })
+      );
+      trigger?.click();
+    });
+    await flushHookEffects(() =>
+      document.body.querySelector<HTMLElement>('[data-message-action="archive"]')?.click()
+    );
+
+    expect(onMessageAction).toHaveBeenCalledWith(message, "archive");
+    expect(mocks.success).toHaveBeenCalledWith("Message archived.");
     expect(mocks.error).not.toHaveBeenCalled();
     await view.unmount();
   });

--- a/test/unit/app/messages/message-html.test.tsx
+++ b/test/unit/app/messages/message-html.test.tsx
@@ -92,7 +92,7 @@ describe("message HTML view", () => {
     );
 
     expect(html).toContain(
-      "Remote images are hidden. Loading them may reveal that you opened this email."
+      "Some remote images are hidden. Loading them may reveal that you opened this email."
     );
     expect(html).toContain("Load images");
     expect(html).toContain("Always load from this sender");

--- a/test/unit/app/search/global-search.test.tsx
+++ b/test/unit/app/search/global-search.test.tsx
@@ -48,6 +48,8 @@ describe("global search", () => {
     );
     const input = requiredInput(view.container);
     expect(input.className).toContain("h-[30px]");
+    expect(input.className).not.toContain("focus-visible:ring");
+    expect(input.className).not.toContain("focus-visible:border-input");
 
     await setInput(input, "old");
     await flushHookEffects(() => vi.advanceTimersByTime(200));
@@ -113,6 +115,7 @@ describe("global search", () => {
     const clear = view.container.querySelector<HTMLButtonElement>('[aria-label="Clear search"]');
     const focus = vi.spyOn(input, "focus");
     expect(clear).not.toBeNull();
+    expect(clear?.className).not.toContain("focus-visible:ring");
 
     await flushHookEffects(() => clear?.click());
 

--- a/test/unit/app/signatures/compose-signature.test.tsx
+++ b/test/unit/app/signatures/compose-signature.test.tsx
@@ -56,6 +56,7 @@ describe("compose signature", () => {
     const preview = view.container.querySelector<HTMLIFrameElement>(
       'iframe[title="Signature preview"]'
     );
+    expect(view.container.firstElementChild?.className).toContain("shrink-0");
     expect(preview?.srcdoc).toContain("HQBase Support");
     const trigger = view.container.querySelector<HTMLButtonElement>('[aria-label="Signature"]');
     expect(trigger?.textContent).toContain("Support · Support");

--- a/test/unit/app/ui/dropdown-select.test.tsx
+++ b/test/unit/app/ui/dropdown-select.test.tsx
@@ -28,6 +28,7 @@ describe("dropdown select", () => {
     expect(trigger?.className).toContain("h-[34px]");
     expect(trigger?.className).toContain("min-h-[34px]");
     expect(trigger?.className).toContain("rounded-[calc(var(--radius)+2px)]");
+    expect(trigger?.dataset.slot).toBe("dropdown-select");
 
     await flushHookEffects(() => {
       trigger?.dispatchEvent(

--- a/test/unit/scripts/deploy.test.mjs
+++ b/test/unit/scripts/deploy.test.mjs
@@ -172,9 +172,9 @@ describe("HQBase release deployment", () => {
     const deploymentConfig = {
       name: "customer-worker",
       durable_objects: {
-        bindings: [{ name: "MAIL_EVENTS", class_name: "MailEvents" }]
+        bindings: [{ name: "CUSTOMER_EVENTS", class_name: "CustomerEvents" }]
       },
-      migrations: [{ tag: "mail-events-v1", new_sqlite_classes: ["MailEvents"] }]
+      migrations: [{ tag: "customer-events-v1", new_sqlite_classes: ["CustomerEvents"] }]
     };
     const previous = normalizeConfig(deploymentConfig, "1.2.0", "a".repeat(64), {});
     expect(previous).not.toHaveProperty("durable_objects");
@@ -186,13 +186,9 @@ describe("HQBase release deployment", () => {
       },
       migrations: [{ tag: "mail-events-v1", new_sqlite_classes: ["MailEvents"] }]
     };
-    const candidate = normalizeConfig(
-      { name: "customer-worker" },
-      "1.3.0",
-      "b".repeat(64),
-      releaseConfig
-    );
-    expect(candidate).toMatchObject(releaseConfig);
+    const candidate = normalizeConfig(deploymentConfig, "1.3.0", "b".repeat(64), releaseConfig);
+    expect(candidate.durable_objects).toEqual(releaseConfig.durable_objects);
+    expect(candidate.migrations).toEqual(releaseConfig.migrations);
   });
   it("creates an immutable active-version tag from the signed HQBase artifact", () => {
     expect(hqbaseReleaseTag("0.1.5", "a".repeat(64))).toBe(`hqbase:0.1.5:${"a".repeat(64)}`);

--- a/test/unit/scripts/deploy.test.mjs
+++ b/test/unit/scripts/deploy.test.mjs
@@ -168,6 +168,32 @@ describe("HQBase release deployment", () => {
     });
     expect(normalized.d1_databases[0]).not.toHaveProperty("migrations_pattern");
   });
+  it("uses only the Durable Objects exported by the verified release", () => {
+    const deploymentConfig = {
+      name: "customer-worker",
+      durable_objects: {
+        bindings: [{ name: "MAIL_EVENTS", class_name: "MailEvents" }]
+      },
+      migrations: [{ tag: "mail-events-v1", new_sqlite_classes: ["MailEvents"] }]
+    };
+    const previous = normalizeConfig(deploymentConfig, "1.2.0", "a".repeat(64), {});
+    expect(previous).not.toHaveProperty("durable_objects");
+    expect(previous).not.toHaveProperty("migrations");
+
+    const releaseConfig = {
+      durable_objects: {
+        bindings: [{ name: "MAIL_EVENTS", class_name: "MailEvents" }]
+      },
+      migrations: [{ tag: "mail-events-v1", new_sqlite_classes: ["MailEvents"] }]
+    };
+    const candidate = normalizeConfig(
+      { name: "customer-worker" },
+      "1.3.0",
+      "b".repeat(64),
+      releaseConfig
+    );
+    expect(candidate).toMatchObject(releaseConfig);
+  });
   it("creates an immutable active-version tag from the signed HQBase artifact", () => {
     expect(hqbaseReleaseTag("0.1.5", "a".repeat(64))).toBe(`hqbase:0.1.5:${"a".repeat(64)}`);
     expect(() => hqbaseReleaseTag("0.1.5", "not-a-digest")).toThrow("identity");

--- a/test/unit/scripts/release-version.test.mjs
+++ b/test/unit/scripts/release-version.test.mjs
@@ -22,6 +22,13 @@ describe("stable release version", () => {
     );
   });
 
+  it("rejects leading zeros in every numeric part", () => {
+    expect(assertStableReleaseVersion("0.0.0")).toBe("0.0.0");
+    expect(() => assertStableReleaseVersion("01.2.3")).toThrow("must be a stable semantic version");
+    expect(() => assertStableReleaseVersion("1.02.3")).toThrow("must be a stable semantic version");
+    expect(() => assertStableReleaseVersion("1.2.03")).toThrow("must be a stable semantic version");
+  });
+
   it("guards both release entry points", () => {
     expect(packageSource).toContain("assertStableReleaseVersion(version)");
     expect(workflowSource).toContain(

--- a/test/unit/scripts/release-version.test.mjs
+++ b/test/unit/scripts/release-version.test.mjs
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { assertStableReleaseVersion } from "../../../scripts/release/version.mjs";
+
+const packageSource = readFileSync(
+  new URL("../../../scripts/release/package.mjs", import.meta.url),
+  "utf8"
+);
+const workflowSource = readFileSync(
+  new URL("../../../.github/workflows/release.yml", import.meta.url),
+  "utf8"
+);
+
+describe("stable release version", () => {
+  it("accepts stable versions and rejects prerelease suffixes", () => {
+    expect(assertStableReleaseVersion("1.3.0")).toBe("1.3.0");
+    expect(() => assertStableReleaseVersion("1.3.0-rc.1")).toThrow(
+      "must be a stable semantic version"
+    );
+    expect(() => assertStableReleaseVersion("1.3.0-beta")).toThrow(
+      "must be a stable semantic version"
+    );
+  });
+
+  it("guards both release entry points", () => {
+    expect(packageSource).toContain("assertStableReleaseVersion(version)");
+    expect(workflowSource).toContain(
+      'assertStableReleaseVersion(packageJson.version, "package.json version")'
+    );
+  });
+});

--- a/test/unit/worker/features/messages/message-thread.test.ts
+++ b/test/unit/worker/features/messages/message-thread.test.ts
@@ -36,7 +36,7 @@ const row: MessageRow = {
 };
 
 describe("message threads", () => {
-  it("loads messages chronologically from only accessible mailboxes", async () => {
+  it("loads the complete thread chronologically from only accessible mailboxes", async () => {
     const threadBind = vi.fn(() => ({ all: vi.fn(async () => ({ results: [row] })) }));
     const attachmentBind = vi.fn(() => ({ all: vi.fn(async () => ({ results: [] })) }));
     const prepare = vi.fn((sql: string) =>
@@ -56,6 +56,7 @@ describe("message threads", () => {
     });
     expect(prepare.mock.calls[0]?.[0]).toContain("ORDER BY COALESCE");
     expect(prepare.mock.calls[0]?.[0]).toContain("SELECT messages.* FROM messages");
+    expect(prepare.mock.calls[0]?.[0]).not.toMatch(/\bLIMIT\b/u);
     expect(threadBind).toHaveBeenCalledWith("thr_1", "mbx_allowed", "mbx_second");
     expect(prepare.mock.calls[0]?.[0]).not.toContain("IS NULL");
   });

--- a/test/unit/worker/features/send/forward-service.test.ts
+++ b/test/unit/worker/features/send/forward-service.test.ts
@@ -10,7 +10,8 @@ vi.mock("@worker/features/mailboxes/queries", () => ({
   findMailboxForSending: vi.fn()
 }));
 vi.mock("@worker/features/messages/queries", () => ({
-  getMessageDetail: vi.fn()
+  getMessageDetail: vi.fn(),
+  getMessageHtmlKey: vi.fn()
 }));
 vi.mock("@worker/features/send/service", () => ({
   sendNewMessage: vi.fn()
@@ -23,7 +24,7 @@ import {
   saveDraft
 } from "@worker/features/drafts/queries";
 import { findMailboxForSending } from "@worker/features/mailboxes/queries";
-import { getMessageDetail } from "@worker/features/messages/queries";
+import { getMessageDetail, getMessageHtmlKey } from "@worker/features/messages/queries";
 import { forwardMessage, sendForwardDraft } from "@worker/features/send/forward";
 import { sendNewMessage } from "@worker/features/send/service";
 import type { WorkerEnv } from "@worker/lib/env";
@@ -96,6 +97,7 @@ describe("forward service", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(getMessageDetail).mockResolvedValue(original);
+    vi.mocked(getMessageHtmlKey).mockResolvedValue(null);
     vi.mocked(findMailboxForSending).mockResolvedValue(mailbox);
     vi.mocked(sendNewMessage).mockResolvedValue(sent);
   });
@@ -131,7 +133,8 @@ describe("forward service", () => {
       undefined,
       expect.objectContaining({
         text: expect.stringContaining("---------- Forwarded message ---------")
-      })
+      }),
+      []
     );
     expect(saveDraft).not.toHaveBeenCalled();
   });
@@ -176,7 +179,8 @@ describe("forward service", () => {
       expect.objectContaining({ attachmentIds: [] }),
       "user-1",
       undefined,
-      expect.any(Object)
+      expect.any(Object),
+      []
     );
   });
 
@@ -300,7 +304,8 @@ describe("forward service", () => {
       undefined,
       expect.objectContaining({
         text: expect.stringContaining("---------- Forwarded message ---------")
-      })
+      }),
+      []
     );
     expect(vi.mocked(sendNewMessage).mock.calls[0]?.[1]).not.toHaveProperty("draftId");
     expect(deleteDraft).toHaveBeenCalledWith(env.DB, env.MAIL_OBJECTS, "user-1", "draft-forward");
@@ -368,10 +373,73 @@ describe("forward service", () => {
       undefined,
       expect.objectContaining({
         text: expect.stringContaining("---------- Forwarded message ---------")
-      })
+      }),
+      []
     );
     expect(saveDraft).not.toHaveBeenCalled();
     expect(removeDraftAttachment).not.toHaveBeenCalled();
+  });
+
+  it("keeps sanitized HTML images and referenced inline files in a forward", async () => {
+    const inlineAttachment = {
+      id: "inline-logo",
+      messageId: original.id,
+      filename: "logo.png",
+      contentType: "image/png",
+      sizeBytes: 4,
+      contentId: "logo@example.com",
+      disposition: "inline" as const,
+      r2Key: "mail/logo.png",
+      createdAt: original.createdAt
+    };
+    vi.mocked(getMessageDetail).mockResolvedValue({
+      ...original,
+      htmlAvailable: true,
+      attachments: [inlineAttachment]
+    });
+    vi.mocked(getMessageHtmlKey).mockResolvedValue("mail/message.html");
+    get.mockImplementation(async (key: string) =>
+      key === "mail/message.html"
+        ? {
+            text: async () =>
+              '<p>Original <img src="cid:logo@example.com"><img src="https://images.example.com/remote.png"></p>'
+          }
+        : {
+            arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer
+          }
+    );
+
+    await forwardMessage(
+      env,
+      {
+        messageId: original.id,
+        from: mailbox.address,
+        to: ["recipient@example.com"],
+        cc: [],
+        bcc: [],
+        text: "Please review",
+        attachmentIds: [],
+        includeOriginalAttachments: true
+      },
+      "user-1"
+    );
+
+    expect(sendNewMessage).toHaveBeenCalledWith(
+      env,
+      expect.any(Object),
+      "user-1",
+      undefined,
+      expect.objectContaining({
+        html: expect.stringContaining('src="https://images.example.com/remote.png"')
+      }),
+      [
+        expect.objectContaining({
+          contentId: "logo@example.com",
+          disposition: "inline",
+          filename: "logo.png"
+        })
+      ]
+    );
   });
 
   it("removes copied attachments when a web forward draft is not sent", async () => {

--- a/test/unit/worker/features/send/send-service.test.ts
+++ b/test/unit/worker/features/send/send-service.test.ts
@@ -226,6 +226,61 @@ describe("send service", () => {
     );
   });
 
+  it("sends and stores inline images from forwarded HTML context", async () => {
+    send.mockResolvedValue({ messageId: "<cloudflare-forward-image@example.com>" });
+
+    await sendNewMessage(
+      env,
+      {
+        attachmentIds: [],
+        bcc: [],
+        cc: [],
+        from: mailbox.address,
+        subject: "Forwarded image",
+        text: "Please review",
+        to: ["owner@example.com"]
+      },
+      undefined,
+      undefined,
+      {
+        text: "Forwarded content",
+        html: '<blockquote><img src="cid:forwarded-logo@example.com"></blockquote>'
+      },
+      [
+        {
+          id: "forwarded-logo",
+          filename: "logo.png",
+          contentType: "image/png",
+          sizeBytes: 3,
+          contentId: "forwarded-logo@example.com",
+          disposition: "inline",
+          r2Key: "mail/original-logo.png",
+          content: new Uint8Array([1, 2, 3]).buffer
+        }
+      ]
+    );
+
+    const payload = send.mock.calls[0]?.[0] as Parameters<SendEmail["send"]>[0];
+    expect(payload.html).toContain('src="cid:forwarded-logo@example.com"');
+    expect(payload.attachments).toEqual([
+      expect.objectContaining({
+        contentId: "forwarded-logo@example.com",
+        disposition: "inline",
+        filename: "logo.png"
+      })
+    ]);
+    expect(put).toHaveBeenCalledWith("sent/2026-07-10/html-1-1", expect.any(ArrayBuffer), {
+      httpMetadata: { contentType: "image/png" }
+    });
+    expect(insertAttachment).toHaveBeenCalledWith(
+      env.DB,
+      expect.objectContaining({
+        contentId: "forwarded-logo@example.com",
+        r2Key: "sent/2026-07-10/html-1-1"
+      })
+    );
+  });
+
   it("uses only referenced private draft images and removes unused draft objects", async () => {
     send.mockResolvedValue({ messageId: "<cloudflare-inline@example.com>" });
     vi.mocked(draftAttachmentObjects).mockResolvedValue([

--- a/test/unit/worker/features/send/send-service.test.ts
+++ b/test/unit/worker/features/send/send-service.test.ts
@@ -675,6 +675,16 @@ describe("send service", () => {
       sentAt: "2026-07-10T00:05:00.000Z",
       createdAt: "2026-07-10T00:05:00.000Z"
     };
+    const trashedMessage = {
+      ...firstMessage,
+      id: "message-trashed",
+      folder: "trash" as const,
+      messageId: "<trashed@example.com>",
+      snippet: "Deleted message",
+      textBody: "Deleted message",
+      receivedAt: "2026-07-10T00:03:00.000Z",
+      createdAt: "2026-07-10T00:03:00.000Z"
+    };
     const laterMessage = {
       ...targetMessage,
       id: "message-3",
@@ -690,7 +700,12 @@ describe("send service", () => {
       createdAt: "2026-07-10T00:10:00.000Z"
     };
     vi.mocked(getMessageDetail).mockResolvedValue(targetMessage);
-    vi.mocked(listThreadMessages).mockResolvedValue([firstMessage, targetMessage, laterMessage]);
+    vi.mocked(listThreadMessages).mockResolvedValue([
+      firstMessage,
+      trashedMessage,
+      targetMessage,
+      laterMessage
+    ]);
     send.mockResolvedValue({ messageId: "<cloudflare-reply@example.com>" });
 
     await replyToMessage(
@@ -721,6 +736,7 @@ describe("send service", () => {
     const payloadText = payload.text ?? "";
     expect(payloadText).toContain("Second message");
     expect(payloadText).toContain("First message");
+    expect(payloadText).not.toContain("Deleted message");
     expect(payloadText).not.toContain("Later message");
     expect(payloadText.indexOf("Second message")).toBeLessThan(
       payloadText.indexOf("First message")

--- a/worker/features/messages/conversation-queries.ts
+++ b/worker/features/messages/conversation-queries.ts
@@ -61,6 +61,8 @@ export async function listConversationPage(
       totalCount: filters.cursor ? null : 0
     };
   }
+  const visibility =
+    filters.folder === "trash" ? sql`messages.folder = 'trash'` : sql`messages.folder <> 'trash'`;
 
   const eligibilityWhere: SQL[] = [];
   if (filters.mailboxId) {
@@ -124,7 +126,7 @@ export async function listConversationPage(
          SELECT messages.*,
            COALESCE(messages.received_at, messages.sent_at, messages.created_at) AS activity_at
          FROM messages
-         WHERE ${scope}
+         WHERE ${scope} AND ${visibility}
        ),
        eligible_threads AS (
          SELECT DISTINCT accessible.thread_id

--- a/worker/features/messages/queries.ts
+++ b/worker/features/messages/queries.ts
@@ -231,8 +231,7 @@ export async function listThreadMessages(
     db,
     sql`${messageSelect}
        WHERE thread_id = ${threadId} AND ${scopeCondition}
-       ORDER BY COALESCE(received_at, sent_at, created_at) ASC
-       LIMIT 100`
+       ORDER BY COALESCE(received_at, sent_at, created_at) ASC`
   );
   return Promise.all(rows.map((row) => mapMessageDetail(db, row)));
 }

--- a/worker/features/send/forward.ts
+++ b/worker/features/send/forward.ts
@@ -1,3 +1,4 @@
+import { nowIso } from "../../db/client";
 import type { WorkerEnv } from "../../lib/env";
 import { AppError } from "../../lib/errors";
 import {
@@ -12,6 +13,15 @@ import type { MessageDetail } from "../messages/types";
 import type { SignatureSnapshot } from "../signatures/types";
 
 import { assembleMessageBody } from "./body";
+import {
+  loadAttachments,
+  loadQuotedMessageHtml,
+  maxAttachmentBytes,
+  maxAttachmentCount,
+  prepareSignature,
+  type StoredOutgoingAttachment,
+  totalAttachmentBytes
+} from "./content-attachments";
 import { sendNewMessage } from "./service";
 import type { ForwardMessageInput, SendMessageInput } from "./validation";
 
@@ -32,7 +42,6 @@ export async function forwardMessage(
     throw new AppError("MAILBOX_DISABLED", "Disabled mailboxes cannot send email.", 400);
   }
 
-  const context = forwardedContext(original);
   const subject = input.subject ?? forwardSubject(original.subject);
   const originalAttachments = forwardableAttachments(original.attachments);
   const outbound: SendMessageInput = {
@@ -47,7 +56,21 @@ export async function forwardMessage(
     signature: input.signature
   };
   if (!input.includeOriginalAttachments || originalAttachments.length === 0) {
-    return sendNewMessage(env, outbound, principalId, signature, context);
+    const forwarded = await loadForwardedContext(
+      env,
+      original,
+      input.attachmentIds,
+      principalId,
+      signature
+    );
+    return sendNewMessage(
+      env,
+      outbound,
+      principalId,
+      signature,
+      forwarded.context,
+      forwarded.inlineAttachments
+    );
   }
 
   requireForwardedAttachmentCount(originalAttachments.length, input.attachmentIds.length);
@@ -81,15 +104,24 @@ export async function forwardMessage(
   }
 
   try {
+    const attachmentIds = [...input.attachmentIds, ...copiedAttachmentIds];
+    const forwarded = await loadForwardedContext(
+      env,
+      original,
+      attachmentIds,
+      principalId,
+      signature
+    );
     return await sendNewMessage(
       env,
       {
         ...outbound,
-        attachmentIds: [...input.attachmentIds, ...copiedAttachmentIds]
+        attachmentIds
       },
       principalId,
       signature,
-      context
+      forwarded.context,
+      forwarded.inlineAttachments
     );
   } finally {
     try {
@@ -111,10 +143,23 @@ export async function sendForwardDraft(
   const original = await getMessageDetail(env.DB, originalMessageId);
   if (!original) throw new AppError("MESSAGE_NOT_FOUND", "Message not found.", 404);
   const authored = stripLegacyForwardContext(input);
-  const context = forwardedContext(original);
   const originalAttachments = forwardableAttachments(original.attachments);
   if (originalAttachments.length === 0) {
-    return sendNewMessage(env, { ...input, ...authored, draftId }, principalId, signature, context);
+    const forwarded = await loadForwardedContext(
+      env,
+      original,
+      input.attachmentIds,
+      principalId,
+      signature
+    );
+    return sendNewMessage(
+      env,
+      { ...input, ...authored, draftId },
+      principalId,
+      signature,
+      forwarded.context,
+      forwarded.inlineAttachments
+    );
   }
 
   requireForwardedAttachmentCount(originalAttachments.length, input.attachmentIds.length);
@@ -125,17 +170,26 @@ export async function sendForwardDraft(
     originalAttachments
   );
   try {
+    const attachmentIds = [...input.attachmentIds, ...copiedAttachmentIds];
+    const forwarded = await loadForwardedContext(
+      env,
+      original,
+      attachmentIds,
+      principalId,
+      signature
+    );
     return await sendNewMessage(
       env,
       {
         ...input,
         ...authored,
-        attachmentIds: [...input.attachmentIds, ...copiedAttachmentIds],
+        attachmentIds,
         draftId
       },
       principalId,
       signature,
-      context
+      forwarded.context,
+      forwarded.inlineAttachments
     );
   } catch (error) {
     await removeCopiedAttachments(env, principalId, draftId, copiedAttachmentIds);
@@ -215,21 +269,54 @@ export function forwardedBody(
   return { text: body.text, html: body.html ?? "" };
 }
 
-export function forwardedContext(message: MessageDetail): { text: string; html: string } {
+export function forwardedContext(
+  message: MessageDetail,
+  forwardedHtml?: string
+): { text: string; html: string } {
   const timestamp = message.receivedAt ?? message.sentAt ?? message.createdAt;
-  const forwarded = [
+  const headers = [
     "---------- Forwarded message ---------",
     `From: ${message.fromName ? `${message.fromName} <${message.fromAddress}>` : message.fromAddress}`,
     `Date: ${new Date(timestamp).toUTCString()}`,
     `Subject: ${message.subject}`,
     `To: ${message.to.join(", ")}`,
-    ...(message.cc.length ? [`Cc: ${message.cc.join(", ")}`] : []),
-    "",
-    message.textBody || message.snippet
-  ].join("\n");
+    ...(message.cc.length ? [`Cc: ${message.cc.join(", ")}`] : [])
+  ];
+  const bodyText = message.textBody || message.snippet;
+  const forwarded = [...headers, "", bodyText].join("\n");
+  const htmlBody = forwardedHtml ?? escapeHtml(bodyText).replaceAll("\n", "<br>");
   return {
     text: forwarded,
-    html: `<blockquote>${escapeHtml(forwarded).replaceAll("\n", "<br>")}</blockquote>`
+    html: `<blockquote>${escapeHtml(headers.join("\n")).replaceAll("\n", "<br>")}<br><br>${htmlBody}</blockquote>`
+  };
+}
+
+async function loadForwardedContext(
+  env: WorkerEnv,
+  message: MessageDetail,
+  attachmentIds: string[],
+  principalId: string,
+  signature?: SignatureSnapshot
+): Promise<{
+  context: { text: string; html: string };
+  inlineAttachments: StoredOutgoingAttachment[];
+}> {
+  if (!message.htmlAvailable) {
+    return { context: forwardedContext(message), inlineAttachments: [] };
+  }
+  const authoredAttachments = await loadAttachments(env, attachmentIds, principalId);
+  const signatureAttachments = prepareSignature(signature, nowIso()).attachments;
+  const baseAttachments = [...authoredAttachments, ...signatureAttachments];
+  const quoted = await loadQuotedMessageHtml(
+    env,
+    message.id,
+    message.attachments,
+    maxAttachmentBytes - totalAttachmentBytes(baseAttachments),
+    maxAttachmentCount - baseAttachments.length
+  );
+  return {
+    context: forwardedContext(message, quoted.html),
+    inlineAttachments: quoted.inlineAttachments
   };
 }
 

--- a/worker/features/send/service.ts
+++ b/worker/features/send/service.ts
@@ -136,7 +136,9 @@ export async function replyToMessage(
     throw new AppError("MESSAGE_NOT_FOUND", "Message not found.", 404);
   }
   const threadMessages = messageScope
-    ? await listThreadMessages(env.DB, original.threadId, messageScope)
+    ? (await listThreadMessages(env.DB, original.threadId, messageScope)).filter(
+        (message) => (message.folder === "trash") === (original.folder === "trash")
+      )
     : [original];
   const targetIndex = threadMessages.findIndex((message) => message.id === original.id);
   const replyChain = targetIndex < 0 ? [original] : threadMessages.slice(0, targetIndex + 1);

--- a/worker/features/send/service.ts
+++ b/worker/features/send/service.ts
@@ -47,7 +47,8 @@ export async function sendNewMessage(
   input: SendMessageInput,
   principalId?: string,
   signature?: SignatureSnapshot,
-  context?: MessageBodyPart
+  context?: MessageBodyPart,
+  contextAttachments: StoredOutgoingAttachment[] = []
 ): Promise<MessageSummary> {
   const mailbox = await ensureActiveMailbox(env.DB, input.from);
 
@@ -62,12 +63,17 @@ export async function sendNewMessage(
   });
   const preparedDraftAttachments = prepareStoredAttachments(authored.attachments, timestamp);
   const preparedSignature = prepareSignature(signature, timestamp);
+  const preparedContextAttachments = prepareStoredAttachments(contextAttachments, timestamp);
   const body = assembleMessageBody({
     authored: authored.body,
     signature: preparedSignature.snapshot,
     context
   });
-  const attachments = [...preparedDraftAttachments, ...preparedSignature.attachments];
+  const attachments = [
+    ...preparedDraftAttachments,
+    ...preparedSignature.attachments,
+    ...preparedContextAttachments
+  ];
   requireAttachmentLimits(attachments);
   const email = {
     from: { name: mailbox.displayName, email: mailbox.address },
@@ -75,7 +81,11 @@ export async function sendNewMessage(
     subject: input.subject,
     text: body.text
   };
-  const stagedAttachments = [...preparedDraftAttachments, ...preparedSignature.attachments];
+  const stagedAttachments = [
+    ...preparedDraftAttachments,
+    ...preparedSignature.attachments,
+    ...preparedContextAttachments
+  ];
   await stageOutgoingAttachments(env.MAIL_OBJECTS, stagedAttachments);
   const sendResult = await sendWithStagedCleanup(
     env,


### PR DESCRIPTION
## Summary

Merge the tested next changes into main as the v1.3.0 release candidate.

This PR preserves the individual feature and fix commits. Release version and user-facing notes will follow in a separate release PR after staging and audit checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forwarded messages preserve quoted HTML, inline images, and included attachments as read-only files.
  * Added per-message archive, trash, restore, and unarchive actions.
  * Reply and forward controls now appear for every message.
  * Private contact details are collapsible.
  * Conversation views now load complete message histories.

* **Bug Fixes**
  * Inbox and Trash show only messages belonging to the selected folder.
  * Improved routing and refresh behavior after message actions.
  * Remote-image notices now clarify that some images may be hidden.

* **Style**
  * Refined focus indicators and compacted compose layouts.
  * Simplified the account menu label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->