### PR TITLE
release: HQBase 1.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,12 +194,18 @@ jobs:
             --dir /tmp/hqbase-previous
           previous_version="${PREVIOUS_TAG#v}"
           previous_archive="/tmp/hqbase-previous/hqbase-${previous_version}.tar.gz"
+          previous_source="/tmp/hqbase-previous/source"
+          mkdir -p "$previous_source"
+          tar -xzf "$previous_archive" -C "$previous_source"
+          pnpm --dir "$previous_source" install --frozen-lockfile
+          previous_updater="$previous_source/scripts/release/deploy.mjs"
+          echo "HQBASE_PREVIOUS_UPDATER=$previous_updater" >> "$GITHUB_ENV"
           config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
           HQBASE_AUTH_SECRET="$HQBASE_STAGING_AUTH_SECRET" \
           HQBASE_EXPECTED_RELEASE_VERSION="$previous_version" \
           HQBASE_RELEASE_ARTIFACT_FILE="$previous_archive" \
           HQBASE_RELEASE_MANIFEST_FILE="/tmp/hqbase-previous/stable.json" \
-            node scripts/release/deploy.mjs --config "$config"
+            node "$previous_updater" --config "$GITHUB_WORKSPACE/$config"
       - name: Wait for the previous stable release
         if: needs.candidate.outputs.previous_tag != ''
         run: |
@@ -228,11 +234,12 @@ jobs:
             --client-id "$HQBASE_STAGING_OAUTH_CLIENT_ID" \
             --skip-deploy
           config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          updater="${HQBASE_PREVIOUS_UPDATER:-$GITHUB_WORKSPACE/scripts/release/deploy.mjs}"
           HQBASE_AUTH_SECRET="$HQBASE_STAGING_AUTH_SECRET" \
           HQBASE_EXPECTED_RELEASE_VERSION="$CANDIDATE_VERSION" \
-          HQBASE_RELEASE_ARTIFACT_FILE="release/hqbase-${CANDIDATE_VERSION}.tar.gz" \
-          HQBASE_RELEASE_MANIFEST_FILE="release/stable.json" \
-            node scripts/release/deploy.mjs --config "$config"
+          HQBASE_RELEASE_ARTIFACT_FILE="$GITHUB_WORKSPACE/release/hqbase-${CANDIDATE_VERSION}.tar.gz" \
+          HQBASE_RELEASE_MANIFEST_FILE="$GITHUB_WORKSPACE/release/stable.json" \
+            node "$updater" --config "$GITHUB_WORKSPACE/$config"
       - name: Wait for the signed candidate
         run: |
           for attempt in $(seq 1 150); do
@@ -257,6 +264,20 @@ jobs:
             --command "SELECT installed_version FROM release_state WHERE singleton = 1")"
           jq -e --arg version "$CANDIDATE_VERSION" \
             '.[0].results[0].installed_version == $version' <<<"$result"
+      - name: Verify active Worker bindings
+        run: |
+          config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          status="$(pnpm exec wrangler deployments status \
+            --name hqbase-e2e-staging --json --config "$config")"
+          version_id="$(jq -er '.versions[] | select(.percentage == 100) | .version_id' \
+            <<<"$status")"
+          version="$(pnpm exec wrangler versions view "$version_id" \
+            --name hqbase-e2e-staging --json --config "$config")"
+          jq -e '
+            [.resources.bindings[].name] as $names |
+            (["DB", "MAIL_OBJECTS", "HQBASE_JOBS", "MAIL_SENDER", "MAIL_EVENTS"] - $names) |
+            length == 0
+          ' <<<"$version"
       - name: Verify PWA, app shell, access, and operator lifecycle
         run: pnpm test:e2e:staging
       - name: Exercise populated remote backup and restore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.3.1
+
+### Fixed
+
+- Restore and validate the live-event Durable Object binding when an older supported updater builds
+  this release, and stop an update if Cloudflare does not report all required bindings on the active
+  Worker.
+- Keep an open composer and its unsaved input stable during event reconnection, mailbox refresh, and
+  fallback synchronization. A new composer no longer creates duplicate empty drafts during these
+  refreshes.
+- Return a safe service-unavailable response when live events are not configured or cannot connect.
+  The app continues through the HTTP synchronization journals, and Worker logs contain only a safe
+  diagnostic code and request ID.
+- Test signed release candidates with the previous stable updater and verify the active bindings and
+  authenticated event WebSocket before publication.
+
 ## 1.3.0
 
 ### New

