### PR TITLE
fix: restore management API asset routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.3.2
+
+### Fixed
+
+- Restore every release-managed Worker-first asset route when an older installation updates. The
+  connections page now receives JSON from the Management API instead of the app HTML shell.
+- Reject an invalid successful API response with a clear error, and verify the authenticated agent
+  list route during signed-release staging.
+
 ## 1.3.1
 
 ### Fixed

--- a/app/lib/api-client.ts
+++ b/app/lib/api-client.ts
@@ -19,6 +19,7 @@ export async function apiGetPage<T>(
       typeof data === "object" && data && "error" in data ? data.error.message : "Request failed.";
     throw new Error(message);
   }
+  if (data === null) throw new Error("The server returned an invalid response.");
   return { data: data as T, nextPageUrl: nextPageUrl(response.headers.get("link")) };
 }
 
@@ -169,6 +170,9 @@ async function apiRequest<T>(path: string, init: RequestInit): Promise<T> {
     const message =
       typeof data === "object" && data && "error" in data ? data.error.message : "Request failed.";
     throw new Error(message);
+  }
+  if (data === null && response.status !== 204) {
+    throw new Error("The server returned an invalid response.");
   }
 
   return data as T;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hqbase",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/scripts/release/manifest.mjs
+++ b/scripts/release/manifest.mjs
@@ -108,6 +108,7 @@ export function normalizeConfig(config, version, artifactSha256, releaseConfig =
     ],
     assets: {
       ...config.assets,
+      ...releaseConfig.assets,
       directory: "./dist"
     },
     observability: {

--- a/scripts/release/prepare-worker-config.mjs
+++ b/scripts/release/prepare-worker-config.mjs
@@ -4,6 +4,18 @@ import { resolve } from "node:path";
 
 const mailEventsBinding = { name: "MAIL_EVENTS", class_name: "MailEvents" };
 const mailEventsMigration = { tag: "mail-events-v1", new_sqlite_classes: ["MailEvents"] };
+const requiredWorkerFirstRoutes = [
+  "/api/*",
+  "/management/*",
+  "/mcp",
+  "/mcp/*",
+  "/.well-known/*",
+  "/skills/hqbase-mail/SKILL.md",
+  "/skills/hqbase-mailbox/SKILL.md",
+  "/skills/hqbase-provisioner/SKILL.md",
+  "/AGENTS.md",
+  "/agents.md"
+];
 
 export function prepareRequiredWorkerConfig(config) {
   assertObject(config, "Worker configuration");
@@ -33,9 +45,17 @@ export function prepareRequiredWorkerConfig(config) {
   if (conflictingMigration) {
     throw new Error("MailEvents is assigned to an unexpected Durable Object migration tag.");
   }
+  const workerFirstRoutes = array(config.assets?.run_worker_first);
 
   const prepared = {
     ...config,
+    assets: {
+      ...config.assets,
+      run_worker_first: [
+        ...workerFirstRoutes,
+        ...requiredWorkerFirstRoutes.filter((route) => !workerFirstRoutes.includes(route))
+      ]
+    },
     durable_objects: {
       ...config.durable_objects,
       bindings: currentBinding ? durableBindings : [...durableBindings, mailEventsBinding]
@@ -47,8 +67,13 @@ export function prepareRequiredWorkerConfig(config) {
 }
 
 export function assertRequiredWorkerConfig(config) {
+  const workerFirstRoutes = array(config.assets?.run_worker_first);
   const checks = [
     [config.assets?.binding === "ASSETS", "ASSETS Worker Assets binding"],
+    [
+      requiredWorkerFirstRoutes.every((route) => workerFirstRoutes.includes(route)),
+      "Worker-first asset routes"
+    ],
     [array(config.d1_databases).some((binding) => binding?.binding === "DB"), "DB D1 binding"],
     [
       array(config.r2_buckets).some((binding) => binding?.binding === "MAIL_OBJECTS"),

--- a/test/e2e/staging/lifecycle.spec.ts
+++ b/test/e2e/staging/lifecycle.spec.ts
@@ -277,6 +277,12 @@ test("a mailbox agent stays inside its assigned mailbox and revokes cleanly", as
   const mailbox = mailboxes.find((item) => item.address === sender);
   if (!mailbox) throw new Error(`Staging mailbox ${sender} was not found.`);
 
+  const agentsResponse = await request.get("/management/v1/agents");
+  const agentsBody = await agentsResponse.text();
+  expect(agentsResponse.status(), agentsBody).toBe(200);
+  expect(agentsResponse.headers()["content-type"]).toContain("application/json");
+  expect(JSON.parse(agentsBody)).toMatchObject({ agents: expect.any(Array) });
+
   const createdResponse = await request.post("/management/v1/agents", {
     data: {
       profile: "mailbox",

--- a/test/unit/app/agents/agent-api.test.ts
+++ b/test/unit/app/agents/agent-api.test.ts
@@ -37,6 +37,15 @@ describe("agent management API", () => {
     });
   });
 
+  it("rejects an app shell returned for the management API", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response("<!doctype html>", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(listAgents()).rejects.toThrow("The server returned an invalid response.");
+  });
+
   it("creates mailbox agents with an exact mailbox request", async () => {
     const result = { agent, credential: "hqb_agent_secret" };
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(Response.json(result));

--- a/test/unit/scripts/deploy.test.mjs
+++ b/test/unit/scripts/deploy.test.mjs
@@ -178,9 +178,15 @@ describe("HQBase release deployment", () => {
     });
     expect(normalized.d1_databases[0]).not.toHaveProperty("migrations_pattern");
   });
-  it("uses only the Durable Objects exported by the verified release", () => {
+  it("uses release-managed Worker configuration from the verified release", () => {
     const deploymentConfig = {
       name: "customer-worker",
+      assets: {
+        binding: "ASSETS",
+        directory: "../../../dist",
+        not_found_handling: "single-page-application",
+        run_worker_first: ["/api/*"]
+      },
       durable_objects: {
         bindings: [{ name: "CUSTOMER_EVENTS", class_name: "CustomerEvents" }]
       },
@@ -191,16 +197,23 @@ describe("HQBase release deployment", () => {
     expect(previous).not.toHaveProperty("migrations");
 
     const releaseConfig = {
+      assets: {
+        binding: "ASSETS",
+        directory: "./dist",
+        not_found_handling: "single-page-application",
+        run_worker_first: ["/api/*", "/management/*"]
+      },
       durable_objects: {
         bindings: [{ name: "MAIL_EVENTS", class_name: "MailEvents" }]
       },
       migrations: [{ tag: "mail-events-v1", new_sqlite_classes: ["MailEvents"] }]
     };
     const candidate = normalizeConfig(deploymentConfig, "1.3.0", "b".repeat(64), releaseConfig);
+    expect(candidate.assets).toEqual(releaseConfig.assets);
     expect(candidate.durable_objects).toEqual(releaseConfig.durable_objects);
     expect(candidate.migrations).toEqual(releaseConfig.migrations);
   });
-  it("repairs the required realtime configuration left out by an older updater", () => {
+  it("repairs required release configuration left out by an older updater", () => {
     const staleConfig = {
       assets: { binding: "ASSETS", directory: "./dist" },
       d1_databases: [{ binding: "DB", database_id: "database-id" }],
@@ -215,6 +228,7 @@ describe("HQBase release deployment", () => {
 
     const prepared = prepareRequiredWorkerConfig(staleConfig);
 
+    expect(prepared.assets.run_worker_first).toContain("/management/*");
     expect(prepared.durable_objects.bindings).toEqual([
       { name: "CUSTOMER_EVENTS", class_name: "CustomerEvents" },
       { name: "MAIL_EVENTS", class_name: "MailEvents" }


### PR DESCRIPTION
## Summary

- restore every release-managed Worker-first asset route during supported updates
- reject an HTML app shell as an invalid API response
- add unit and authenticated staging coverage for the connections route

## Verification

- [x] 791 unit tests
- [x] 193 Worker integration tests
- [x] coverage, type, architecture, build, and deployment dry-run gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored worker-first routing for API, management, MCP, discovery, skill, and agent paths during upgrades.
  * Connections and management agent listings now load from the correct API data instead of the app shell.
  * Invalid or empty successful API responses now produce clear errors.
  * Improved release validation to confirm authenticated agent-list access before staging.

* **Documentation**
  * Added the 1.3.2 changelog entry.

* **Release**
  * Updated the application version to 1.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->