### PR TITLE
Fix catch-all policy overflow

### DIFF
--- a/app/features/domains/catch-all-policy-control.tsx
+++ b/app/features/domains/catch-all-policy-control.tsx
@@ -47,7 +47,7 @@ export function CatchAllPolicyControl({
   ];
 
   return (
-    <fieldset className="space-y-1.5" disabled={disabled}>
+    <fieldset className="min-w-0 space-y-1.5" disabled={disabled}>
       <legend className="sr-only">Unknown address policy</legend>
       {options.map((option) => {
         const id = `${idPrefix}-${option.policy}`;

--- a/test/unit/app/setup/setup-ui.test.tsx
+++ b/test/unit/app/setup/setup-ui.test.tsx
@@ -156,6 +156,7 @@ describe("setup UI", () => {
     expect(html).toContain("Default From mailbox");
     expect(html).toContain("Mail to unknown addresses");
     expect(html).toContain("Deliver to a mailbox");
+    expect(html).toContain('class="min-w-0 space-y-1.5"');
     expect(html).toContain('aria-label="Catch-all mailbox"');
     expect(html).toContain("Replies use the mailbox that received");
     expect(html).not.toContain("Add shared addresses");


### PR DESCRIPTION
## Summary

- keep catch-all policy controls within narrow domain cards
- add focused setup UI regression coverage

## Verification

- `pnpm check`
- `pnpm deploy:dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the layout of the catch-all policy section to prevent content overflow and maintain consistent spacing.
* **Tests**
  * Added coverage verifying the catch-all section’s updated layout styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->