--- a/app/features/compose/compose-dialog.tsx
+++ b/app/features/compose/compose-dialog.tsx
@@ -3,20 +3,22 @@ import { toast } from "sonner";
 
 import { createDraft, deleteDraft, listDrafts } from "@/features/drafts/api";
 import type { Draft } from "@/features/drafts/types";
-import type { SignatureSnapshot } from "@/features/signatures/types";
 import { playNotificationSound } from "@/lib/notification-sounds";
 
 import { replyToMessage, sendMessage } from "./api";
 import { ComposeForm } from "./compose-form";
 import {
+  beginComposeInitialization,
   type ComposeDialogProps,
   composeContextLabel,
+  composeInitializationKey,
   composeTitle,
   type DraftSaveState,
   defaultSendingIdentity,
   draftEditorHtml,
   draftRecoveryKey,
   draftStatus,
+  emptyAutomaticSignature,
   findDraftForComposer,
   forwardedMessage,
   hasInvalidRecipients,
@@ -32,15 +34,9 @@ import {
 import { ComposeSurface } from "./compose-surface";
 import { referencedInlineAttachmentIds } from "./email-images";
 import { useComposeAttachments } from "./use-compose-attachments";
+import { useComposeFrom } from "./use-compose-from";
 import { useDraftAutosave } from "./use-draft-autosave";
 
-const emptyAutomaticSignature: SignatureSnapshot = {
-  mode: "automatic",
-  id: null,
-  name: "",
-  html: "",
-  text: ""
-};
 export function ComposeDialog({
   defaultFromMailboxId = null,
   dockIndex = 0,
@@ -80,9 +76,9 @@ export function ComposeDialog({
   const [html, setHtml] = React.useState("<p></p>");
   const [text, setText] = React.useState("");
   const [isPending, setIsPending] = React.useState(false);
-  const [isSignaturePending, setIsSignaturePending] = React.useState(false);
   const [saveState, setSaveState] = React.useState<DraftSaveState>("saved");
   const initialized = React.useRef(false);
+  const initializationKeyRef = React.useRef<string | null>(null);
   const generationRef = React.useRef(0);
   const draftRef = React.useRef<Draft | null>(null);
   const htmlRef = React.useRef(html);
@@ -95,6 +91,14 @@ export function ComposeDialog({
   const formId = React.useId();
   const replyToMessageId = mode === "reply" ? (message?.id ?? null) : null;
   const forwardOfMessageId = mode === "forward" ? (message?.id ?? null) : null;
+  const initializationKey = composeInitializationKey(
+    mode,
+    draftId,
+    replyToMessageId,
+    forwardOfMessageId,
+    initialTo,
+    defaultFromMailboxId
+  );
   const contextLabel = composeContextLabel(mode, message);
   const recoveryKey = draft ? draftRecoveryKey(draft.id) : "";
   const { initializeAutosave, resetAutosave, saveFrom, saveSignature } = useDraftAutosave({
@@ -115,6 +119,11 @@ export function ComposeDialog({
     setDraft,
     setSaveState
   });
+  const { changeFrom, isSignaturePending, setIsSignaturePending } = useComposeFrom(
+    from,
+    setFrom,
+    saveFrom
+  );
   draftRef.current = draft;
   htmlRef.current = html;
   const {
@@ -130,8 +139,13 @@ export function ComposeDialog({
   } = useComposeAttachments({ draftRef, generationRef, htmlRef });
 
   React.useEffect(() => {
-    const generation = startSession();
-    if (!open) return;
+    const generation = beginComposeInitialization(
+      open,
+      initializationKey,
+      initializationKeyRef,
+      startSession
+    );
+    if (generation === null) return;
     initialized.current = false;
     void (async () => {
       try {
@@ -206,12 +220,14 @@ export function ComposeDialog({
         initialized.current = true;
       } catch (error) {
         if (generation !== generationRef.current) return;
+        initializationKeyRef.current = null;
         toast.error(error instanceof Error ? error.message : "Draft could not be opened.");
         if (draftId) onOpenChangeRef.current(false);
       }
     })();
   }, [
     open,
+    initializationKey,
     message,
     mode,
     identities,
@@ -275,21 +291,6 @@ export function ComposeDialog({
       toast.error(error instanceof Error ? error.message : "Sending failed.");
     } finally {
       setIsPending(false);
-    }
-  }
-
-  async function changeFrom(nextFrom: string): Promise<void> {
-    if (nextFrom === from) return;
-    const previousFrom = from;
-    setFrom(nextFrom);
-    setIsSignaturePending(true);
-    try {
-      await saveFrom(nextFrom);
-    } catch (error) {
-      setFrom(previousFrom);
-      toast.error(error instanceof Error ? error.message : "From address could not be changed.");
-    } finally {
-      setIsSignaturePending(false);
     }
   }
 

--- a/app/features/compose/compose-state.ts
+++ b/app/features/compose/compose-state.ts
@@ -3,11 +3,20 @@ import { z } from "zod";
 import type { Draft } from "@/features/drafts/types";
 import type { Mailbox } from "@/features/mailboxes/types";
 import type { MessageDetail } from "@/features/messages/types";
+import type { SignatureSnapshot } from "@/features/signatures/types";
 import { formatDateTime } from "@/lib/format";
 import type { SendingIdentity } from "./compose-fields";
 
 export type ComposeMode = "new" | "reply" | "forward";
 export type DraftSaveState = "saved" | "saving" | "local" | "error";
+
+export const emptyAutomaticSignature: SignatureSnapshot = {
+  mode: "automatic",
+  id: null,
+  name: "",
+  html: "",
+  text: ""
+};
 
 export type ComposeDialogProps = {
   defaultFromMailboxId?: string | null;
@@ -34,6 +43,29 @@ export type ComposeDialogProps = {
   onReturnToThread?: (() => void) | undefined;
   onSent: () => void;
 };
+
+export function composeInitializationKey(
+  mode: ComposeMode,
+  ...target: Array<string | null>
+): string {
+  return JSON.stringify([mode, ...target]);
+}
+
+export function beginComposeInitialization(
+  open: boolean,
+  key: string,
+  state: { current: string | null },
+  startSession: () => number
+): number | null {
+  if (!open) {
+    if (state.current !== null) startSession();
+    state.current = null;
+    return null;
+  }
+  if (state.current === key) return null;
+  state.current = key;
+  return startSession();
+}
 
 export function findDraftForComposer(
   drafts: Draft[],

--- a/app/features/compose/use-compose-from.ts
+++ b/app/features/compose/use-compose-from.ts
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { toast } from "sonner";
+
+export function useComposeFrom(
+  from: string,
+  setFrom: React.Dispatch<React.SetStateAction<string>>,
+  saveFrom: (nextFrom: string) => Promise<unknown>
+): {
+  changeFrom: (nextFrom: string) => Promise<void>;
+  isSignaturePending: boolean;
+  setIsSignaturePending: React.Dispatch<React.SetStateAction<boolean>>;
+} {
+  const [isSignaturePending, setIsSignaturePending] = React.useState(false);
+
+  async function changeFrom(nextFrom: string): Promise<void> {
+    if (nextFrom === from) return;
+    setFrom(nextFrom);
+    setIsSignaturePending(true);
+    try {
+      await saveFrom(nextFrom);
+    } catch (error) {
+      setFrom(from);
+      toast.error(error instanceof Error ? error.message : "From address could not be changed.");
+    } finally {
+      setIsSignaturePending(false);
+    }
+  }
+
+  return { changeFrom, isSignaturePending, setIsSignaturePending };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hqbase",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",
@@ -13,7 +13,7 @@
     "dev:vite": "vite --host 127.0.0.1 --port 5173",
     "dev:ui": "vite --host 127.0.0.1 --port 5173 --open /__ui/design",
     "dev:setup-ui": "vite --host 127.0.0.1 --port 5173 --open /__ui/setup?state=loading",
-    "build": "vite build && node scripts/build-pwa.mjs && node scripts/check-setup-preview-boundary.mjs",
+    "build": "node scripts/release/prepare-worker-config.mjs && vite build && node scripts/build-pwa.mjs && node scripts/check-setup-preview-boundary.mjs",
     "deploy": "node scripts/release/deploy.mjs",
     "db:reset:local": "wrangler d1 execute DB --local --yes --file scripts/hqbase/reset-d1.sql && node scripts/d1-migrations.mjs --local",
     "db:migrate:local": "node scripts/d1-migrations.mjs --local",

--- a/scripts/release/active-version.mjs
+++ b/scripts/release/active-version.mjs
@@ -1,5 +1,7 @@
 import { attemptRun, capture as captureRun, emitCommandOutput } from "./command.mjs";
 
+const requiredActiveBindings = ["DB", "MAIL_OBJECTS", "HQBASE_JOBS", "MAIL_SENDER", "MAIL_EVENTS"];
+
 export function inspectActiveRelease(cwd, workerName, options = {}) {
   const attempt = options.attempt ?? attemptRun;
   const capture = options.capture ?? captureRun;
@@ -61,11 +63,29 @@ export function parseActiveRelease(deployment, version) {
   return {
     versionId,
     version: binding.text,
+    missingBindings: missingRequiredActiveBindings(version),
     tag:
       typeof version?.annotations?.["workers/tag"] === "string"
         ? version.annotations["workers/tag"]
         : null
   };
+}
+
+export function assertRequiredActiveBindings(activeRelease) {
+  if (!activeRelease || activeRelease.missingBindings.length > 0) {
+    const missing = activeRelease?.missingBindings.join(", ") || requiredActiveBindings.join(", ");
+    throw new Error(`The active HQBase Worker is missing required bindings: ${missing}.`);
+  }
+  return activeRelease;
+}
+
+export function missingRequiredActiveBindings(version) {
+  const names = new Set(
+    (Array.isArray(version?.resources?.bindings) ? version.resources.bindings : [])
+      .map((binding) => binding?.name)
+      .filter((name) => typeof name === "string")
+  );
+  return requiredActiveBindings.filter((name) => !names.has(name));
 }
 
 export function isDeployButtonBootstrap(deployment, version) {

--- a/scripts/release/deploy.mjs
+++ b/scripts/release/deploy.mjs
@@ -7,7 +7,7 @@ import { resolve } from "node:path";
 import { applyMigrationPhase } from "../d1-migrations.mjs";
 import { recordWorkerDeployedForConfig } from "../hqbase/manifest.mjs";
 import { windowsSystem32Executable } from "../windows-system32.mjs";
-import { inspectActiveRelease } from "./active-version.mjs";
+import { assertRequiredActiveBindings, inspectActiveRelease } from "./active-version.mjs";
 import { capture, run } from "./command.mjs";
 import {
   compareVersions,
@@ -94,6 +94,7 @@ export async function deploy(options = {}) {
     if (!activeRelease) {
       applyMigrationPhase(source, "normal", { target: "remote" });
       deploySource(source, { releaseTag });
+      assertRequiredActiveBindings(inspectActiveRelease(source, config.name));
       recordWorkerDeployed();
       applyMigrationPhase(source, "after-deploy", { target: "remote" });
       executeSql(
@@ -113,6 +114,9 @@ export async function deploy(options = {}) {
       );
     }
     if (activeRelease.version === manifest.version && activeRelease.tag === releaseTag) {
+      if (activeRelease.missingBindings.length > 0) {
+        deployConfiguration(source, config.name, releaseTag);
+      }
       completeActiveReleaseRetry(source, manifest, recordWorkerDeployed);
       console.log(`HQBase ${manifest.version} is already the active signed release.`);
       return;
@@ -165,22 +169,8 @@ export async function deploy(options = {}) {
       ],
       source
     );
+    assertRequiredActiveBindings(inspectActiveRelease(source, config.name));
     recordWorkerDeployed();
-    capture(
-      "pnpm",
-      [
-        "exec",
-        "wrangler",
-        "deployments",
-        "status",
-        "--name",
-        config.name,
-        "--json",
-        "--config",
-        "wrangler.jsonc"
-      ],
-      source
-    );
     applyMigrationPhase(source, "after-deploy", { target: "remote" });
     recovery.cleanupComplete = true;
     executeSql(
@@ -242,7 +232,7 @@ export function deployConfiguration(source, workerName, releaseTag, options = {}
       "Refusing to continue: Cloudflare does not report a new active version for the configuration deployment."
     );
   }
-  return after;
+  return assertRequiredActiveBindings(after);
 }
 
 export function completeActiveReleaseRetry(source, manifest, recordWorkerDeployed, options = {}) {

--- a/scripts/release/prepare-worker-config.mjs
+++ b/scripts/release/prepare-worker-config.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const mailEventsBinding = { name: "MAIL_EVENTS", class_name: "MailEvents" };
+const mailEventsMigration = { tag: "mail-events-v1", new_sqlite_classes: ["MailEvents"] };
+
+export function prepareRequiredWorkerConfig(config) {
+  assertObject(config, "Worker configuration");
+  const durableBindings = array(config.durable_objects?.bindings);
+  const currentBinding = durableBindings.find(
+    (binding) => binding?.name === mailEventsBinding.name
+  );
+  if (currentBinding && currentBinding.class_name !== mailEventsBinding.class_name) {
+    throw new Error("MAIL_EVENTS must bind the MailEvents Durable Object class.");
+  }
+
+  const migrations = array(config.migrations);
+  const currentMigration = migrations.find(
+    (migration) => migration?.tag === mailEventsMigration.tag
+  );
+  if (
+    currentMigration &&
+    !array(currentMigration.new_sqlite_classes).includes(mailEventsBinding.class_name)
+  ) {
+    throw new Error("mail-events-v1 must create the MailEvents SQLite Durable Object class.");
+  }
+  const conflictingMigration = migrations.find(
+    (migration) =>
+      migration?.tag !== mailEventsMigration.tag &&
+      array(migration?.new_sqlite_classes).includes(mailEventsBinding.class_name)
+  );
+  if (conflictingMigration) {
+    throw new Error("MailEvents is assigned to an unexpected Durable Object migration tag.");
+  }
+
+  const prepared = {
+    ...config,
+    durable_objects: {
+      ...config.durable_objects,
+      bindings: currentBinding ? durableBindings : [...durableBindings, mailEventsBinding]
+    },
+    migrations: currentMigration ? migrations : [...migrations, mailEventsMigration]
+  };
+  assertRequiredWorkerConfig(prepared);
+  return prepared;
+}
+
+export function assertRequiredWorkerConfig(config) {
+  const checks = [
+    [config.assets?.binding === "ASSETS", "ASSETS Worker Assets binding"],
+    [array(config.d1_databases).some((binding) => binding?.binding === "DB"), "DB D1 binding"],
+    [
+      array(config.r2_buckets).some((binding) => binding?.binding === "MAIL_OBJECTS"),
+      "MAIL_OBJECTS R2 binding"
+    ],
+    [
+      array(config.queues?.producers).some((binding) => binding?.binding === "HQBASE_JOBS"),
+      "HQBASE_JOBS Queue binding"
+    ],
+    [
+      array(config.send_email).some((binding) => binding?.name === "MAIL_SENDER"),
+      "MAIL_SENDER Email binding"
+    ],
+    [
+      array(config.durable_objects?.bindings).some(
+        (binding) =>
+          binding?.name === mailEventsBinding.name &&
+          binding?.class_name === mailEventsBinding.class_name
+      ),
+      "MAIL_EVENTS Durable Object binding"
+    ],
+    [
+      array(config.migrations).some(
+        (migration) =>
+          migration?.tag === mailEventsMigration.tag &&
+          array(migration?.new_sqlite_classes).includes(mailEventsBinding.class_name)
+      ),
+      "mail-events-v1 Durable Object migration"
+    ]
+  ];
+  const missing = checks.filter(([present]) => !present).map(([, label]) => label);
+  if (missing.length > 0) {
+    throw new Error(`HQBase Worker configuration is missing: ${missing.join(", ")}.`);
+  }
+}
+
+export function prepareRequiredWorkerConfigFile(configFile) {
+  const source = readFileSync(configFile, "utf8");
+  const config = JSON.parse(source);
+  const prepared = prepareRequiredWorkerConfig(config);
+  if (JSON.stringify(prepared) !== JSON.stringify(config)) {
+    writeFileSync(configFile, `${JSON.stringify(prepared, null, 2)}\n`);
+  }
+  return prepared;
+}
+
+function array(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function assertObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object.`);
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(import.meta.filename)) {
+  prepareRequiredWorkerConfigFile(resolve(process.cwd(), "wrangler.jsonc"));
+  console.log("HQBase Worker bindings and migrations are ready.");
+}

--- a/test/e2e/staging/lifecycle.spec.ts
+++ b/test/e2e/staging/lifecycle.spec.ts
@@ -113,6 +113,10 @@ test("HQBase web lifecycle remains healthy", async ({ page, request }) => {
     name: /^(?:Compose|New email)$/
   });
   const loginEmail = page.getByLabel("Email");
+  const eventSocket = page.waitForEvent("websocket", {
+    predicate: (socket) => new URL(socket.url()).pathname === "/api/v2/events",
+    timeout: 60_000
+  });
   try {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await expect(
@@ -137,6 +141,7 @@ test("HQBase web lifecycle remains healthy", async ({ page, request }) => {
     await page.getByRole("button", { name: "Continue" }).click();
   }
   await expect(primaryEmailAction).toBeVisible({ timeout: 60_000 });
+  await expect(eventSocket).resolves.toBeDefined();
   const expectedUpdate = process.env.HQBASE_STAGING_EXPECT_UPDATE_VERSION;
   if (expectedUpdate) {
     await expect

--- a/test/unit/app/compose/compose-signature-send.test.tsx
+++ b/test/unit/app/compose/compose-signature-send.test.tsx
@@ -20,6 +20,7 @@ type CapturedComposeProps = {
 
 const mocks = vi.hoisted(() => ({
   captured: null as CapturedComposeProps | null,
+  createDraft: vi.fn(),
   deleteDraftAttachment: vi.fn(),
   initializeAutosave: vi.fn(),
   listDrafts: vi.fn(),
@@ -31,7 +32,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/features/drafts/api", () => ({
-  createDraft: vi.fn(),
+  createDraft: mocks.createDraft,
   deleteDraft: vi.fn(),
   deleteDraftAttachment: mocks.deleteDraftAttachment,
   listDrafts: mocks.listDrafts,
@@ -97,6 +98,7 @@ const mailbox = {
 describe("compose signature send ordering", () => {
   beforeEach(() => {
     mocks.captured = null;
+    mocks.createDraft.mockReset().mockResolvedValue(draft);
     mocks.initializeAutosave.mockReset();
     mocks.listDrafts.mockReset().mockResolvedValue([draft]);
     mocks.resetAutosave.mockReset();
@@ -191,6 +193,44 @@ describe("compose signature send ordering", () => {
     const html = "<p>First &lt;line&gt; &amp; next<br>Second</p>";
     expect(mocks.captured?.html).toBe(html);
     expect(mocks.initializeAutosave).toHaveBeenCalledWith({ ...textOnlyDraft, html });
+    await view.unmount();
+  });
+
+  it("keeps one new draft and unsaved input through a mailbox refresh", async () => {
+    const newDraft = {
+      ...draft,
+      id: "draft-new-message",
+      subject: "",
+      text: "",
+      html: "<p></p>"
+    };
+    mocks.listDrafts.mockResolvedValue([]);
+    mocks.createDraft.mockResolvedValue(newDraft);
+    const props = {
+      draftId: null,
+      mailboxes: [mailbox],
+      open: true,
+      onOpenChange: () => undefined,
+      onSent: () => undefined
+    };
+    const view = await renderComponent(<ComposeDialog {...props} />);
+    await flushHookEffects();
+    await flushHookEffects();
+
+    await flushHookEffects(() =>
+      mocks.captured?.onEditorChange("<p>Unsaved words</p>", "Unsaved words")
+    );
+    await view.rerender(
+      <ComposeDialog
+        {...props}
+        mailboxes={[{ ...mailbox, displayName: "Support team", updatedAt: "2026-08-31" }]}
+      />
+    );
+    await flushHookEffects();
+
+    expect(mocks.listDrafts).toHaveBeenCalledOnce();
+    expect(mocks.createDraft).toHaveBeenCalledOnce();
+    expect(mocks.captured?.html).toBe("<p>Unsaved words</p>");
     await view.unmount();
   });
 

--- a/test/unit/scripts/d1-migrations.test.mjs
+++ b/test/unit/scripts/d1-migrations.test.mjs
@@ -248,7 +248,7 @@ describe("two-phase D1 migrations", () => {
     expectOrder(update, [
       'applyMigrationPhase(source, "normal"',
       '"deploy",\n        "--keep-vars"',
-      '"deployments",\n        "status"',
+      "assertRequiredActiveBindings(inspectActiveRelease(source, config.name))",
       'applyMigrationPhase(source, "after-deploy"',
       "recovery.cleanupComplete = true",
       "UPDATE release_state SET installed_version"

--- a/test/unit/scripts/deploy.test.mjs
+++ b/test/unit/scripts/deploy.test.mjs
@@ -5,6 +5,7 @@ import { dirname, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { configPath } from "../../../scripts/hqbase/manifest.mjs";
 import {
+  assertRequiredActiveBindings,
   inspectActiveRelease,
   isDeployButtonBootstrap,
   parseActiveRelease
@@ -23,6 +24,10 @@ import {
   verifyManifest,
   workerNameFromConfig
 } from "../../../scripts/release/deploy.mjs";
+import {
+  assertRequiredWorkerConfig,
+  prepareRequiredWorkerConfig
+} from "../../../scripts/release/prepare-worker-config.mjs";
 import { foreignTrustees } from "../../../scripts/secure-directory.mjs";
 
 describe("HQBase release deployment", () => {
@@ -51,8 +56,8 @@ describe("HQBase release deployment", () => {
   it("verifies that a configuration deployment produced a new active version", () => {
     const commands = [];
     const versions = [
-      { versionId: "version-1", version: "1.2.3", tag: "hqbase:1.2.3" },
-      { versionId: "version-2", version: "1.2.3", tag: "hqbase:1.2.3" }
+      { missingBindings: [], versionId: "version-1", version: "1.2.3", tag: "hqbase:1.2.3" },
+      { missingBindings: [], versionId: "version-2", version: "1.2.3", tag: "hqbase:1.2.3" }
     ];
     const inspect = () => versions.shift() ?? versions[0];
 
@@ -67,7 +72,12 @@ describe("HQBase release deployment", () => {
     expect(commands[0]).toContain("--strict");
     expect(commands[0]).toContain("--tag hqbase:1.2.3");
 
-    const unchanged = { versionId: "version-1", version: "1.2.3", tag: "hqbase:1.2.3" };
+    const unchanged = {
+      missingBindings: [],
+      versionId: "version-1",
+      version: "1.2.3",
+      tag: "hqbase:1.2.3"
+    };
     expect(() =>
       deployConfiguration("/source", "hqbase-qa", "hqbase:1.2.3", {
         inspect: () => unchanged,
@@ -190,6 +200,31 @@ describe("HQBase release deployment", () => {
     expect(candidate.durable_objects).toEqual(releaseConfig.durable_objects);
     expect(candidate.migrations).toEqual(releaseConfig.migrations);
   });
+  it("repairs the required realtime configuration left out by an older updater", () => {
+    const staleConfig = {
+      assets: { binding: "ASSETS", directory: "./dist" },
+      d1_databases: [{ binding: "DB", database_id: "database-id" }],
+      durable_objects: {
+        bindings: [{ name: "CUSTOMER_EVENTS", class_name: "CustomerEvents" }]
+      },
+      migrations: [{ tag: "customer-events-v1", new_sqlite_classes: ["CustomerEvents"] }],
+      queues: { producers: [{ binding: "HQBASE_JOBS", queue: "jobs" }] },
+      r2_buckets: [{ binding: "MAIL_OBJECTS", bucket_name: "mail" }],
+      send_email: [{ name: "MAIL_SENDER" }]
+    };
+
+    const prepared = prepareRequiredWorkerConfig(staleConfig);
+
+    expect(prepared.durable_objects.bindings).toEqual([
+      { name: "CUSTOMER_EVENTS", class_name: "CustomerEvents" },
+      { name: "MAIL_EVENTS", class_name: "MailEvents" }
+    ]);
+    expect(prepared.migrations).toEqual([
+      { tag: "customer-events-v1", new_sqlite_classes: ["CustomerEvents"] },
+      { tag: "mail-events-v1", new_sqlite_classes: ["MailEvents"] }
+    ]);
+    expect(() => assertRequiredWorkerConfig(prepared)).not.toThrow();
+  });
   it("creates an immutable active-version tag from the signed HQBase artifact", () => {
     expect(hqbaseReleaseTag("0.1.5", "a".repeat(64))).toBe(`hqbase:0.1.5:${"a".repeat(64)}`);
     expect(() => hqbaseReleaseTag("0.1.5", "not-a-digest")).toThrow("identity");
@@ -209,6 +244,7 @@ describe("HQBase release deployment", () => {
     ).toEqual({
       versionId: "active-version",
       version: "0.1.14",
+      missingBindings: ["DB", "MAIL_OBJECTS", "HQBASE_JOBS", "MAIL_SENDER", "MAIL_EVENTS"],
       tag: `hqbase:0.1.14:${"a".repeat(64)}`
     });
     expect(() =>
@@ -217,6 +253,16 @@ describe("HQBase release deployment", () => {
         { id: "one", resources: { bindings: [] } }
       )
     ).toThrow("one active 100-percent version");
+  });
+  it("rejects an active release that Cloudflare reports without a required binding", () => {
+    expect(() =>
+      assertRequiredActiveBindings({
+        missingBindings: ["MAIL_EVENTS"],
+        versionId: "broken-version",
+        version: "1.3.0",
+        tag: "hqbase:1.3.0"
+      })
+    ).toThrow("MAIL_EVENTS");
   });
   it("distinguishes a fresh Worker from an existing active release", () => {
     expect(

--- a/test/unit/worker/features/events/route.test.ts
+++ b/test/unit/worker/features/events/route.test.ts
@@ -1,0 +1,79 @@
+import type { WorkerEnv } from "@worker/lib/env";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireMailApiPrincipal: vi.fn()
+}));
+
+vi.mock("@worker/auth/mail-api", () => ({
+  MailApiAuthError: class MailApiAuthError extends Error {},
+  mailApiChallenge: vi.fn(() => "Bearer"),
+  requireMailApiPrincipal: mocks.requireMailApiPrincipal
+}));
+
+import { handleMailEventRoute } from "@worker/features/events/route";
+
+describe("mail event route configuration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireMailApiPrincipal.mockResolvedValue({
+      authentication: "session",
+      principal: { id: "user-1" },
+      scopes: new Set(["mail:read", "mail:send"])
+    });
+  });
+
+  it("returns a safe fallback response when the Durable Object binding is missing", async () => {
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const response = await handleMailEventRoute(
+      new Request("https://mail.example.com/api/v2/events", {
+        headers: {
+          authorization: "Bearer secret-value",
+          origin: "https://mail.example.com",
+          upgrade: "websocket",
+          "x-request-id": "request_12345678"
+        }
+      }),
+      {} as WorkerEnv
+    );
+
+    expect(response?.status).toBe(503);
+    await expect(response?.json()).resolves.toEqual({
+      error: {
+        code: "EVENT_SERVICE_UNAVAILABLE",
+        message: "The event service is unavailable. Continue with HTTP synchronization."
+      }
+    });
+    expect(response?.headers.get("x-request-id")).toBe("request_12345678");
+    expect(log).toHaveBeenCalledWith(
+      JSON.stringify({
+        code: "EVENT_BINDING_MISSING",
+        event: "mail_event_service_failure",
+        requestId: "request_12345678"
+      })
+    );
+    expect(log.mock.calls.flat().join(" ")).not.toContain("secret-value");
+    log.mockRestore();
+  });
+
+  it("keeps an unavailable Durable Object request on the HTTP fallback path", async () => {
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const response = await handleMailEventRoute(
+      new Request("https://mail.example.com/api/v2/events", {
+        headers: { origin: "https://mail.example.com", upgrade: "websocket" }
+      }),
+      {
+        MAIL_EVENTS: {
+          getByName: () => ({ fetch: () => Promise.reject(new Error("platform failure")) })
+        }
+      } as unknown as WorkerEnv
+    );
+
+    expect(response?.status).toBe(503);
+    await expect(response?.json()).resolves.toMatchObject({
+      error: { code: "EVENT_SERVICE_UNAVAILABLE" }
+    });
+    expect(log).toHaveBeenCalledOnce();
+    log.mockRestore();
+  });
+});

--- a/worker/features/events/route.ts
+++ b/worker/features/events/route.ts
@@ -35,14 +35,36 @@ export async function handleMailEventRoute(
     const topics: MailEventTopic[] = ["messages", "mailboxes", "labels"];
     if (principal.scopes.has("mail:send")) topics.push("drafts");
 
+    if (!env.MAIL_EVENTS) {
+      logEventServiceFailure("EVENT_BINDING_MISSING", requestId);
+      return eventError(
+        "EVENT_SERVICE_UNAVAILABLE",
+        "The event service is unavailable. Continue with HTTP synchronization.",
+        503,
+        { "x-request-id": requestId }
+      );
+    }
+
     const headers = new Headers({ upgrade: "websocket" });
     headers.set(mailEventInternalHeaders.requestId, requestId);
     headers.set(mailEventInternalHeaders.topics, topics.join(","));
     headers.set(mailEventInternalHeaders.user, principal.principal.id);
-    const response = await env.MAIL_EVENTS.getByName(workspaceHubName).fetch(
-      new Request(request.url, { headers })
-    );
+    let response: Response;
+    try {
+      response = await env.MAIL_EVENTS.getByName(workspaceHubName).fetch(
+        new Request(request.url, { headers })
+      );
+    } catch {
+      logEventServiceFailure("EVENT_SERVICE_REQUEST_FAILED", requestId);
+      return eventError(
+        "EVENT_SERVICE_UNAVAILABLE",
+        "The event service is unavailable. Continue with HTTP synchronization.",
+        503,
+        { "x-request-id": requestId }
+      );
+    }
     if (response.status !== 101) {
+      logEventServiceFailure("EVENT_UPGRADE_REJECTED", requestId);
       return eventError("EVENT_CONNECTION_FAILED", "The event connection failed.", 503, {
         "x-request-id": requestId
       });
@@ -56,6 +78,10 @@ export async function handleMailEventRoute(
     }
     return eventError(appError.code, appError.message, appError.status, headers);
   }
+}
+
+function logEventServiceFailure(code: string, requestId: string): void {
+  console.error(JSON.stringify({ code, event: "mail_event_service_failure", requestId }));
 }
 
 function validateSessionOrigin(


### PR DESCRIPTION
## Summary

Promote the tested HQBase 1.3.1 fix from `next`.

- self-heal and validate required realtime Worker configuration during managed updates
- preserve active composer state during event fallback and reconnect
- return safe event-service fallback responses and strengthen signed-release staging

## Verification

- `pnpm check`
- `pnpm deploy:dry-run`
- PR #96 passed Linux, Windows, CLA, and security checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compose and draft stability when switching contexts or synchronizing mailboxes.
  - Preserved unsaved editor content when creating a new draft.
  - Added safer handling for unavailable live-event services, with clear service-unavailable responses.
  - Strengthened release validation to detect and repair missing mail and data-service configuration.

- **Reliability**
  - Improved staging and release-candidate verification.
  - Updated to version 1.3.1 with enhanced deployment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->