### PR TITLE
Keep the N-1 release bootstrap version-aware

### DIFF
--- a/test/e2e/staging/lifecycle.spec.ts
+++ b/test/e2e/staging/lifecycle.spec.ts
@@ -255,6 +255,11 @@ test("Track 1 enforces read-only mailbox access and exposes operator diagnostics
 test("a mailbox agent stays inside its assigned mailbox and revokes cleanly", async ({
   request
 }) => {
+  test.skip(
+    (process.env.HQBASE_STAGING_MAIL_API_BASE_PATH ?? "/api/v2") === "/api",
+    "The N-1 bootstrap predates mailbox agents."
+  );
+
   const login = await request.post("/api/auth/sign-in/email", {
     data: { email, password, rememberMe: false },
     headers: { origin: stagingUrl }

--- a/test/unit/e2e/staging-mail-api-path.test.ts
+++ b/test/unit/e2e/staging-mail-api-path.test.ts
@@ -41,4 +41,18 @@ describe("staging Mail API path", () => {
     expect(bootstrapStep).toContain("HQBASE_STAGING_MAIL_API_BASE_PATH: /api");
     expect(bootstrapStep).toContain("run: pnpm test:e2e:staging:lifecycle");
   });
+
+  it("skips candidate-only mailbox agent checks during N-1 bootstrap", () => {
+    const agentTestStart = lifecycleSpec.indexOf(
+      'test("a mailbox agent stays inside its assigned mailbox and revokes cleanly"'
+    );
+    const nextTest = lifecycleSpec.indexOf('\ntest("candidate mail experience', agentTestStart);
+    const agentTest = lifecycleSpec.slice(agentTestStart, nextTest);
+
+    expect(agentTestStart).toBeGreaterThan(-1);
+    expect(nextTest).toBeGreaterThan(agentTestStart);
+    expect(agentTest).toContain('HQBASE_STAGING_MAIL_API_BASE_PATH ?? "/api/v2"');
+    expect(agentTest).toContain('=== "/api"');
+    expect(agentTest.indexOf("test.skip(")).toBeLessThan(agentTest.indexOf("request.post("));
+  });
 });


### PR DESCRIPTION
The signed release gate deploys v1.2.0 before it applies v1.3.0. The current lifecycle suite was running the candidate-only mailbox-agent test during that v1.2.0 bootstrap, where the Management API does not exist.\n\nThis change skips only that candidate-only test while the workflow uses the legacy /api base path. The same test still runs in full after the signed v1.3.0 candidate is applied.\n\nVerified locally:\n- focused staging-path regression: 5 passed\n- pnpm check\n- pnpm deploy:dry-run\n\nThe failed release remained fail-closed: publish was skipped, the draft was removed, and disposable resources were destroyed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsupported mailbox-agent lifecycle checks from running with the legacy staging API path.
  * Ensured candidate-only checks are skipped before any staging API requests are made in this configuration.

* **Tests**
  * Added coverage validating the staging bootstrap behavior for the legacy API path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->