### PR TITLE
Fix N-1 release deployment for legacy migration phases

### DIFF
--- a/scripts/d1-migrations.mjs
+++ b/scripts/d1-migrations.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
-import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 
 import { run } from "./release/command.mjs";
@@ -23,15 +23,13 @@ export function applyMigrationPhase(cwd, phase, options = {}) {
     runMigrations(cwd, configFile, target, options.run);
     return;
   }
-
   const config = JSON.parse(readFileSync(configFile, "utf8"));
   const database = config.d1_databases?.find(({ binding }) => binding === "DB");
   if (!database) throw new Error("wrangler.jsonc has no DB binding.");
+  const migrationDirectory = resolve(cwd, afterDeployDirectory);
+  if (!existsSync(migrationDirectory)) return;
 
-  database.migrations_dir = relative(
-    dirname(configFile),
-    resolve(cwd, afterDeployDirectory)
-  ).replaceAll("\\", "/");
+  database.migrations_dir = relative(dirname(configFile), migrationDirectory).replaceAll("\\", "/");
   database.migrations_table = afterDeployTable;
   delete database.migrations_pattern;
 

--- a/test/unit/scripts/d1-migrations.test.mjs
+++ b/test/unit/scripts/d1-migrations.test.mjs
@@ -84,6 +84,25 @@ describe("two-phase D1 migrations", () => {
     }
   });
 
+  it("skips an absent after-deploy phase in an older release", () => {
+    const workspace = createWorkspace();
+    const temporaryConfig = resolve(workspace, ".wrangler-after-deploy-legacy-release.jsonc");
+    const run = vi.fn();
+    try {
+      rmSync(resolve(workspace, "migrations-after-deploy"), { recursive: true });
+      applyMigrationPhase(workspace, "after-deploy", {
+        target: "remote",
+        randomUUID: () => "legacy-release",
+        run
+      });
+
+      expect(run).not.toHaveBeenCalled();
+      expect(existsSync(temporaryConfig)).toBe(false);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
   it("runs both local phases in order and refuses a remote CLI target", () => {
     const workspace = createWorkspace();
     const commands = [];


### PR DESCRIPTION
## Summary

- treat an absent optional after-deploy migration phase in older signed releases as no work
- keep normal migrations and present after-deploy phases fail-closed
- add focused regression coverage for legacy archives

## Release evidence

Signed release run 33346016563 deployed v1.2.0 and then failed only because v1.2.0 predates `migrations-after-deploy/`. Publication was skipped, disposable resources were destroyed, and the failed draft was removed.

## Verification

- focused migration regression: 8 tests passed
- `pnpm check`: 782 unit and 193 integration tests passed
- `pnpm deploy:dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * After-deploy migrations are now skipped when no migration directory is included in a release.
  * Prevents unnecessary configuration changes and migration commands in this scenario.

* **Tests**
  * Added coverage confirming that skipped migrations do not invoke deployment tooling or create temporary configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->