### PR TITLE
Fix previous-release staging manifest path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,10 +198,11 @@ jobs:
           mkdir -p "$previous_source"
           tar -xzf "$previous_archive" -C "$previous_source"
           pnpm --dir "$previous_source" install --frozen-lockfile
-          test ! -e "$previous_source/.hqbase"
-          ln -s "$GITHUB_WORKSPACE/.hqbase" "$previous_source/.hqbase"
+          previous_deployment="$previous_source/.hqbase/deployments/$DEPLOYMENT_NAME"
+          test ! -e "$previous_deployment"
+          ln -s "$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME" "$previous_deployment"
           previous_updater="$previous_source/scripts/release/deploy.mjs"
-          previous_config="$previous_source/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          previous_config="$previous_deployment/wrangler.jsonc"
           echo "HQBASE_PREVIOUS_UPDATER=$previous_updater" >> "$GITHUB_ENV"
           echo "HQBASE_PREVIOUS_CONFIG=$previous_config" >> "$GITHUB_ENV"
           if test -f "$previous_source/migrations/0025_activate_catch_all_policy.sql"; then

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -116,11 +116,12 @@ describe("staging workflow lifecycle record", () => {
 
   it("runs the previous updater against its own deployment root", () => {
     expect(releaseWorkflow).toContain(
-      'ln -s "$GITHUB_WORKSPACE/.hqbase" "$previous_source/.hqbase"'
+      'previous_deployment="$previous_source/.hqbase/deployments/$DEPLOYMENT_NAME"'
     );
     expect(releaseWorkflow).toContain(
-      'previous_config="$previous_source/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"'
+      'ln -s "$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME" "$previous_deployment"'
     );
+    expect(releaseWorkflow).toContain('previous_config="$previous_deployment/wrangler.jsonc"');
     expect(releaseWorkflow).toContain('node "$previous_updater" --config "$previous_config"');
     expect(releaseWorkflow).toContain(
       `config="\${HQBASE_PREVIOUS_CONFIG:-$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc}"`


### PR DESCRIPTION
## Summary\n\n- link only the unique disposable deployment directory into the extracted previous release\n- keep the tracked release archive structure intact\n- let the previous updater checkpoint the real staging manifest for safe cleanup\n\n## Verification\n\n- focused tests: 12 passed\n- pnpm check: 790 unit tests and 193 Worker integration tests passed\n- pnpm deploy:dry-run: passed with MAIL_EVENTS present\n- failed private release run cleaned its disposable resources and removed its draft

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging release handling by linking only the relevant previous deployment files.
  * Updated updater configuration resolution to use the correct deployment-specific location.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->