### PR TITLE
test: keep catch-all staging expectations phase-aware

### DIFF
--- a/test/e2e/staging/lifecycle.spec.ts
+++ b/test/e2e/staging/lifecycle.spec.ts
@@ -344,11 +344,13 @@ test("candidate mail experience contracts work together", async ({ request }) =>
   if (!primaryMailbox) throw new Error(`Staging mailbox ${sender} was not found.`);
   const domainsResponse = await request.get("/api/domains");
   expect(domainsResponse.ok(), await domainsResponse.text()).toBeTruthy();
+  const expectedPrimaryCatchAll = process.env.PREVIOUS_TAG
+    ? { catchAllMailboxId: null, catchAllPolicy: "unassigned" }
+    : { catchAllMailboxId: primaryMailbox.id, catchAllPolicy: "mailbox" };
   expect(await domainsResponse.json()).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        catchAllMailboxId: primaryMailbox.id,
-        catchAllPolicy: "mailbox",
+        ...expectedPrimaryCatchAll,
         id: primaryMailbox.mailDomainId
       })
     ])

--- a/test/unit/e2e/staging-mail-api-path.test.ts
+++ b/test/unit/e2e/staging-mail-api-path.test.ts
@@ -55,4 +55,20 @@ describe("staging Mail API path", () => {
     expect(agentTest).toContain('=== "/api"');
     expect(agentTest.indexOf("test.skip(")).toBeLessThan(agentTest.indexOf("request.post("));
   });
+
+  it("keeps catch-all expectations specific to fresh installs and N-1 upgrades", () => {
+    const experienceTestStart = lifecycleSpec.indexOf(
+      'test("candidate mail experience contracts work together"'
+    );
+    const experienceTest = lifecycleSpec.slice(experienceTestStart);
+
+    expect(experienceTestStart).toBeGreaterThan(-1);
+    expect(releaseWorkflow).toContain("PREVIOUS_TAG:");
+    expect(releaseWorkflow).toContain("needs.candidate.outputs.previous_tag");
+    expect(experienceTest).toContain("process.env.PREVIOUS_TAG");
+    expect(experienceTest).toContain('{ catchAllMailboxId: null, catchAllPolicy: "unassigned" }');
+    expect(experienceTest).toContain(
+      '{ catchAllMailboxId: primaryMailbox.id, catchAllPolicy: "mailbox" }'
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- keep fresh-install staging strict: the first human mailbox receives unknown mail
- keep N-1 upgrade staging strict: existing domains preserve owner-only unassigned mail
- add regression coverage that binds the expectation to the release workflow phase

## Why

Signed release run 33350035042 completed the v1.2.0 deployment, N-1 bootstrap, v1.3.0 update, readiness, and installed-version checks. The lifecycle test then applied a fresh-install assertion to the upgraded workspace. The product state was correct and matched the canonical migration and specification.

## Verification

- CI=true pnpm check
- CI=true pnpm deploy:dry-run
- focused staging and migration regression tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated staging lifecycle coverage to validate the correct primary-domain catch-all configuration for tagged and current environments.
  * Added end-to-end coverage for fresh installs and N-1 upgrades, including candidate workflow version handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->