### PR TITLE
Fix 1.3.1 signed release staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,14 +198,22 @@ jobs:
           mkdir -p "$previous_source"
           tar -xzf "$previous_archive" -C "$previous_source"
           pnpm --dir "$previous_source" install --frozen-lockfile
+          test ! -e "$previous_source/.hqbase"
+          ln -s "$GITHUB_WORKSPACE/.hqbase" "$previous_source/.hqbase"
           previous_updater="$previous_source/scripts/release/deploy.mjs"
+          previous_config="$previous_source/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
           echo "HQBASE_PREVIOUS_UPDATER=$previous_updater" >> "$GITHUB_ENV"
-          config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          echo "HQBASE_PREVIOUS_CONFIG=$previous_config" >> "$GITHUB_ENV"
+          if test -f "$previous_source/migrations/0025_activate_catch_all_policy.sql"; then
+            echo "HQBASE_STAGING_PREVIOUS_HAS_CATCH_ALL_POLICY=1" >> "$GITHUB_ENV"
+          else
+            echo "HQBASE_STAGING_PREVIOUS_HAS_CATCH_ALL_POLICY=0" >> "$GITHUB_ENV"
+          fi
           HQBASE_AUTH_SECRET="$HQBASE_STAGING_AUTH_SECRET" \
           HQBASE_EXPECTED_RELEASE_VERSION="$previous_version" \
           HQBASE_RELEASE_ARTIFACT_FILE="$previous_archive" \
           HQBASE_RELEASE_MANIFEST_FILE="/tmp/hqbase-previous/stable.json" \
-            node "$previous_updater" --config "$GITHUB_WORKSPACE/$config"
+            node "$previous_updater" --config "$previous_config"
       - name: Wait for the previous stable release
         if: needs.candidate.outputs.previous_tag != ''
         run: |
@@ -233,13 +241,13 @@ jobs:
             --auth-url "$HQBASE_STAGING_URL" \
             --client-id "$HQBASE_STAGING_OAUTH_CLIENT_ID" \
             --skip-deploy
-          config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          config="${HQBASE_PREVIOUS_CONFIG:-$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc}"
           updater="${HQBASE_PREVIOUS_UPDATER:-$GITHUB_WORKSPACE/scripts/release/deploy.mjs}"
           HQBASE_AUTH_SECRET="$HQBASE_STAGING_AUTH_SECRET" \
           HQBASE_EXPECTED_RELEASE_VERSION="$CANDIDATE_VERSION" \
           HQBASE_RELEASE_ARTIFACT_FILE="$GITHUB_WORKSPACE/release/hqbase-${CANDIDATE_VERSION}.tar.gz" \
           HQBASE_RELEASE_MANIFEST_FILE="$GITHUB_WORKSPACE/release/stable.json" \
-            node "$updater" --config "$GITHUB_WORKSPACE/$config"
+            node "$updater" --config "$config"
       - name: Wait for the signed candidate
         run: |
           for attempt in $(seq 1 150); do

--- a/test/e2e/staging/lifecycle.spec.ts
+++ b/test/e2e/staging/lifecycle.spec.ts
@@ -349,7 +349,10 @@ test("candidate mail experience contracts work together", async ({ request }) =>
   if (!primaryMailbox) throw new Error(`Staging mailbox ${sender} was not found.`);
   const domainsResponse = await request.get("/api/domains");
   expect(domainsResponse.ok(), await domainsResponse.text()).toBeTruthy();
-  const expectedPrimaryCatchAll = process.env.PREVIOUS_TAG
+  const upgradesLegacyCatchAll =
+    Boolean(process.env.PREVIOUS_TAG) &&
+    process.env.HQBASE_STAGING_PREVIOUS_HAS_CATCH_ALL_POLICY === "0";
+  const expectedPrimaryCatchAll = upgradesLegacyCatchAll
     ? { catchAllMailboxId: null, catchAllPolicy: "unassigned" }
     : { catchAllMailboxId: primaryMailbox.id, catchAllPolicy: "mailbox" };
   expect(await domainsResponse.json()).toEqual(

--- a/test/unit/e2e/staging-mail-api-path.test.ts
+++ b/test/unit/e2e/staging-mail-api-path.test.ts
@@ -56,7 +56,7 @@ describe("staging Mail API path", () => {
     expect(agentTest.indexOf("test.skip(")).toBeLessThan(agentTest.indexOf("request.post("));
   });
 
-  it("keeps catch-all expectations specific to fresh installs and N-1 upgrades", () => {
+  it("keeps catch-all expectations specific to the previous release schema", () => {
     const experienceTestStart = lifecycleSpec.indexOf(
       'test("candidate mail experience contracts work together"'
     );
@@ -65,7 +65,12 @@ describe("staging Mail API path", () => {
     expect(experienceTestStart).toBeGreaterThan(-1);
     expect(releaseWorkflow).toContain("PREVIOUS_TAG:");
     expect(releaseWorkflow).toContain("needs.candidate.outputs.previous_tag");
+    expect(releaseWorkflow).toContain("HQBASE_STAGING_PREVIOUS_HAS_CATCH_ALL_POLICY=1");
+    expect(releaseWorkflow).toContain("HQBASE_STAGING_PREVIOUS_HAS_CATCH_ALL_POLICY=0");
     expect(experienceTest).toContain("process.env.PREVIOUS_TAG");
+    expect(experienceTest).toContain(
+      'process.env.HQBASE_STAGING_PREVIOUS_HAS_CATCH_ALL_POLICY === "0"'
+    );
     expect(experienceTest).toContain('{ catchAllMailboxId: null, catchAllPolicy: "unassigned" }');
     expect(experienceTest).toContain(
       '{ catchAllMailboxId: primaryMailbox.id, catchAllPolicy: "mailbox" }'

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -114,6 +114,20 @@ describe("staging workflow lifecycle record", () => {
     expect(waitStep).toContain("candidate=$CANDIDATE_VERSION&attempt=$attempt");
   });
 
+  it("runs the previous updater against its own deployment root", () => {
+    expect(releaseWorkflow).toContain(
+      'ln -s "$GITHUB_WORKSPACE/.hqbase" "$previous_source/.hqbase"'
+    );
+    expect(releaseWorkflow).toContain(
+      'previous_config="$previous_source/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"'
+    );
+    expect(releaseWorkflow).toContain('node "$previous_updater" --config "$previous_config"');
+    expect(releaseWorkflow).toContain(
+      `config="\${HQBASE_PREVIOUS_CONFIG:-$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc}"`
+    );
+    expect(releaseWorkflow).toContain('node "$updater" --config "$config"');
+  });
+
   it("moves the Deploy Button source before publication and verifies the exact commit", () => {
     const readSource = releaseWorkflow.indexOf("Read current Deploy Button source");
     const verifyTag = releaseWorkflow.indexOf("Verify any existing release tag source");


### PR DESCRIPTION
## Summary\n\n- run the previous stable updater from the deployment root it expects\n- detect whether the previous release already contains the catch-all activation migration\n- preserve the real Worker deployment checkpoint so disposable staging cleanup removes bound queues safely\n\n## Verification\n\n- focused regression tests: 39 passed\n- pnpm check: 790 unit tests and 193 Worker integration tests passed\n- pnpm deploy:dry-run: passed with MAIL_EVENTS present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging upgrades to select the correct deployment configuration from the previous or current release.
  * Preserved catch-all email behavior when upgrading from releases with different configuration policies.

* **Tests**
  * Added coverage for deployment configuration selection and catch-all policy handling during staging lifecycle upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->