### PR TITLE
fix: repair legacy managed installations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
     needs: candidate
     runs-on: ubuntu-latest
     environment: hqbase-staging
-    timeout-minutes: 35
+    timeout-minutes: 45
     permissions:
       contents: read
     env:
@@ -146,6 +146,7 @@ jobs:
       HQBASE_STAGING_OAUTH_CLIENT_ID: ${{ vars.HQBASE_E2E_OAUTH_CLIENT_ID }}
       HQBASE_STAGING_SENDER: hello@${{ secrets.HQBASE_E2E_EMAIL_DOMAIN }}
       HQBASE_STAGING_URL: https://${{ secrets.HQBASE_E2E_APP_HOSTNAME }}
+      OLDEST_UPDATER_TAG: v1.0.0
       DEPLOYMENT_NAME: release-${{ github.run_id }}
     steps:
       - uses: actions/checkout@v6
@@ -168,6 +169,12 @@ jobs:
           path: release
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps chromium
+      - name: Verify the customer source checkout starts unchanged
+        run: |
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git diff --quiet
+          git diff --cached --quiet
+          test -z "$(git ls-files --others --exclude-standard)"
       - name: Create disposable customer resources
         run: >-
           pnpm hqbase install
@@ -183,28 +190,37 @@ jobs:
           auth_secret="$(openssl rand -base64 48)"
           echo "::add-mask::$auth_secret"
           echo "HQBASE_STAGING_AUTH_SECRET=$auth_secret" >> "$GITHUB_ENV"
-      - name: Download and deploy the previous stable release
-        if: needs.candidate.outputs.previous_tag != ''
+      - name: Install the previous stable release with the oldest supported updater
         run: |
-          mkdir -p /tmp/hqbase-previous
+          test -n "$PREVIOUS_TAG"
+          oldest_version="${OLDEST_UPDATER_TAG#v}"
+          mkdir -p /tmp/hqbase-oldest-updater /tmp/hqbase-previous
+          gh release download "$OLDEST_UPDATER_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "hqbase-${oldest_version}.tar.gz" \
+            --dir /tmp/hqbase-oldest-updater
           gh release download "$PREVIOUS_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --pattern stable.json \
             --pattern 'hqbase-*.tar.gz' \
             --dir /tmp/hqbase-previous
+          oldest_source="/tmp/hqbase-oldest-updater/source"
+          mkdir -p "$oldest_source"
+          tar -xzf "/tmp/hqbase-oldest-updater/hqbase-${oldest_version}.tar.gz" \
+            -C "$oldest_source"
+          pnpm --dir "$oldest_source" install --frozen-lockfile
           previous_version="${PREVIOUS_TAG#v}"
           previous_archive="/tmp/hqbase-previous/hqbase-${previous_version}.tar.gz"
           previous_source="/tmp/hqbase-previous/source"
           mkdir -p "$previous_source"
           tar -xzf "$previous_archive" -C "$previous_source"
-          pnpm --dir "$previous_source" install --frozen-lockfile
-          previous_deployment="$previous_source/.hqbase/deployments/$DEPLOYMENT_NAME"
-          test ! -e "$previous_deployment"
-          ln -s "$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME" "$previous_deployment"
-          previous_updater="$previous_source/scripts/release/deploy.mjs"
-          previous_config="$previous_deployment/wrangler.jsonc"
-          echo "HQBASE_PREVIOUS_UPDATER=$previous_updater" >> "$GITHUB_ENV"
-          echo "HQBASE_PREVIOUS_CONFIG=$previous_config" >> "$GITHUB_ENV"
+          oldest_deployment="$oldest_source/.hqbase/deployments/$DEPLOYMENT_NAME"
+          test ! -e "$oldest_deployment"
+          ln -s "$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME" "$oldest_deployment"
+          oldest_updater="$oldest_source/scripts/release/deploy.mjs"
+          oldest_config="$oldest_deployment/wrangler.jsonc"
+          echo "HQBASE_OLDEST_UPDATER=$oldest_updater" >> "$GITHUB_ENV"
+          echo "HQBASE_OLDEST_CONFIG=$oldest_config" >> "$GITHUB_ENV"
           if test -f "$previous_source/migrations/0025_activate_catch_all_policy.sql"; then
             echo "HQBASE_STAGING_PREVIOUS_HAS_CATCH_ALL_POLICY=1" >> "$GITHUB_ENV"
           else
@@ -214,9 +230,8 @@ jobs:
           HQBASE_EXPECTED_RELEASE_VERSION="$previous_version" \
           HQBASE_RELEASE_ARTIFACT_FILE="$previous_archive" \
           HQBASE_RELEASE_MANIFEST_FILE="/tmp/hqbase-previous/stable.json" \
-            node "$previous_updater" --config "$previous_config"
+            node "$oldest_updater" --config "$oldest_config"
       - name: Wait for the previous stable release
-        if: needs.candidate.outputs.previous_tag != ''
         run: |
           for attempt in $(seq 1 150); do
             if curl --fail --silent --show-error \
@@ -230,25 +245,36 @@ jobs:
           echo "Previous stable HQBase was not healthy within 300 seconds"
           exit 1
       - name: Bootstrap persistent N-1 staging data
-        if: needs.candidate.outputs.previous_tag != ''
         env:
           HQBASE_STAGING_MAIL_API_BASE_PATH: /api
         run: pnpm test:e2e:staging:lifecycle
+      - name: Configure customer OAuth for the candidate
+        run: >-
+          pnpm hqbase oauth
+          --name "$DEPLOYMENT_NAME"
+          --mode customer
+          --auth-url "$HQBASE_STAGING_URL"
+          --client-id "$HQBASE_STAGING_OAUTH_CLIENT_ID"
+          --skip-deploy
+      - name: Reproduce the legacy Worker configuration
+        run: |
+          config="$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          CONFIG_FILE="$config" node --input-type=module -e '
+            import { readFileSync, writeFileSync } from "node:fs";
+            const file = process.env.CONFIG_FILE;
+            const config = JSON.parse(readFileSync(file, "utf8"));
+            delete config.durable_objects;
+            delete config.migrations;
+            writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`);
+          '
+          jq -e 'has("durable_objects") == false and has("migrations") == false' "$config"
       - name: Apply the exact signed candidate
         run: |
-          pnpm hqbase oauth \
-            --name "$DEPLOYMENT_NAME" \
-            --mode customer \
-            --auth-url "$HQBASE_STAGING_URL" \
-            --client-id "$HQBASE_STAGING_OAUTH_CLIENT_ID" \
-            --skip-deploy
-          config="${HQBASE_PREVIOUS_CONFIG:-$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc}"
-          updater="${HQBASE_PREVIOUS_UPDATER:-$GITHUB_WORKSPACE/scripts/release/deploy.mjs}"
           HQBASE_AUTH_SECRET="$HQBASE_STAGING_AUTH_SECRET" \
           HQBASE_EXPECTED_RELEASE_VERSION="$CANDIDATE_VERSION" \
           HQBASE_RELEASE_ARTIFACT_FILE="$GITHUB_WORKSPACE/release/hqbase-${CANDIDATE_VERSION}.tar.gz" \
           HQBASE_RELEASE_MANIFEST_FILE="$GITHUB_WORKSPACE/release/stable.json" \
-            node "$updater" --config "$config"
+            node "$HQBASE_OLDEST_UPDATER" --config "$HQBASE_OLDEST_CONFIG"
       - name: Wait for the signed candidate
         run: |
           for attempt in $(seq 1 150); do
@@ -265,14 +291,98 @@ jobs:
           done
           echo "Signed HQBase candidate was not active within 300 seconds"
           exit 1
-      - name: Verify the installed candidate release marker
+      - name: Verify the candidate restored the binding while the database remained at S0
         run: |
           config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
           database="hqbase-$DEPLOYMENT_NAME"
+          status="$(pnpm exec wrangler deployments status \
+            --name hqbase-e2e-staging --json --config "$config")"
+          version_id="$(jq -er '.versions[] | select(.percentage == 100) | .version_id' \
+            <<<"$status")"
+          worker="$(pnpm exec wrangler versions view "$version_id" \
+            --name hqbase-e2e-staging --json --config "$config")"
+          jq -e '[.resources.bindings[].name] | index("MAIL_EVENTS") != null' <<<"$worker"
+          expected_normal_count="$(find migrations -maxdepth 1 -type f -name '*.sql' | wc -l | tr -d ' ')"
+          expected_schema_version="$(node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+            const envelope = JSON.parse(readFileSync("release/stable.json", "utf8"));
+            const manifest = JSON.parse(Buffer.from(envelope.payload, "base64url").toString("utf8"));
+            process.stdout.write(String(manifest.schemaVersion));
+          ')"
           result="$(pnpm exec wrangler d1 execute "$database" --remote --config "$config" --json \
-            --command "SELECT installed_version FROM release_state WHERE singleton = 1")"
-          jq -e --arg version "$CANDIDATE_VERSION" \
-            '.[0].results[0].installed_version == $version' <<<"$result"
+            --command "SELECT (SELECT installed_version FROM release_state WHERE singleton = 1) AS installed_version, (SELECT installed_schema_version FROM release_state WHERE singleton = 1) AS installed_schema_version, (SELECT COUNT(*) FROM d1_migrations) AS normal_migration_count, (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'd1_migrations_after_deploy') AS after_deploy_ledger_table_count, (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('mailbox_addresses', 'mailbox_address_migration')) AS alias_table_count, (SELECT COUNT(*) FROM pragma_table_info('messages') WHERE name IN ('delivered_to_address_id', 'sent_from_address_id')) AS message_legacy_column_count, (SELECT COUNT(*) FROM pragma_table_info('mailbox_grants') WHERE name IN ('user_id', 'created_by')) AS grant_legacy_column_count, (SELECT COUNT(*) FROM pragma_table_info('drafts') WHERE name = 'user_id') AS draft_legacy_column_count, (SELECT COUNT(*) FROM pragma_table_info('draft_changes') WHERE name = 'user_id') AS draft_change_legacy_column_count, (SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name IN ('mailbox_addresses_transition_insert_guard', 'mailbox_addresses_transition_update_guard', 'mailbox_addresses_transition_delete_guard', 'mailboxes_transition_update_guard', 'mailboxes_transition_delete_guard', 'mailbox_grants_transition_insert_guard', 'mailbox_grants_transition_update_guard', 'mailbox_grants_transition_delete_guard', 'retention_policies_transition_insert_guard', 'retention_policies_transition_update_guard', 'retention_policies_transition_delete_guard')) AS transition_guard_count")"
+          jq -e \
+            --arg version "$CANDIDATE_VERSION" \
+            --argjson normal_count "$expected_normal_count" \
+            --argjson schema_version "$expected_schema_version" \
+            '.[0].results[0] == {installed_version:$version,installed_schema_version:$schema_version,normal_migration_count:$normal_count,after_deploy_ledger_table_count:0,alias_table_count:2,message_legacy_column_count:2,grant_legacy_column_count:2,draft_legacy_column_count:1,draft_change_legacy_column_count:1,transition_guard_count:11}' \
+            <<<"$result"
+          pnpm exec wrangler d1 execute "$database" --remote --config "$config" \
+            --command "INSERT INTO app_settings (key, value_json, created_at, updated_at) VALUES ('release-updater-bridge-probe', '{\"state\":\"preserved\"}', datetime('now'), datetime('now'))"
+          snapshot="$(pnpm exec wrangler d1 execute "$database" --remote --config "$config" --json \
+            --command "SELECT (SELECT COUNT(*) FROM \"user\") AS user_count, (SELECT COUNT(*) FROM mailboxes) AS mailbox_count, (SELECT value_json FROM app_settings WHERE key = 'release-updater-bridge-probe') AS probe")"
+          jq -c '.[0].results[0]' <<<"$snapshot" > /tmp/hqbase-pre-repair-data.json
+          pnpm test:e2e:staging:event-socket
+      - name: Finish the candidate through its canonical signed bootstrap
+        run: |
+          config="$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          HQBASE_AUTH_SECRET="$HQBASE_STAGING_AUTH_SECRET" \
+          HQBASE_EXPECTED_RELEASE_VERSION="$CANDIDATE_VERSION" \
+          HQBASE_RELEASE_ARTIFACT_FILE="$GITHUB_WORKSPACE/release/hqbase-${CANDIDATE_VERSION}.tar.gz" \
+          HQBASE_RELEASE_MANIFEST_FILE="$GITHUB_WORKSPACE/release/stable.json" \
+            node "$GITHUB_WORKSPACE/scripts/release/bootstrap.mjs" --config "$config"
+      - name: Verify exact migration ledgers, final schema, and preserved data
+        run: |
+          config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          database="hqbase-$DEPLOYMENT_NAME"
+          expected_schema_version="$(node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+            const envelope = JSON.parse(readFileSync("release/stable.json", "utf8"));
+            const manifest = JSON.parse(Buffer.from(envelope.payload, "base64url").toString("utf8"));
+            process.stdout.write(String(manifest.schemaVersion));
+          ')"
+          expected_normal="$(node --input-type=module -e '
+            import { readdirSync } from "node:fs";
+            process.stdout.write(JSON.stringify(readdirSync("migrations").filter((name) => name.endsWith(".sql")).sort()));
+          ')"
+          expected_after_deploy="$(node --input-type=module -e '
+            import { readdirSync } from "node:fs";
+            process.stdout.write(JSON.stringify(readdirSync("migrations-after-deploy").filter((name) => name.endsWith(".sql")).sort()));
+          ')"
+          normal="$(pnpm exec wrangler d1 execute "$database" --remote --config "$config" --json \
+            --command "SELECT name FROM d1_migrations ORDER BY id")"
+          after_deploy="$(pnpm exec wrangler d1 execute "$database" --remote --config "$config" --json \
+            --command "SELECT name FROM d1_migrations_after_deploy ORDER BY id")"
+          test "$(jq -c '[.[0].results[].name]' <<<"$normal")" = "$expected_normal"
+          test "$(jq -c '[.[0].results[].name]' <<<"$after_deploy")" = "$expected_after_deploy"
+          result="$(pnpm exec wrangler d1 execute "$database" --remote --config "$config" --json \
+            --command "SELECT (SELECT installed_version FROM release_state WHERE singleton = 1) AS installed_version, (SELECT installed_schema_version FROM release_state WHERE singleton = 1) AS installed_schema_version, (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('mailbox_addresses', 'mailbox_address_migration')) AS alias_table_count, (SELECT COUNT(*) FROM pragma_table_info('messages') WHERE name IN ('delivered_to_address_id', 'sent_from_address_id')) AS message_legacy_column_count, (SELECT COUNT(*) FROM pragma_table_info('mailbox_grants') WHERE name IN ('user_id', 'created_by')) AS grant_legacy_column_count, (SELECT COUNT(*) FROM pragma_table_info('drafts') WHERE name = 'user_id') AS draft_legacy_column_count, (SELECT COUNT(*) FROM pragma_table_info('draft_changes') WHERE name = 'user_id') AS draft_change_legacy_column_count, (SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name LIKE '%_transition_%') AS transition_guard_count, (SELECT COUNT(*) FROM pragma_foreign_key_list('draft_labels') WHERE \"table\" = 'drafts' AND \"from\" = 'draft_id') AS draft_label_fk_count, (SELECT COUNT(*) FROM update_history WHERE from_version = '${CANDIDATE_VERSION}' AND to_version = '${CANDIDATE_VERSION}' AND checkpoint_bookmark IS NOT NULL AND worker_version IS NOT NULL AND state = 'verified') AS repair_history_count")"
+          jq -e \
+            --arg version "$CANDIDATE_VERSION" \
+            --argjson schema_version "$expected_schema_version" \
+            '.[0].results[0] == {installed_version:$version,installed_schema_version:$schema_version,alias_table_count:0,message_legacy_column_count:0,grant_legacy_column_count:0,draft_legacy_column_count:0,draft_change_legacy_column_count:0,transition_guard_count:0,draft_label_fk_count:1,repair_history_count:1}' \
+            <<<"$result"
+          foreign_keys="$(pnpm exec wrangler d1 execute "$database" --remote --config "$config" --json \
+            --command "PRAGMA foreign_key_check")"
+          jq -e '.[0].results == []' <<<"$foreign_keys"
+          snapshot="$(pnpm exec wrangler d1 execute "$database" --remote --config "$config" --json \
+            --command "SELECT (SELECT COUNT(*) FROM \"user\") AS user_count, (SELECT COUNT(*) FROM mailboxes) AS mailbox_count, (SELECT value_json FROM app_settings WHERE key = 'release-updater-bridge-probe') AS probe")"
+          jq -e '.[0].results[0].probe == "{\"state\":\"preserved\"}"' <<<"$snapshot"
+          test "$(jq -c '.[0].results[0]' <<<"$snapshot")" = "$(< /tmp/hqbase-pre-repair-data.json)"
+      - name: Prove the canonical same-version retry is idempotent
+        run: |
+          config="$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          database="hqbase-$DEPLOYMENT_NAME"
+          before="$(pnpm exec wrangler d1 execute "$database" --remote --config "$config" --json \
+            --command "SELECT (SELECT COUNT(*) FROM d1_migrations) AS normal_migration_count, (SELECT COUNT(*) FROM d1_migrations_after_deploy) AS after_deploy_migration_count, (SELECT COUNT(*) FROM update_history) AS update_history_count, (SELECT COUNT(*) FROM \"user\") AS user_count, (SELECT COUNT(*) FROM mailboxes) AS mailbox_count, (SELECT value_json FROM app_settings WHERE key = 'release-updater-bridge-probe') AS probe")"
+          HQBASE_AUTH_SECRET="$HQBASE_STAGING_AUTH_SECRET" \
+          HQBASE_EXPECTED_RELEASE_VERSION="$CANDIDATE_VERSION" \
+          HQBASE_RELEASE_ARTIFACT_FILE="$GITHUB_WORKSPACE/release/hqbase-${CANDIDATE_VERSION}.tar.gz" \
+          HQBASE_RELEASE_MANIFEST_FILE="$GITHUB_WORKSPACE/release/stable.json" \
+            node "$GITHUB_WORKSPACE/scripts/release/bootstrap.mjs" --config "$config"
+          after="$(pnpm exec wrangler d1 execute "$database" --remote --config "$config" --json \
+            --command "SELECT (SELECT COUNT(*) FROM d1_migrations) AS normal_migration_count, (SELECT COUNT(*) FROM d1_migrations_after_deploy) AS after_deploy_migration_count, (SELECT COUNT(*) FROM update_history) AS update_history_count, (SELECT COUNT(*) FROM \"user\") AS user_count, (SELECT COUNT(*) FROM mailboxes) AS mailbox_count, (SELECT value_json FROM app_settings WHERE key = 'release-updater-bridge-probe') AS probe")"
+          test "$(jq -c '.[0].results[0]' <<<"$after")" = "$(jq -c '.[0].results[0]' <<<"$before")"
       - name: Verify active Worker bindings
         run: |
           config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
@@ -302,6 +412,12 @@ jobs:
           result="$(pnpm exec wrangler d1 execute "$database" --remote --config "$config" --json \
             --command "SELECT value_json FROM app_settings WHERE key = 'staging-restore-probe'")"
           jq -e '.[0].results[0].value_json == "{\"state\":\"before\"}"' <<<"$result"
+      - name: Verify the customer source checkout stayed unchanged
+        run: |
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git diff --quiet
+          git diff --cached --quiet
+          test -z "$(git ls-files --others --exclude-standard)"
       - name: Upload non-secret deployment record
         if: always()
         uses: actions/upload-artifact@v6
@@ -394,10 +510,13 @@ jobs:
       - name: Verify public stable asset, signature, and digest
         run: |
           stable_url="https://github.com/HQBase/hqbase/releases/latest/download/stable.json"
+          version_manifest_url="https://github.com/HQBase/hqbase/releases/download/v${HQBASE_RELEASE_VERSION}/manifest-${HQBASE_RELEASE_VERSION}.json"
           artifact_url="https://github.com/HQBase/hqbase/releases/download/v${HQBASE_RELEASE_VERSION}/hqbase-${HQBASE_RELEASE_VERSION}.tar.gz"
           for attempt in $(seq 1 30); do
             if curl --fail --location --silent --show-error "$stable_url" --output /tmp/stable.json &&
-               curl --fail --location --silent --show-error "$artifact_url" --output /tmp/hqbase.tar.gz; then
+               curl --fail --location --silent --show-error "$version_manifest_url" --output /tmp/version-manifest.json &&
+               curl --fail --location --silent --show-error "$artifact_url" --output /tmp/hqbase.tar.gz &&
+               cmp -s /tmp/stable.json /tmp/version-manifest.json; then
               break
             fi
             test "$attempt" -lt 30
@@ -424,6 +543,11 @@ jobs:
             const version = process.env.HQBASE_RELEASE_VERSION;
             const config = JSON.parse(readFileSync("config/product.json", "utf8"));
             const envelope = JSON.parse(readFileSync("/tmp/stable.json", "utf8"));
+            const versionEnvelope = JSON.parse(readFileSync("/tmp/version-manifest.json", "utf8"));
+            if (versionEnvelope.payload !== envelope.payload ||
+                versionEnvelope.signature !== envelope.signature) {
+              throw new Error("Published stable and versioned manifests do not match.");
+            }
             const key = createPublicKey({
               key: Buffer.from(config.releasePublicKey, "base64"),
               format: "der",
@@ -436,10 +560,26 @@ jobs:
             if (manifest.product !== "hqbase" || manifest.version !== version) {
               throw new Error("Published stable manifest identity is invalid.");
             }
+            const expectedArtifactUrl = `https://github.com/HQBase/hqbase/releases/download/v${version}/hqbase-${version}.tar.gz`;
+            const expectedUpdaterUrl = `https://raw.githubusercontent.com/HQBase/hqbase/${process.env.RELEASE_COMMIT}/scripts/release/bootstrap.mjs`;
+            if (manifest.artifact.url !== expectedArtifactUrl ||
+                manifest.updater?.protocol !== 2 ||
+                manifest.updater.sourceUrl !== expectedUpdaterUrl) {
+              throw new Error("Published stable manifest sources are invalid.");
+            }
             const bytes = readFileSync("/tmp/hqbase.tar.gz");
             if (createHash("sha256").update(bytes).digest("hex") !== manifest.artifact.sha256 ||
                 statSync("/tmp/hqbase.tar.gz").size !== manifest.artifact.size) {
               throw new Error("Published artifact does not match the signed manifest.");
+            }
+            const updaterResponse = await fetch(manifest.updater.sourceUrl);
+            if (!updaterResponse.ok) {
+              throw new Error(`Published updater download failed (${updaterResponse.status}).`);
+            }
+            const updaterBytes = Buffer.from(await updaterResponse.arrayBuffer());
+            if (createHash("sha256").update(updaterBytes).digest("hex") !== manifest.updater.sha256 ||
+                updaterBytes.length !== manifest.updater.size) {
+              throw new Error("Published updater does not match the signed manifest.");
             }
           '
       - name: Post complete release notes to Discord

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,7 @@ jobs:
       HQBASE_STAGING_OAUTH_CLIENT_ID: ${{ vars.HQBASE_E2E_OAUTH_CLIENT_ID }}
       HQBASE_STAGING_SENDER: hello@${{ secrets.HQBASE_E2E_EMAIL_DOMAIN }}
       HQBASE_STAGING_URL: https://${{ secrets.HQBASE_E2E_APP_HOSTNAME }}
+      # This frozen bootstrap is independent of the active-release compatibility floor.
       OLDEST_UPDATER_TAG: v1.0.0
       DEPLOYMENT_NAME: release-${{ github.run_id }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.3.3
+
+### Fixed
+
+- Repair installations that reached HQBase 1.3 without completing the signed post-deploy database
+  phase. This fixes connection loading errors while preserving mail, drafts, labels, grants, and
+  other workspace data behind a new D1 recovery checkpoint.
+- Replace the frozen customer-repository update command with a signed canonical updater after owner
+  approval. Managed updates no longer depend on patching or synchronizing each customer source
+  repository.
+- Test releases through the oldest supported updater, then verify both migration ledgers, the final
+  schema, preserved data, required Worker bindings, and an idempotent same-version retry before
+  publication.
+
 ## 1.3.2
 
 ### Fixed

--- a/app/features/settings/settings-page.tsx
+++ b/app/features/settings/settings-page.tsx
@@ -11,7 +11,7 @@ import { InterfaceSettings } from "@/features/settings/interface-settings";
 import type { SetupStatus } from "@/features/setup/types";
 import { SignatureSettings } from "@/features/signatures/signature-settings";
 import type { UpdateStatus } from "@/features/updates/types";
-import type { UpdateProgress } from "@/features/updates/update-progress";
+import type { UpdateActionKind, UpdateProgress } from "@/features/updates/update-progress";
 import { UpdateSettings } from "@/features/updates/update-settings";
 import type { WorkspaceUser } from "@/features/users/types";
 import { UserSettings } from "@/features/users/user-settings";
@@ -31,7 +31,7 @@ type SettingsPageProps = {
   onDefaultFromMailboxChange: (mailboxId: string) => void;
   onRefresh: () => Promise<void>;
   onLabelsChanged?: () => Promise<void>;
-  onUpdateStarted: (buildId: string) => void;
+  onUpdateStarted: (buildId: string, kind: UpdateActionKind) => void;
   onUpdateStatusChange: (status: UpdateStatus) => void;
   updateProgress: UpdateProgress | null;
   updateStatus: UpdateStatus | null;

--- a/app/features/updates/types.ts
+++ b/app/features/updates/types.ts
@@ -6,6 +6,7 @@ export type UpdateStatus = {
   checkedAt: string;
   available: boolean;
   compatible: boolean;
+  repairRequired: boolean;
   release: {
     version: string;
     schemaVersion: number;

--- a/app/features/updates/update-banner.tsx
+++ b/app/features/updates/update-banner.tsx
@@ -15,9 +15,20 @@ export function UpdateBanner({
   status: UpdateStatus | null;
   onOpen: () => void;
 }): React.ReactElement | null {
-  if (ready || (!inProgress && !status?.available)) return null;
+  const repairOnly =
+    status?.repairRequired === true && status.release.version === status.installedVersion;
+  if ((ready && !repairOnly) || (!inProgress && !status?.available)) return null;
   const targetVersion = status?.release.version;
-  const firstNote = status?.release.notes[0];
+  const firstNote = repairOnly
+    ? "Complete the signed database migration phase omitted by the older build bootstrap."
+    : status?.release.notes[0];
+  const title = inProgress
+    ? repairOnly
+      ? "Installation repair in progress"
+      : "Update in progress"
+    : repairOnly
+      ? "Installation repair available"
+      : "Update available";
   return (
     <div
       aria-live="polite"
@@ -36,7 +47,7 @@ export function UpdateBanner({
         )}
         <div className="min-w-0">
           <p>
-            <strong>{inProgress ? "Update in progress" : "Update available"}</strong>
+            <strong>{title}</strong>
             {targetVersion ? ` · HQBase ${targetVersion}` : null}
           </p>
           {!inProgress && firstNote ? (
@@ -45,7 +56,7 @@ export function UpdateBanner({
         </div>
       </div>
       <Button className="h-7 px-3 text-xs" onClick={onOpen} type="button" variant="outline">
-        {inProgress ? "View progress" : "View changelog"}
+        {inProgress ? "View progress" : repairOnly ? "View repair" : "View changelog"}
       </Button>
     </div>
   );

--- a/app/features/updates/update-progress.ts
+++ b/app/features/updates/update-progress.ts
@@ -5,11 +5,18 @@ const progressLifetimeMs = 30 * 60 * 1000;
 
 export type UpdateProgress = {
   buildId: string;
+  kind: UpdateActionKind;
   startedAt: number;
 };
 
-export function beginUpdateProgress(buildId: string, now = Date.now()): UpdateProgress {
-  const progress = { buildId, startedAt: now };
+export type UpdateActionKind = "repair" | "update";
+
+export function beginUpdateProgress(
+  buildId: string,
+  kind: UpdateActionKind,
+  now = Date.now()
+): UpdateProgress {
+  const progress = { buildId, kind, startedAt: now };
   storage()?.setItem(storageKey, JSON.stringify(progress));
   if (typeof window !== "undefined") {
     window.dispatchEvent(
@@ -35,7 +42,15 @@ export function readUpdateProgress(now = Date.now()): UpdateProgress | null {
       sessionStorage?.removeItem(storageKey);
       return null;
     }
-    return { buildId: progress.buildId, startedAt: progress.startedAt };
+    if (progress.kind !== undefined && progress.kind !== "repair" && progress.kind !== "update") {
+      sessionStorage?.removeItem(storageKey);
+      return null;
+    }
+    return {
+      buildId: progress.buildId,
+      kind: progress.kind === "repair" ? "repair" : "update",
+      startedAt: progress.startedAt
+    };
   } catch {
     sessionStorage?.removeItem(storageKey);
     return null;

--- a/app/features/updates/update-settings.tsx
+++ b/app/features/updates/update-settings.tsx
@@ -7,8 +7,9 @@ import { CloudflareAuthorizationDialog } from "@/features/settings/cloudflare-au
 import { SettingsSection } from "@/features/settings/settings-section";
 import { applyUpdate, getUpdateStatus } from "./api";
 import type { UpdateStatus } from "./types";
-import type { UpdateProgress } from "./update-progress";
+import type { UpdateActionKind, UpdateProgress } from "./update-progress";
 
+const reviewedActionKindKey = "hqb_update_action_kind";
 const reviewedVersionKey = "hqb_update_expected_version";
 
 export function UpdateSettings({
@@ -20,7 +21,7 @@ export function UpdateSettings({
   initialStatus: UpdateStatus | null;
   progress: UpdateProgress | null;
   onStatusChange: (status: UpdateStatus) => void;
-  onUpdateStarted: (buildId: string) => void;
+  onUpdateStarted: (buildId: string, kind: UpdateActionKind) => void;
 }): React.ReactElement {
   const [status, setStatus] = React.useState(initialStatus);
   const [checkError, setCheckError] = React.useState<string | null>(null);
@@ -51,7 +52,9 @@ export function UpdateSettings({
     window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
 
     const expectedVersion = window.sessionStorage.getItem(reviewedVersionKey);
+    const reviewedActionKind = window.sessionStorage.getItem(reviewedActionKindKey);
     window.sessionStorage.removeItem(reviewedVersionKey);
+    window.sessionStorage.removeItem(reviewedActionKindKey);
 
     if (oauthResult !== "connected") {
       setApplyError(oauthErrorMessage(oauthResult));
@@ -62,9 +65,10 @@ export function UpdateSettings({
       return;
     }
 
+    const actionKind: UpdateActionKind = reviewedActionKind === "repair" ? "repair" : "update";
     setPendingAction("apply");
     void applyUpdate(expectedVersion)
-      .then((result) => onUpdateStarted(result.buildId))
+      .then((result) => onUpdateStarted(result.buildId, actionKind))
       .catch((nextError: unknown) => {
         setApplyError(nextError instanceof Error ? nextError.message : "Update could not start.");
       })
@@ -85,6 +89,9 @@ export function UpdateSettings({
     }
   }
   const isPending = pendingAction !== null;
+  const repairOnly =
+    status?.repairRequired === true && status.release.version === status.installedVersion;
+  const repairInProgress = progress?.kind === "repair";
 
   return (
     <SettingsSection description="Signed stable releases" title="Updates">
@@ -111,11 +118,17 @@ export function UpdateSettings({
               <Spinner aria-hidden="true" className="size-4 text-foreground" role="presentation" />
             </div>
             <div className="min-w-0">
-              <h3 className="text-sm font-medium">Update in progress</h3>
+              <h3 className="text-sm font-medium">
+                {repairInProgress ? "Installation repair in progress" : "Update in progress"}
+              </h3>
               <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                {status?.release.version
-                  ? `HQBase ${status.release.version} is being deployed. `
-                  : "The new version is being deployed. "}
+                {repairInProgress
+                  ? status?.release.version
+                    ? `HQBase ${status.release.version} is completing its signed installation. `
+                    : "HQBase is completing its signed installation. "
+                  : status?.release.version
+                    ? `HQBase ${status.release.version} is being deployed. `
+                    : "The new version is being deployed. "}
                 You can keep working while Cloudflare finishes the build.
               </p>
               <div className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
@@ -138,7 +151,10 @@ export function UpdateSettings({
             aria-hidden="true"
             className="pointer-events-none size-3.5 text-muted-foreground/70"
           />
-          <Version label="Available" value={status?.release.version ?? "Not checked"} />
+          <Version
+            label={repairOnly ? "Installation" : "Available"}
+            value={repairOnly ? "Repair required" : (status?.release.version ?? "Not checked")}
+          />
         </div>
         <Button
           className="self-start sm:self-auto"
@@ -163,41 +179,57 @@ export function UpdateSettings({
       </div>
       {status?.available && !progress ? (
         <div className="flex flex-col gap-4 pt-1">
-          <div className="rounded-xl border border-border/80 bg-muted/25 p-4">
-            <h3 className="text-sm font-medium">What’s changing</h3>
-            {status.release.notes.length > 0 ? (
-              <ul className="mt-2 space-y-2 pl-4 text-xs leading-5 text-muted-foreground">
-                {status.release.notes.map((note) => (
-                  <li className="list-disc pl-1" key={note}>
-                    {note}
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="mt-2 text-xs leading-5 text-muted-foreground">
-                This older release record does not include an embedded changelog.
-              </p>
-            )}
-            <a
-              className="mt-3 inline-flex text-xs font-medium text-foreground underline-offset-4 hover:underline"
-              href={status.release.notesUrl}
-              rel="noreferrer"
-              target="_blank"
-            >
-              Read complete release notes
-            </a>
-          </div>
+          {repairOnly ? (
+            <Alert>
+              <AlertTitle>Finish installation repair</AlertTitle>
+              <AlertDescription>
+                This installation runs HQBase {status.release.version}, but its older build
+                bootstrap did not finish the signed database migration phase. HQBase will replace
+                that bootstrap and complete the same release from a fresh recovery checkpoint. It
+                will not change your source repository.
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <div className="rounded-xl border border-border/80 bg-muted/25 p-4">
+              <h3 className="text-sm font-medium">What’s changing</h3>
+              {status.release.notes.length > 0 ? (
+                <ul className="mt-2 space-y-2 pl-4 text-xs leading-5 text-muted-foreground">
+                  {status.release.notes.map((note) => (
+                    <li className="list-disc pl-1" key={note}>
+                      {note}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                  This older release record does not include an embedded changelog.
+                </p>
+              )}
+              <a
+                className="mt-3 inline-flex text-xs font-medium text-foreground underline-offset-4 hover:underline"
+                href={status.release.notesUrl}
+                rel="noreferrer"
+                target="_blank"
+              >
+                Read complete release notes
+              </a>
+            </div>
+          )}
           <div>
-            <h3 className="text-sm font-medium">Apply update</h3>
+            <h3 className="text-sm font-medium">
+              {repairOnly ? "Complete repair" : "Apply update"}
+            </h3>
             <p className="mt-1 max-w-2xl text-xs leading-5 text-muted-foreground">
-              HQBase verifies the artifact, records the Worker version and D1 bookmark, migrates,
-              deploys, and verifies before reporting success.
+              HQBase verifies the signed artifact, records the Worker version and a new D1 bookmark,
+              completes the migrations, and verifies the result before reporting success.
             </p>
           </div>
           <div className="flex flex-col gap-4">
             {!status.compatible ? (
               <Alert variant="destructive">
-                <AlertTitle>Direct update unavailable</AlertTitle>
+                <AlertTitle>
+                  {repairOnly ? "Repair unavailable" : "Direct update unavailable"}
+                </AlertTitle>
                 <AlertDescription>
                   This release cannot update directly from the installed version.
                 </AlertDescription>
@@ -209,7 +241,7 @@ export function UpdateSettings({
               </Button>
             ) : !status.compatible ? (
               <Button className="self-start" disabled type="button">
-                Install update
+                {repairOnly ? "Finish repair" : "Install update"}
               </Button>
             ) : (
               <Button
@@ -217,7 +249,7 @@ export function UpdateSettings({
                 onClick={() => setAuthorizationOpen(true)}
                 type="button"
               >
-                Install update
+                {repairOnly ? "Finish repair" : "Install update"}
               </Button>
             )}
           </div>
@@ -225,11 +257,16 @@ export function UpdateSettings({
       ) : null}
       <CloudflareAuthorizationDialog
         authorizeHref="/api/updates/cloudflare/oauth/start"
-        description="To install this update, HQBase needs temporary access to your Cloudflare account. You’ll return to Updates automatically, and HQBase will start the update."
+        description={
+          repairOnly
+            ? "To finish this installation repair, HQBase needs temporary access to your Cloudflare account. You’ll return to Updates automatically, and HQBase will start the signed repair."
+            : "To install this update, HQBase needs temporary access to your Cloudflare account. You’ll return to Updates automatically, and HQBase will start the update."
+        }
         open={authorizationOpen}
         onAuthorize={() => {
           if (status?.release.version) {
             window.sessionStorage.setItem(reviewedVersionKey, status.release.version);
+            window.sessionStorage.setItem(reviewedActionKindKey, repairOnly ? "repair" : "update");
           }
         }}
         onOpenChange={setAuthorizationOpen}

--- a/app/features/updates/use-update-monitor.ts
+++ b/app/features/updates/use-update-monitor.ts
@@ -6,6 +6,7 @@ import {
   beginUpdateProgress,
   clearUpdateProgress,
   readUpdateProgress,
+  type UpdateActionKind,
   type UpdateProgress
 } from "./update-progress";
 
@@ -16,17 +17,23 @@ export function useUpdateMonitor(canManage: boolean): {
   acceptStatus: (status: UpdateStatus) => void;
   progress: UpdateProgress | null;
   ready: boolean;
-  start: (buildId: string) => void;
+  start: (buildId: string, kind: UpdateActionKind) => void;
   status: UpdateStatus | null;
 } {
   const [status, setStatus] = React.useState<UpdateStatus | null>(null);
   const [progress, setProgress] = React.useState<UpdateProgress | null>(() => readUpdateProgress());
+  const progressRef = React.useRef(progress);
   const [ready, setReady] = React.useState(readPwaUpdateReady);
 
   const acceptStatus = React.useCallback((nextStatus: UpdateStatus) => {
     setStatus(nextStatus);
-    if (!nextStatus.available) {
+    const updateReachedRepair =
+      progressRef.current?.kind === "update" &&
+      nextStatus.repairRequired === true &&
+      nextStatus.release.version === nextStatus.installedVersion;
+    if (!nextStatus.available || updateReachedRepair) {
       clearUpdateProgress();
+      progressRef.current = null;
       setProgress(null);
     }
   }, []);
@@ -77,8 +84,10 @@ export function useUpdateMonitor(canManage: boolean): {
     };
   }, [acceptStatus, canManage, progress]);
 
-  const start = React.useCallback((buildId: string) => {
-    setProgress(beginUpdateProgress(buildId));
+  const start = React.useCallback((buildId: string, kind: UpdateActionKind) => {
+    const nextProgress = beginUpdateProgress(buildId, kind);
+    progressRef.current = nextProgress;
+    setProgress(nextProgress);
   }, []);
 
   return { acceptStatus, progress, ready, start, status };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hqbase",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",
@@ -31,7 +31,8 @@
     "api:generate": "node scripts/generate-mail-api-artifacts.mjs --write && biome format --write api/hqbase-mail-api-v1.openapi.json api/hqbase-mail-api-v1.postman_collection.json api/hqbase-mail-api-v1.postman_environment.json api/hqbase-mail-api-v2.openapi.json api/hqbase-mail-api-v2.postman_collection.json api/hqbase-mail-api-v2.postman_environment.json",
     "api:check": "node scripts/generate-mail-api-artifacts.mjs --check",
     "test:pwa": "node scripts/test-pwa.mjs",
-    "test:e2e:staging": "playwright test --config playwright.config.ts app-shell-smoke.spec.ts lifecycle.spec.ts",
+    "test:e2e:staging": "playwright test --config playwright.config.ts app-shell-smoke.spec.ts event-socket.spec.ts lifecycle.spec.ts",
+    "test:e2e:staging:event-socket": "playwright test --config playwright.config.ts event-socket.spec.ts",
     "test:e2e:staging:smoke": "playwright test --config playwright.config.ts app-shell-smoke.spec.ts",
     "test:e2e:staging:lifecycle": "playwright test --config playwright.config.ts lifecycle.spec.ts",
     "pwa:icons": "node scripts/generate-pwa-icons.mjs",

--- a/scripts/release/after-deploy-state.mjs
+++ b/scripts/release/after-deploy-state.mjs
@@ -1,0 +1,348 @@
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { capture } from "./command.mjs";
+
+const afterDeployMigrations = [
+  "0001_remove_mailbox_alias_storage.sql",
+  "0002_finalize_agent_principals.sql",
+  "0003_finalize_draft_labels.sql"
+];
+
+const addressTransitionTables = ["mailbox_addresses", "mailbox_address_migration"];
+const addressTransitionColumns = [
+  "messages.delivered_to_address_id",
+  "messages.sent_from_address_id"
+];
+const addressTransitionTriggers = [
+  "mailbox_addresses_transition_insert_guard",
+  "mailbox_addresses_transition_update_guard",
+  "mailbox_addresses_transition_delete_guard",
+  "mailboxes_transition_update_guard",
+  "mailboxes_transition_delete_guard",
+  "mailbox_grants_transition_insert_guard",
+  "mailbox_grants_transition_update_guard",
+  "mailbox_grants_transition_delete_guard",
+  "retention_policies_transition_insert_guard",
+  "retention_policies_transition_update_guard",
+  "retention_policies_transition_delete_guard"
+];
+const principalTransitionColumns = [
+  "mailbox_grants.user_id",
+  "mailbox_grants.created_by",
+  "drafts.user_id",
+  "draft_changes.user_id"
+];
+const principalTransitionTriggers = [
+  "mailbox_grants_identity_insert_guard",
+  "mailbox_grants_after_insert_sync",
+  "mailbox_grants_after_legacy_identity_update",
+  "mailbox_grants_after_principal_identity_update",
+  "drafts_identity_insert_guard",
+  "drafts_after_insert_sync_ownership",
+  "drafts_after_legacy_owner_update",
+  "drafts_after_principal_owner_update"
+];
+const requiredTables = ["messages", "mailbox_grants", "drafts", "draft_changes", "draft_labels"];
+const requiredColumns = [
+  "messages.mailbox_id",
+  "messages.delivered_to_address",
+  "mailbox_grants.mailbox_id",
+  "mailbox_grants.principal_id",
+  "mailbox_grants.created_by_principal_id",
+  "drafts.id",
+  "drafts.principal_id",
+  "draft_changes.sequence",
+  "draft_changes.draft_id",
+  "draft_changes.principal_id",
+  "draft_labels.draft_id",
+  "draft_labels.label_id",
+  "draft_labels.assigned_by_principal_id"
+];
+const requiredTriggers = [
+  "mailboxes_mail_domain_insert_guard",
+  "mailboxes_mail_domain_update_guard",
+  "principals_after_user_insert",
+  "principals_after_user_update",
+  "principals_after_user_delete",
+  "agents_before_agent_created_child",
+  "mailboxes_after_soft_delete_agent_access",
+  "mailbox_grants_before_agent_insert_on_deleted_mailbox",
+  "mailbox_grants_before_agent_update_on_deleted_mailbox",
+  "principals_before_agent_reenable_with_deleted_mailbox",
+  "agent_credentials_before_active_insert_with_deleted_mailbox",
+  "agent_credentials_before_unrevoke_with_deleted_mailbox",
+  "draft_changes_after_insert",
+  "draft_changes_after_update",
+  "draft_changes_after_delete",
+  "draft_changes_after_attachment_insert",
+  "draft_changes_after_attachment_delete",
+  "draft_changes_after_label_insert",
+  "draft_changes_after_label_delete"
+];
+const requiredForeignKeys = [
+  "mailbox_grants.mailbox_id->mailboxes.id:CASCADE",
+  "mailbox_grants.principal_id->principals.id:CASCADE",
+  "mailbox_grants.created_by_principal_id->principals.id:RESTRICT",
+  "drafts.principal_id->principals.id:CASCADE"
+];
+const principalTransitionForeignKeys = [
+  "mailbox_grants.user_id->user.id:CASCADE",
+  "mailbox_grants.created_by->user.id:RESTRICT",
+  "drafts.user_id->user.id:CASCADE"
+];
+const draftLabelsForeignKey = "draft_labels.draft_id->drafts.id:CASCADE";
+
+const inspectedTables = [
+  ...requiredTables,
+  ...addressTransitionTables,
+  "d1_migrations_after_deploy"
+];
+const inspectedTriggers = [
+  ...requiredTriggers,
+  ...addressTransitionTriggers,
+  ...principalTransitionTriggers
+];
+
+export const afterDeploySchemaSql = `
+SELECT 'table:' || name AS item
+FROM sqlite_master
+WHERE type = 'table' AND name IN (${sqlList(inspectedTables)})
+UNION ALL
+SELECT 'trigger:' || name AS item
+FROM sqlite_master
+WHERE type = 'trigger' AND name IN (${sqlList(inspectedTriggers)})
+UNION ALL
+SELECT 'column:messages.' || name AS item
+FROM pragma_table_info('messages')
+WHERE name IN ('mailbox_id', 'delivered_to_address', 'delivered_to_address_id', 'sent_from_address_id')
+UNION ALL
+SELECT 'column:mailbox_grants.' || name AS item
+FROM pragma_table_info('mailbox_grants')
+WHERE name IN ('mailbox_id', 'user_id', 'principal_id', 'created_by', 'created_by_principal_id')
+UNION ALL
+SELECT 'column:drafts.' || name AS item
+FROM pragma_table_info('drafts')
+WHERE name IN ('id', 'user_id', 'principal_id')
+UNION ALL
+SELECT 'column:draft_changes.' || name AS item
+FROM pragma_table_info('draft_changes')
+WHERE name IN ('sequence', 'draft_id', 'user_id', 'principal_id')
+UNION ALL
+SELECT 'column:draft_labels.' || name AS item
+FROM pragma_table_info('draft_labels')
+WHERE name IN ('draft_id', 'label_id', 'assigned_by_principal_id')
+UNION ALL
+SELECT 'foreign-key:mailbox_grants.' || "from" || '->' || "table" || '.' || "to" || ':' || "on_delete" AS item
+FROM pragma_foreign_key_list('mailbox_grants')
+WHERE "from" IN ('mailbox_id', 'user_id', 'principal_id', 'created_by', 'created_by_principal_id')
+UNION ALL
+SELECT 'foreign-key:drafts.' || "from" || '->' || "table" || '.' || "to" || ':' || "on_delete" AS item
+FROM pragma_foreign_key_list('drafts')
+WHERE "from" IN ('user_id', 'principal_id')
+UNION ALL
+SELECT 'foreign-key:draft_labels.' || "from" || '->' || "table" || '.' || "to" || ':' || "on_delete" AS item
+FROM pragma_foreign_key_list('draft_labels')
+WHERE "from" = 'draft_id'
+ORDER BY item
+`.trim();
+
+export function inspectRemoteAfterDeployState(source, version, options = {}) {
+  const query =
+    options.query ?? ((sql) => queryRemoteD1(source, sql, { capture: options.capture ?? capture }));
+  const expectedNormalMigrations = migrationNames(resolve(source, "migrations"));
+  const packagedAfterDeployMigrations = migrationNames(resolve(source, "migrations-after-deploy"));
+  if (!sameList(packagedAfterDeployMigrations, afterDeployMigrations)) {
+    throw inconsistentState("The signed release has an unknown after-deploy migration sequence.");
+  }
+
+  const normalMigrations = rowsOfStrings(
+    query("SELECT name FROM d1_migrations ORDER BY id"),
+    "name"
+  );
+  const schemaItems = rowsOfStrings(query(afterDeploySchemaSql), "item");
+  const hasAfterDeployLedger = schemaItems.includes("table:d1_migrations_after_deploy");
+  const appliedAfterDeployMigrations = hasAfterDeployLedger
+    ? rowsOfStrings(query("SELECT name FROM d1_migrations_after_deploy ORDER BY id"), "name")
+    : [];
+  const pendingUpdates = query(
+    `SELECT id, from_version, to_version, checkpoint_bookmark, worker_version, state
+     FROM update_history
+     WHERE to_version = ${quote(version)} AND state IN ('started', 'deployed')
+     ORDER BY started_at, rowid`
+  );
+
+  return classifyAfterDeployState({
+    appliedAfterDeployMigrations,
+    expectedNormalMigrations,
+    hasAfterDeployLedger,
+    normalMigrations,
+    pendingUpdates,
+    schemaItems
+  });
+}
+
+export function classifyAfterDeployState({
+  appliedAfterDeployMigrations,
+  expectedNormalMigrations,
+  hasAfterDeployLedger,
+  normalMigrations,
+  pendingUpdates = [],
+  schemaItems
+}) {
+  if (!sameList(normalMigrations, expectedNormalMigrations)) {
+    throw inconsistentState("The normal migration ledger is not complete.");
+  }
+  const phaseIndex = afterDeployMigrations.findIndex(
+    (name, index) => appliedAfterDeployMigrations[index] !== name
+  );
+  const appliedCount = phaseIndex === -1 ? afterDeployMigrations.length : phaseIndex;
+  if (
+    appliedAfterDeployMigrations.length !== appliedCount ||
+    appliedAfterDeployMigrations.length > afterDeployMigrations.length
+  ) {
+    throw inconsistentState("The after-deploy migration ledger is not an exact prefix.");
+  }
+  if (appliedCount > 0 && !hasAfterDeployLedger) {
+    throw inconsistentState("The after-deploy migration ledger table is missing.");
+  }
+  if (!Array.isArray(pendingUpdates) || pendingUpdates.length > 1) {
+    throw inconsistentState("More than one update is pending for this release.");
+  }
+
+  const actual = new Set(schemaItems);
+  const expected = expectedSchemaItems(appliedCount, hasAfterDeployLedger);
+  if (actual.size !== schemaItems.length || !sameSet(actual, expected)) {
+    throw inconsistentState("The migration ledger and the live schema do not match.");
+  }
+
+  const pendingUpdate = pendingUpdates[0] ?? null;
+  if (
+    pendingUpdate &&
+    [
+      pendingUpdate.id,
+      pendingUpdate.from_version,
+      pendingUpdate.to_version,
+      pendingUpdate.checkpoint_bookmark,
+      pendingUpdate.worker_version,
+      pendingUpdate.state
+    ].some((value) => typeof value !== "string" || !value)
+  ) {
+    throw inconsistentState("The pending update recovery record is incomplete.");
+  }
+
+  return {
+    phase: `S${appliedCount}`,
+    pendingUpdate,
+    repairRequired: appliedCount < afterDeployMigrations.length
+  };
+}
+
+export function queryRemoteD1(source, sql, options = {}) {
+  const output = (options.capture ?? capture)(
+    "pnpm",
+    [
+      "exec",
+      "wrangler",
+      "d1",
+      "execute",
+      "DB",
+      "--remote",
+      "--json",
+      "--command",
+      sql,
+      "--config",
+      "wrangler.jsonc"
+    ],
+    source
+  );
+  return parseD1Rows(output);
+}
+
+export function parseD1Rows(output) {
+  let parsed;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    throw new Error("Wrangler returned invalid D1 inspection JSON.");
+  }
+  const rows = findResultRows(parsed);
+  if (!rows) throw new Error("Wrangler returned no D1 inspection results.");
+  return rows;
+}
+
+function expectedSchemaItems(appliedCount, hasAfterDeployLedger) {
+  const items = [
+    ...requiredTables.map((name) => `table:${name}`),
+    ...requiredColumns.map((name) => `column:${name}`),
+    ...requiredTriggers.map((name) => `trigger:${name}`),
+    ...requiredForeignKeys.map((name) => `foreign-key:${name}`)
+  ];
+  if (hasAfterDeployLedger) items.push("table:d1_migrations_after_deploy");
+  if (appliedCount === 0) {
+    items.push(
+      ...addressTransitionTables.map((name) => `table:${name}`),
+      ...addressTransitionColumns.map((name) => `column:${name}`),
+      ...addressTransitionTriggers.map((name) => `trigger:${name}`)
+    );
+  }
+  if (appliedCount < 2) {
+    items.push(
+      ...principalTransitionColumns.map((name) => `column:${name}`),
+      ...principalTransitionTriggers.map((name) => `trigger:${name}`),
+      ...principalTransitionForeignKeys.map((name) => `foreign-key:${name}`)
+    );
+  }
+  if (appliedCount === 3) items.push(`foreign-key:${draftLabelsForeignKey}`);
+  return new Set(items);
+}
+
+function migrationNames(directory) {
+  return readdirSync(directory)
+    .filter((name) => name.endsWith(".sql"))
+    .sort();
+}
+
+function rowsOfStrings(rows, key) {
+  if (!Array.isArray(rows) || rows.some((row) => typeof row?.[key] !== "string")) {
+    throw new Error("Wrangler returned invalid D1 inspection rows.");
+  }
+  return rows.map((row) => row[key]);
+}
+
+function sameList(left, right) {
+  return (
+    Array.isArray(left) &&
+    Array.isArray(right) &&
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+function sameSet(left, right) {
+  return left.size === right.size && [...left].every((value) => right.has(value));
+}
+
+function findResultRows(value) {
+  if (!value || typeof value !== "object") return null;
+  if (Array.isArray(value.results)) return value.results;
+  for (const child of Array.isArray(value) ? value : Object.values(value)) {
+    const rows = findResultRows(child);
+    if (rows) return rows;
+  }
+  return null;
+}
+
+function inconsistentState(detail) {
+  return new Error(
+    `Refusing to repair HQBase because the D1 post-deploy state is inconsistent. ${detail}`
+  );
+}
+
+function quote(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function sqlList(values) {
+  return values.map(quote).join(", ");
+}

--- a/scripts/release/after-deploy-state.mjs
+++ b/scripts/release/after-deploy-state.mjs
@@ -234,7 +234,7 @@ export function classifyAfterDeployState({
   return {
     phase: `S${appliedCount}`,
     pendingUpdate,
-    repairRequired: appliedCount < afterDeployMigrations.length
+    repairRequired: appliedCount < afterDeployMigrations.length || pendingUpdate !== null
   };
 }
 

--- a/scripts/release/bootstrap.mjs
+++ b/scripts/release/bootstrap.mjs
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import { createHash, createPublicKey, verify } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { resolve } from "node:path";
+import { resolve, win32 } from "node:path";
 
 const publicKey = "MCowBQYDK2VwAyEARmCVvXVUDzwewmIDAVez9Uyv2K+7ylU6+YhR5iN2WTc=";
 const stableVersion = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
@@ -51,7 +51,12 @@ export async function bootstrap(options = {}) {
     writeFileSync(archive, bytes);
     writeFileSync(verifiedManifest, `${JSON.stringify(envelope)}\n`);
     const run = options.run ?? runCommand;
-    run("tar", ["-xzf", archive, "-C", source], { cwd: workspace });
+    const platform = options.platform ?? process.platform;
+    const extractor =
+      platform === "win32"
+        ? win32.resolve(process.env.SystemRoot || "C:\\Windows", "System32", "tar.exe")
+        : "tar";
+    run(extractor, ["-xzf", archive, "-C", source], { cwd: workspace });
     const candidateEnvironment = {
       ...process.env,
       CI: process.env.CI ?? "true",
@@ -59,7 +64,7 @@ export async function bootstrap(options = {}) {
       HQBASE_RELEASE_ARTIFACT_FILE: archive,
       HQBASE_RELEASE_MANIFEST_FILE: verifiedManifest
     };
-    if ((options.platform ?? process.platform) === "win32") {
+    if (platform === "win32") {
       // The extracted updater uses cross-spawn for safe Windows argv handling. Install its frozen
       // dependencies first through a fixed cmd.exe command, before that module is imported.
       run(
@@ -75,7 +80,7 @@ export async function bootstrap(options = {}) {
         "--config",
         resolve(
           options.configFile ??
-            (managedDataUrl ? null : process.env.HQBASE_UPDATER_CONFIG_FILE) ??
+            (managedDataUrl ? null : process.env.HQBASE_UPDATER_CONFIG_FILE?.trim() || null) ??
             resolve(process.cwd(), "wrangler.jsonc")
         )
       ],

--- a/scripts/release/bootstrap.mjs
+++ b/scripts/release/bootstrap.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createHash, createPublicKey, verify } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+const publicKey = "MCowBQYDK2VwAyEARmCVvXVUDzwewmIDAVez9Uyv2K+7ylU6+YhR5iN2WTc=";
+const stableVersion = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const sha256 = /^[a-f0-9]{64}$/;
+const updaterSource =
+  /^https:\/\/raw\.githubusercontent\.com\/HQBase\/hqbase\/[a-f0-9]{40}\/scripts\/release\/bootstrap\.mjs$/;
+const managedDataUrl = import.meta.url.startsWith("data:");
+
+export async function bootstrap(options = {}) {
+  const expectedVersion = options.expectedVersion ?? process.env.HQBASE_EXPECTED_RELEASE_VERSION;
+  if (!stableVersion.test(expectedVersion ?? "")) {
+    throw new Error("HQBASE_EXPECTED_RELEASE_VERSION must name one stable HQBase release.");
+  }
+  const fetcher = options.fetcher ?? fetch;
+  const manifestFile =
+    options.manifestFile ??
+    (managedDataUrl ? null : process.env.HQBASE_RELEASE_MANIFEST_FILE?.trim() || null);
+  const envelope = manifestFile
+    ? JSON.parse(readFileSync(resolve(manifestFile), "utf8"))
+    : await fetchJson(
+        fetcher,
+        `https://github.com/HQBase/hqbase/releases/download/v${expectedVersion}/manifest-${expectedVersion}.json`,
+        "Release manifest"
+      );
+  const manifest = verifyBootstrapManifest(envelope, expectedVersion, options.publicKeyBase64);
+  const artifactFile =
+    options.artifactFile ??
+    (managedDataUrl ? null : process.env.HQBASE_RELEASE_ARTIFACT_FILE?.trim() || null);
+  const bytes = artifactFile
+    ? readFileSync(resolve(artifactFile))
+    : await fetchBytes(fetcher, manifest.artifact.url, "Release artifact");
+  if (
+    bytes.length !== manifest.artifact.size ||
+    createHash("sha256").update(bytes).digest("hex") !== manifest.artifact.sha256
+  ) {
+    throw new Error("Release artifact integrity check failed.");
+  }
+
+  const workspace = mkdtempSync(resolve(tmpdir(), "hqbase-bootstrap-"));
+  try {
+    const archive = resolve(workspace, "release.tar.gz");
+    const verifiedManifest = resolve(workspace, "manifest.json");
+    const source = resolve(workspace, "source");
+    mkdirSync(source);
+    writeFileSync(archive, bytes);
+    writeFileSync(verifiedManifest, `${JSON.stringify(envelope)}\n`);
+    const run = options.run ?? runCommand;
+    run("tar", ["-xzf", archive, "-C", source], { cwd: workspace });
+    const candidateEnvironment = {
+      ...process.env,
+      CI: process.env.CI ?? "true",
+      HQBASE_EXPECTED_RELEASE_VERSION: expectedVersion,
+      HQBASE_RELEASE_ARTIFACT_FILE: archive,
+      HQBASE_RELEASE_MANIFEST_FILE: verifiedManifest
+    };
+    if ((options.platform ?? process.platform) === "win32") {
+      // The extracted updater uses cross-spawn for safe Windows argv handling. Install its frozen
+      // dependencies first through a fixed cmd.exe command, before that module is imported.
+      run(
+        options.windowsShell ?? process.env.ComSpec ?? "cmd.exe",
+        ["/d", "/s", "/c", "pnpm install --frozen-lockfile"],
+        { cwd: source, env: candidateEnvironment }
+      );
+    }
+    run(
+      process.execPath,
+      [
+        resolve(source, "scripts/release/deploy.mjs"),
+        "--config",
+        resolve(
+          options.configFile ??
+            (managedDataUrl ? null : process.env.HQBASE_UPDATER_CONFIG_FILE) ??
+            resolve(process.cwd(), "wrangler.jsonc")
+        )
+      ],
+      {
+        cwd: source,
+        env: candidateEnvironment
+      }
+    );
+    return { version: manifest.version };
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+}
+
+export function verifyBootstrapManifest(envelope, expectedVersion, publicKeyBase64 = publicKey) {
+  if (!envelope || typeof envelope.payload !== "string" || typeof envelope.signature !== "string") {
+    throw new Error("Release manifest envelope is invalid.");
+  }
+  const key = createPublicKey({
+    key: Buffer.from(publicKeyBase64, "base64"),
+    format: "der",
+    type: "spki"
+  });
+  const payload = Buffer.from(envelope.payload, "base64url");
+  if (!verify(null, payload, key, Buffer.from(envelope.signature, "base64url"))) {
+    throw new Error("Release manifest signature is invalid.");
+  }
+  const manifest = JSON.parse(payload.toString("utf8"));
+  if (manifest.version !== expectedVersion) {
+    throw new Error(`Expected signed HQBase ${expectedVersion}, received ${manifest.version}.`);
+  }
+  const canonicalArtifactUrl = `https://github.com/HQBase/hqbase/releases/download/v${expectedVersion}/hqbase-${expectedVersion}.tar.gz`;
+  if (
+    manifest.format !== "hqbase-release-v1" ||
+    manifest.product !== "hqbase" ||
+    manifest.channel !== "stable" ||
+    manifest.keyId !== "hqbase-release-2026-01" ||
+    !stableVersion.test(manifest.version) ||
+    !stableVersion.test(manifest.minVersion) ||
+    !Number.isInteger(manifest.schemaVersion) ||
+    manifest.schemaVersion <= 0 ||
+    manifest.artifact?.url !== canonicalArtifactUrl ||
+    !sha256.test(manifest.artifact?.sha256) ||
+    !Number.isInteger(manifest.artifact?.size) ||
+    manifest.artifact.size <= 0 ||
+    manifest.updater?.protocol !== 2 ||
+    !updaterSource.test(manifest.updater?.sourceUrl) ||
+    !sha256.test(manifest.updater?.sha256) ||
+    !Number.isInteger(manifest.updater?.size) ||
+    manifest.updater.size <= 0
+  ) {
+    throw new Error("Release manifest is incompatible with the managed updater.");
+  }
+  return manifest;
+}
+
+async function fetchJson(fetcher, url, label) {
+  const response = await fetcher(url);
+  if (!response.ok) throw new Error(`${label} download failed (${response.status}).`);
+  return response.json();
+}
+
+async function fetchBytes(fetcher, url, label) {
+  const response = await fetcher(url);
+  if (!response.ok) throw new Error(`${label} download failed (${response.status}).`);
+  return Buffer.from(await response.arrayBuffer());
+}
+
+function runCommand(command, args, options) {
+  const result = spawnSync(command, args, { ...options, stdio: "inherit" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `Command failed (${result.status ?? "no exit code"}): ${[command, ...args].join(" ")}`
+    );
+  }
+}
+
+if (
+  managedDataUrl ||
+  (process.argv[1] && resolve(process.argv[1]) === resolve(import.meta.filename))
+) {
+  const configIndex = process.argv.indexOf("--config");
+  if (configIndex >= 0 && !process.argv[configIndex + 1]) {
+    throw new Error("--config requires a wrangler.jsonc path.");
+  }
+  await bootstrap({ configFile: configIndex >= 0 ? process.argv[configIndex + 1] : undefined });
+}

--- a/scripts/release/deploy.mjs
+++ b/scripts/release/deploy.mjs
@@ -8,6 +8,7 @@ import { applyMigrationPhase } from "../d1-migrations.mjs";
 import { recordWorkerDeployedForConfig } from "../hqbase/manifest.mjs";
 import { windowsSystem32Executable } from "../windows-system32.mjs";
 import { assertRequiredActiveBindings, inspectActiveRelease } from "./active-version.mjs";
+import { inspectRemoteAfterDeployState } from "./after-deploy-state.mjs";
 import { capture, run } from "./command.mjs";
 import {
   compareVersions,
@@ -114,10 +115,23 @@ export async function deploy(options = {}) {
       );
     }
     if (activeRelease.version === manifest.version && activeRelease.tag === releaseTag) {
+      const afterDeployState = inspectRemoteAfterDeployState(source, manifest.version);
+      let retryActiveRelease = activeRelease;
       if (activeRelease.missingBindings.length > 0) {
-        deployConfiguration(source, config.name, releaseTag);
+        retryActiveRelease = deployConfiguration(source, config.name, releaseTag);
       }
-      completeActiveReleaseRetry(source, manifest, recordWorkerDeployed);
+      const retry = completeActiveReleaseRetry(source, manifest, recordWorkerDeployed, {
+        activeRelease: retryActiveRelease,
+        afterDeployState,
+        configFile,
+        workerName: config.name,
+        onRecovery: (checkpoint) => {
+          recovery = checkpoint;
+        }
+      });
+      if (activeRelease.missingBindings.length > 0 && !retry.workerRecorded) {
+        recordWorkerDeployed();
+      }
       console.log(`HQBase ${manifest.version} is already the active signed release.`);
       return;
     }
@@ -238,12 +252,94 @@ export function deployConfiguration(source, workerName, releaseTag, options = {}
 export function completeActiveReleaseRetry(source, manifest, recordWorkerDeployed, options = {}) {
   const applyMigrations = options.applyMigrationPhase ?? applyMigrationPhase;
   const updateReleaseState = options.executeSql ?? executeSql;
+  const afterDeployState =
+    options.afterDeployState ??
+    (options.inspectAfterDeployState ?? inspectRemoteAfterDeployState)(source, manifest.version);
+  if (!["S0", "S1", "S2", "S3"].includes(afterDeployState?.phase)) {
+    throw new Error("Refusing to repair HQBase because the D1 post-deploy state is invalid.");
+  }
+
+  let update = afterDeployState.pendingUpdate;
+  if (afterDeployState.phase === "S3" && !update) {
+    return { phase: "S3", repaired: false, workerRecorded: false };
+  }
+
+  let checkpoint;
+  if (update) {
+    checkpoint = {
+      bookmark: update.checkpoint_bookmark,
+      cleanupComplete: afterDeployState.phase === "S3",
+      configFile: options.configFile,
+      name: options.workerName,
+      workerVersion: update.worker_version
+    };
+  } else {
+    const workerVersion = options.activeRelease?.versionId;
+    if (!workerVersion) throw new Error("Could not establish the update recovery checkpoint.");
+    const bookmark = (options.createRecoveryBookmark ?? createRecoveryBookmark)(source, options);
+    const updateId = (options.randomUUID ?? randomUUID)();
+    if (!bookmark) throw new Error("Could not establish the update recovery checkpoint.");
+    update = {
+      checkpoint_bookmark: bookmark,
+      from_version: manifest.version,
+      id: updateId,
+      state: "started",
+      to_version: manifest.version,
+      worker_version: workerVersion
+    };
+    checkpoint = {
+      bookmark,
+      cleanupComplete: false,
+      configFile: options.configFile,
+      name: options.workerName,
+      workerVersion
+    };
+  }
+
+  options.onRecovery?.(checkpoint);
+  if (!afterDeployState.pendingUpdate) {
+    updateReleaseState(
+      source,
+      `INSERT INTO update_history (id, from_version, to_version, checkpoint_bookmark, worker_version, state, started_at) VALUES (${quote(update.id)}, ${quote(manifest.version)}, ${quote(manifest.version)}, ${quote(update.checkpoint_bookmark)}, ${quote(update.worker_version)}, 'started', datetime('now'))`
+    );
+  }
   recordWorkerDeployed();
-  applyMigrations(source, "normal", { target: "remote" });
-  applyMigrations(source, "after-deploy", { target: "remote" });
+  if (afterDeployState.phase !== "S3") {
+    applyMigrations(source, "normal", { target: "remote" });
+    applyMigrations(source, "after-deploy", { target: "remote" });
+    checkpoint.cleanupComplete = true;
+  }
   updateReleaseState(
     source,
-    `UPDATE release_state SET installed_version = ${quote(manifest.version)}, installed_schema_version = ${manifest.schemaVersion}, updated_at = datetime('now') WHERE singleton = 1; UPDATE update_history SET state = 'verified', completed_at = datetime('now') WHERE state IN ('started', 'deployed') AND id = (SELECT id FROM update_history WHERE to_version = ${quote(manifest.version)} AND state IN ('started', 'deployed') ORDER BY started_at DESC, rowid DESC LIMIT 1)`
+    `UPDATE release_state SET installed_version = ${quote(manifest.version)}, installed_schema_version = ${manifest.schemaVersion}, updated_at = datetime('now') WHERE singleton = 1; UPDATE update_history SET state = 'verified', completed_at = datetime('now') WHERE id = ${quote(update.id)} AND state IN ('started', 'deployed')`
+  );
+  return {
+    phase: afterDeployState.phase,
+    repaired: afterDeployState.phase !== "S3",
+    workerRecorded: true
+  };
+}
+
+export function createRecoveryBookmark(source, options = {}) {
+  return findString(
+    JSON.parse(
+      (options.capture ?? capture)(
+        "pnpm",
+        [
+          "exec",
+          "wrangler",
+          "d1",
+          "time-travel",
+          "info",
+          "DB",
+          "--json",
+          "--config",
+          "wrangler.jsonc"
+        ],
+        source
+      )
+    ),
+    "bookmark"
   );
 }
 

--- a/scripts/release/manifest.mjs
+++ b/scripts/release/manifest.mjs
@@ -67,6 +67,16 @@ export function verifyManifest(envelope, publicKeyBase64 = publicKey) {
     throw new Error("Release manifest signature is invalid.");
   }
   const manifest = JSON.parse(Buffer.from(envelope.payload, "base64url").toString("utf8"));
+  // Signed releases before the managed updater bridge do not have updater metadata.
+  const updaterIsValid =
+    manifest.updater === undefined ||
+    (manifest.updater?.protocol === 2 &&
+      /^https:\/\/raw\.githubusercontent\.com\/HQBase\/hqbase\/[a-f0-9]{40}\/scripts\/release\/bootstrap\.mjs$/.test(
+        manifest.updater?.sourceUrl
+      ) &&
+      /^[a-f0-9]{64}$/.test(manifest.updater?.sha256) &&
+      Number.isInteger(manifest.updater?.size) &&
+      manifest.updater.size > 0);
   if (
     manifest.format !== "hqbase-release-v1" ||
     manifest.product !== "hqbase" ||
@@ -81,7 +91,8 @@ export function verifyManifest(envelope, publicKeyBase64 = publicKey) {
         ))) ||
     !/^[a-f0-9]{64}$/.test(manifest.artifact?.sha256) ||
     !Number.isInteger(manifest.artifact?.size) ||
-    manifest.artifact.size <= 0
+    manifest.artifact.size <= 0 ||
+    !updaterIsValid
   ) {
     throw new Error("Release manifest is incompatible.");
   }

--- a/scripts/release/package.mjs
+++ b/scripts/release/package.mjs
@@ -33,6 +33,19 @@ writeFileSync(artifactFile, gzipSync(readFileSync(tarFile), { level: 9 }));
 rmSync(tarFile);
 
 const bytes = readFileSync(artifactFile);
+const sourceCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+  cwd: root,
+  encoding: "utf8"
+}).trim();
+if (!/^[a-f0-9]{40}$/.test(sourceCommit)) {
+  throw new Error("Release source commit is invalid.");
+}
+// Hash the committed source that the URL serves, never uncommitted working-tree bytes.
+const updaterBytes = execFileSync(
+  "git",
+  ["show", `${sourceCommit}:scripts/release/bootstrap.mjs`],
+  { cwd: root }
+);
 const manifest = {
   format: "hqbase-release-v1",
   product,
@@ -47,6 +60,12 @@ const manifest = {
     url: `https://github.com/HQBase/hqbase/releases/download/v${version}/hqbase-${version}.tar.gz`,
     sha256: createHash("sha256").update(bytes).digest("hex"),
     size: statSync(artifactFile).size
+  },
+  updater: {
+    protocol: 2,
+    sourceUrl: `https://raw.githubusercontent.com/HQBase/hqbase/${sourceCommit}/scripts/release/bootstrap.mjs`,
+    sha256: createHash("sha256").update(updaterBytes).digest("hex"),
+    size: updaterBytes.length
   },
   keyId: "hqbase-release-2026-01"
 };

--- a/scripts/release/worker-deploy.mjs
+++ b/scripts/release/worker-deploy.mjs
@@ -1,8 +1,6 @@
-import { randomBytes, randomUUID } from "node:crypto";
+import { createECDH, randomBytes, randomUUID } from "node:crypto";
 import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-import webpush from "web-push";
-
 import { createRestrictedDirectory } from "../secure-directory.mjs";
 import { isWorkerNotFound } from "./active-version.mjs";
 import { attemptRun, emitCommandOutput, run } from "./command.mjs";
@@ -66,7 +64,7 @@ export function deploySource(cwd, options = {}) {
       const generated =
         configuredPublicKey && configuredPrivateKey
           ? { publicKey: configuredPublicKey, privateKey: configuredPrivateKey }
-          : (options.generateVapidKeys ?? webpush.generateVAPIDKeys)();
+          : (options.generateVapidKeys ?? generateVapidKeys)();
       secrets.VAPID_PUBLIC_KEY = generated.publicKey;
       secrets.VAPID_PRIVATE_KEY = generated.privateKey;
     }
@@ -75,6 +73,22 @@ export function deploySource(cwd, options = {}) {
   } finally {
     rmSync(workspace, { recursive: true, force: true });
   }
+}
+
+export function generateVapidKeys() {
+  const key = createECDH("prime256v1");
+  key.generateKeys();
+  return {
+    privateKey: encodeVapidPrivateKey(key.getPrivateKey()),
+    publicKey: key.getPublicKey().toString("base64url")
+  };
+}
+
+export function encodeVapidPrivateKey(bytes) {
+  if (!Buffer.isBuffer(bytes) || bytes.length < 1 || bytes.length > 32) {
+    throw new Error("VAPID private key bytes are invalid.");
+  }
+  return Buffer.concat([Buffer.alloc(32 - bytes.length), bytes]).toString("base64url");
 }
 
 export function workerNameFromConfig(config) {

--- a/scripts/shell.mjs
+++ b/scripts/shell.mjs
@@ -1,4 +1,7 @@
-import crossSpawn from "cross-spawn";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
 
 // pnpm and wrangler are installed as `.cmd` shims on Windows, which CreateProcess cannot launch
 // directly. cross-spawn resolves the shim and builds the command line itself, so argv reaches
@@ -6,5 +9,8 @@ import crossSpawn from "cross-spawn";
 // arguments without escaping them (DEP0190) and still lets cmd.exe expand `%VAR%` inside quoted
 // arguments, which would silently corrupt SQL and any value containing a percent sign.
 export function spawnProcess(command, args = [], options = {}) {
-  return crossSpawn.sync(command, args, options);
+  if (process.platform === "win32") {
+    return require("cross-spawn").sync(command, args, options);
+  }
+  return spawnSync(command, args, options);
 }

--- a/test/e2e/staging/event-socket.spec.ts
+++ b/test/e2e/staging/event-socket.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+const email = required("HQBASE_STAGING_OWNER_EMAIL");
+const password = required("HQBASE_STAGING_OWNER_PASSWORD");
+const stagingUrl = required("HQBASE_STAGING_URL");
+
+test("authenticated event WebSocket opens", async ({ page }) => {
+  const login = await page.context().request.post("/api/auth/sign-in/email", {
+    data: { email, password, rememberMe: false },
+    headers: { origin: stagingUrl }
+  });
+  expect(login.ok(), await login.text()).toBeTruthy();
+
+  await page.goto("/offline.html", { waitUntil: "domcontentloaded" });
+  const outcome = await page.evaluate(
+    () =>
+      new Promise<"failed" | "open">((resolve) => {
+        const url = new URL("/api/v2/events", window.location.href);
+        url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+        const socket = new WebSocket(url);
+        let finished = false;
+        const finish = (value: "failed" | "open"): void => {
+          if (finished) return;
+          finished = true;
+          socket.close();
+          resolve(value);
+        };
+        socket.addEventListener("open", () => finish("open"));
+        socket.addEventListener("error", () => finish("failed"));
+        socket.addEventListener("close", () => finish("failed"));
+        window.setTimeout(() => finish("failed"), 30_000);
+      })
+  );
+
+  expect(outcome).toBe("open");
+});
+
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required for staging E2E.`);
+  return value;
+}

--- a/test/unit/app/updates/update-banner.test.tsx
+++ b/test/unit/app/updates/update-banner.test.tsx
@@ -56,4 +56,21 @@ describe("update banner", () => {
     );
     expect(html).toBe("");
   });
+
+  it("shows a same-release installation repair even when no new app bundle is needed", () => {
+    const status = {
+      installedVersion: "1.3.3",
+      available: true,
+      repairRequired: true,
+      release: { version: "1.3.3", notes: ["Unrelated release note."] }
+    } as unknown as UpdateStatus;
+    const html = renderToStaticMarkup(
+      <UpdateBanner inProgress={false} ready status={status} onOpen={() => undefined} />
+    );
+
+    expect(html).toContain("Installation repair available");
+    expect(html).toContain("View repair");
+    expect(html).toContain("signed database migration phase");
+    expect(html).not.toContain("Unrelated release note");
+  });
 });

--- a/test/unit/app/updates/update-progress.test.ts
+++ b/test/unit/app/updates/update-progress.test.ts
@@ -27,12 +27,14 @@ describe("update progress", () => {
   });
 
   it("retains and announces an accepted build", () => {
-    expect(beginUpdateProgress("build-123", 1_000)).toEqual({
+    expect(beginUpdateProgress("build-123", "update", 1_000)).toEqual({
       buildId: "build-123",
+      kind: "update",
       startedAt: 1_000
     });
     expect(readUpdateProgress(2_000)).toEqual({
       buildId: "build-123",
+      kind: "update",
       startedAt: 1_000
     });
     expect(dispatchEvent).toHaveBeenCalledOnce();
@@ -40,8 +42,21 @@ describe("update progress", () => {
   });
 
   it("expires a stale build marker", () => {
-    beginUpdateProgress("build-123", 1_000);
+    beginUpdateProgress("build-123", "update", 1_000);
     expect(readUpdateProgress(31 * 60 * 1_000)).toBeNull();
     expect(values.size).toBe(0);
+  });
+
+  it("reads an older progress marker as an update", () => {
+    values.set(
+      "hqbase:update-progress",
+      JSON.stringify({ buildId: "build-123", startedAt: 1_000 })
+    );
+
+    expect(readUpdateProgress(2_000)).toEqual({
+      buildId: "build-123",
+      kind: "update",
+      startedAt: 1_000
+    });
   });
 });

--- a/test/unit/app/updates/update-settings.test.tsx
+++ b/test/unit/app/updates/update-settings.test.tsx
@@ -11,6 +11,7 @@ const availableStatus: UpdateStatus = {
   checkedAt: "2026-07-13T12:00:00.000Z",
   available: true,
   compatible: true,
+  repairRequired: false,
   release: {
     version: "0.2.0",
     schemaVersion: 10,
@@ -59,7 +60,7 @@ describe("update settings", () => {
     const html = renderToStaticMarkup(
       <UpdateSettings
         initialStatus={availableStatus}
-        progress={{ buildId: "build-123", startedAt: Date.now() }}
+        progress={{ buildId: "build-123", kind: "update", startedAt: Date.now() }}
         onStatusChange={() => undefined}
         onUpdateStarted={() => undefined}
       />
@@ -68,6 +69,55 @@ describe("update settings", () => {
     expect(html).toContain("animate-spin");
     expect(html).toContain("HQBase 0.2.0 is being deployed");
     expect(html).toContain("build-123");
+    expect(html).not.toContain("Install update");
+  });
+
+  it("labels an accepted repair build separately", () => {
+    const html = renderToStaticMarkup(
+      <UpdateSettings
+        initialStatus={{
+          ...availableStatus,
+          installedVersion: "0.2.0",
+          repairRequired: true
+        }}
+        progress={{ buildId: "repair-123", kind: "repair", startedAt: Date.now() }}
+        onStatusChange={() => undefined}
+        onUpdateStarted={() => undefined}
+      />
+    );
+
+    expect(html).toContain("Installation repair in progress");
+    expect(html).toContain("repair-123");
+    expect(html).not.toContain("Finish repair");
+  });
+
+  it("renders persisted repair progress before update status loads", () => {
+    const html = renderToStaticMarkup(
+      <UpdateSettings
+        initialStatus={null}
+        progress={{ buildId: "repair-123", kind: "repair", startedAt: Date.now() }}
+        onStatusChange={() => undefined}
+        onUpdateStarted={() => undefined}
+      />
+    );
+
+    expect(html).toContain("Installation repair in progress");
+    expect(html).toContain("HQBase is completing its signed installation");
+    expect(html).toContain("repair-123");
+  });
+
+  it("offers one global same-release repair without changing customer source", () => {
+    const html = renderSettings({
+      ...availableStatus,
+      installedVersion: "0.2.0",
+      repairRequired: true
+    });
+
+    expect(html).toContain("Finish installation repair");
+    expect(html).toContain("Finish repair");
+    expect(html).toContain("fresh recovery checkpoint");
+    expect(html).toContain("will not change your source repository");
+    expect(html).not.toContain("What’s changing");
     expect(html).not.toContain("Install update");
   });
 });

--- a/test/unit/app/updates/use-update-monitor.test.tsx
+++ b/test/unit/app/updates/use-update-monitor.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { announcePwaUpdateReady } from "@/features/pwa/update-ready";
 import type { UpdateStatus } from "@/features/updates/types";
@@ -22,6 +22,7 @@ const status: UpdateStatus = {
   checkedAt: "2026-07-29T00:00:00.000Z",
   available: true,
   compatible: true,
+  repairRequired: false,
   release: {
     version: "0.1.23",
     schemaVersion: 5,
@@ -32,6 +33,11 @@ const status: UpdateStatus = {
 };
 
 describe("useUpdateMonitor", () => {
+  beforeEach(() => {
+    mocks.getUpdateStatus.mockReset();
+    window.sessionStorage.clear();
+  });
+
   it("checks while visible and removes refresh listeners when management is revoked", async () => {
     Object.defineProperty(document, "visibilityState", {
       configurable: true,
@@ -60,5 +66,36 @@ describe("useUpdateMonitor", () => {
     expect(mocks.getUpdateStatus).toHaveBeenCalledTimes(2);
     await hook.unmount();
     document.documentElement.removeAttribute("data-hqbase-update-ready");
+  });
+
+  it("clears update progress when the same release needs its second repair phase", async () => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible"
+    });
+    mocks.getUpdateStatus.mockResolvedValue(status);
+    const hook = await renderHook(() => useUpdateMonitor(true), undefined);
+    await flushHookEffects();
+
+    await flushHookEffects(() => hook.result.start("update-build", "update"));
+    expect(hook.result.progress).toMatchObject({ buildId: "update-build", kind: "update" });
+
+    const repairStatus: UpdateStatus = {
+      ...status,
+      installedVersion: status.release.version,
+      repairRequired: true
+    };
+    await flushHookEffects(() => hook.result.acceptStatus(repairStatus));
+    expect(hook.result.progress).toBeNull();
+
+    await flushHookEffects(() => hook.result.start("repair-build", "repair"));
+    await flushHookEffects(() => hook.result.acceptStatus(repairStatus));
+    expect(hook.result.progress).toMatchObject({ buildId: "repair-build", kind: "repair" });
+
+    await flushHookEffects(() =>
+      hook.result.acceptStatus({ ...repairStatus, available: false, repairRequired: false })
+    );
+    expect(hook.result.progress).toBeNull();
+    await hook.unmount();
   });
 });

--- a/test/unit/scripts/after-deploy-state.test.mjs
+++ b/test/unit/scripts/after-deploy-state.test.mjs
@@ -44,6 +44,18 @@ describe("after-deploy state inspection", () => {
         repairRequired: index + 1 < afterDeploy.length
       });
     }
+    expect(
+      classify(database, normal, true, [
+        {
+          checkpoint_bookmark: "bookmark-before-repair",
+          from_version: "1.3.2",
+          id: "repair-update",
+          state: "started",
+          to_version: "1.3.3",
+          worker_version: "worker-before-repair"
+        }
+      ])
+    ).toMatchObject({ phase: "S3", repairRequired: true });
   });
 
   it("fails closed when a ledger is incomplete, out of order, or unlike the live schema", async () => {
@@ -139,7 +151,7 @@ function applyMigration(database, migration, table) {
   }
 }
 
-function classify(database, normal, hasAfterDeployLedger) {
+function classify(database, normal, hasAfterDeployLedger, pendingUpdates = []) {
   return classifyAfterDeployState({
     appliedAfterDeployMigrations: hasAfterDeployLedger
       ? database
@@ -153,6 +165,7 @@ function classify(database, normal, hasAfterDeployLedger) {
       .prepare("SELECT name FROM d1_migrations ORDER BY id")
       .all()
       .map(({ name }) => name),
+    pendingUpdates,
     schemaItems: inspectSchema(database)
   });
 }

--- a/test/unit/scripts/after-deploy-state.test.mjs
+++ b/test/unit/scripts/after-deploy-state.test.mjs
@@ -1,0 +1,165 @@
+import { resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { readD1Migrations } from "@cloudflare/vitest-pool-workers";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  afterDeploySchemaSql,
+  classifyAfterDeployState,
+  parseD1Rows
+} from "../../../scripts/release/after-deploy-state.mjs";
+
+const migrationsDirectory = resolve(import.meta.dirname, "../../../migrations");
+const afterDeployMigrationsDirectory = resolve(
+  import.meta.dirname,
+  "../../../migrations-after-deploy"
+);
+const databases = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+describe("after-deploy state inspection", () => {
+  it("recognizes only the exact S0, S1, S2, and S3 ledger and schema pairs", async () => {
+    const database = createDatabase();
+    const normal = await readD1Migrations(migrationsDirectory);
+    const afterDeploy = await readD1Migrations(afterDeployMigrationsDirectory);
+    for (const migration of normal) applyMigration(database, migration, "d1_migrations");
+
+    expect(classify(database, normal, false)).toMatchObject({
+      phase: "S0",
+      repairRequired: true
+    });
+    createAfterDeployLedger(database);
+    expect(classify(database, normal, true)).toMatchObject({
+      phase: "S0",
+      repairRequired: true
+    });
+
+    for (const [index, migration] of afterDeploy.entries()) {
+      applyMigration(database, migration, "d1_migrations_after_deploy");
+      expect(classify(database, normal, true)).toMatchObject({
+        phase: `S${index + 1}`,
+        repairRequired: index + 1 < afterDeploy.length
+      });
+    }
+  });
+
+  it("fails closed when a ledger is incomplete, out of order, or unlike the live schema", async () => {
+    const database = createDatabase();
+    const normal = await readD1Migrations(migrationsDirectory);
+    for (const migration of normal) applyMigration(database, migration, "d1_migrations");
+    const schemaItems = inspectSchema(database);
+    const normalNames = normal.map(({ name }) => name);
+
+    expect(() =>
+      classifyAfterDeployState({
+        appliedAfterDeployMigrations: [],
+        expectedNormalMigrations: normalNames,
+        hasAfterDeployLedger: false,
+        normalMigrations: normalNames.slice(0, -1),
+        schemaItems
+      })
+    ).toThrow("normal migration ledger is not complete");
+    expect(() =>
+      classifyAfterDeployState({
+        appliedAfterDeployMigrations: ["0002_finalize_agent_principals.sql"],
+        expectedNormalMigrations: normalNames,
+        hasAfterDeployLedger: true,
+        normalMigrations: normalNames,
+        schemaItems: [...schemaItems, "table:d1_migrations_after_deploy"]
+      })
+    ).toThrow("after-deploy migration ledger is not an exact prefix");
+    expect(() =>
+      classifyAfterDeployState({
+        appliedAfterDeployMigrations: [],
+        expectedNormalMigrations: normalNames,
+        hasAfterDeployLedger: false,
+        normalMigrations: normalNames,
+        schemaItems: schemaItems.filter((item) => item !== "column:drafts.user_id")
+      })
+    ).toThrow("migration ledger and the live schema do not match");
+    expect(() =>
+      classifyAfterDeployState({
+        appliedAfterDeployMigrations: [],
+        expectedNormalMigrations: normalNames,
+        hasAfterDeployLedger: false,
+        normalMigrations: normalNames,
+        pendingUpdates: [{}, {}],
+        schemaItems
+      })
+    ).toThrow("More than one update is pending");
+  });
+
+  it("accepts Wrangler D1 JSON wrappers and rejects output without result rows", () => {
+    expect(parseD1Rows(JSON.stringify([{ results: [{ name: "0001.sql" }] }]))).toEqual([
+      { name: "0001.sql" }
+    ]);
+    expect(
+      parseD1Rows(JSON.stringify({ result: [{ results: [{ item: "table:drafts" }] }] }))
+    ).toEqual([{ item: "table:drafts" }]);
+    expect(() => parseD1Rows("{}")).toThrow("no D1 inspection results");
+  });
+});
+
+function createDatabase() {
+  const database = new DatabaseSync(":memory:");
+  database.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE d1_migrations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+  databases.push(database);
+  return database;
+}
+
+function createAfterDeployLedger(database) {
+  database.exec(`
+    CREATE TABLE d1_migrations_after_deploy (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+}
+
+function applyMigration(database, migration, table) {
+  database.exec("BEGIN");
+  try {
+    for (const query of migration.queries) database.exec(query);
+    database.prepare(`INSERT INTO ${table} (name) VALUES (?)`).run(migration.name);
+    database.exec("COMMIT");
+  } catch (error) {
+    database.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+function classify(database, normal, hasAfterDeployLedger) {
+  return classifyAfterDeployState({
+    appliedAfterDeployMigrations: hasAfterDeployLedger
+      ? database
+          .prepare("SELECT name FROM d1_migrations_after_deploy ORDER BY id")
+          .all()
+          .map(({ name }) => name)
+      : [],
+    expectedNormalMigrations: normal.map(({ name }) => name),
+    hasAfterDeployLedger,
+    normalMigrations: database
+      .prepare("SELECT name FROM d1_migrations ORDER BY id")
+      .all()
+      .map(({ name }) => name),
+    schemaItems: inspectSchema(database)
+  });
+}
+
+function inspectSchema(database) {
+  return database
+    .prepare(afterDeploySchemaSql)
+    .all()
+    .map(({ item }) => item);
+}

--- a/test/unit/scripts/bootstrap.test.mjs
+++ b/test/unit/scripts/bootstrap.test.mjs
@@ -90,6 +90,7 @@ describe("signed release bootstrap", () => {
           configFile,
           expectedVersion: version,
           manifestFile,
+          platform: "linux",
           publicKeyBase64: release.publicKeyBase64,
           run: (command, args, options) => {
             commands.push({ command, args, options });

--- a/test/unit/scripts/bootstrap.test.mjs
+++ b/test/unit/scripts/bootstrap.test.mjs
@@ -1,0 +1,215 @@
+import { createHash, generateKeyPairSync, sign } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { bootstrap, verifyBootstrapManifest } from "../../../scripts/release/bootstrap.mjs";
+import { verifyManifest } from "../../../scripts/release/manifest.mjs";
+
+const version = "1.3.3";
+const sourceCommit = "a".repeat(40);
+
+function signedRelease(artifact = Buffer.from("signed release")) {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const manifest = {
+    format: "hqbase-release-v1",
+    product: "hqbase",
+    channel: "stable",
+    version,
+    schemaVersion: 3,
+    minVersion: "1.0.0",
+    publishedAt: "2026-09-01T04:00:00.000Z",
+    notes: [],
+    notesUrl: `https://github.com/HQBase/hqbase/releases/tag/v${version}`,
+    artifact: {
+      url: `https://github.com/HQBase/hqbase/releases/download/v${version}/hqbase-${version}.tar.gz`,
+      sha256: createHash("sha256").update(artifact).digest("hex"),
+      size: artifact.length
+    },
+    updater: {
+      protocol: 2,
+      sourceUrl: `https://raw.githubusercontent.com/HQBase/hqbase/${sourceCommit}/scripts/release/bootstrap.mjs`,
+      sha256: "b".repeat(64),
+      size: 123
+    },
+    keyId: "hqbase-release-2026-01"
+  };
+  const payload = Buffer.from(JSON.stringify(manifest)).toString("base64url");
+  const envelope = {
+    payload,
+    signature: sign(null, Buffer.from(payload, "base64url"), privateKey).toString("base64url")
+  };
+  return {
+    artifact,
+    envelope,
+    manifest,
+    publicKeyBase64: publicKey.export({ type: "spki", format: "der" }).toString("base64")
+  };
+}
+
+describe("signed release bootstrap", () => {
+  it("downloads the immutable manifest for the exact expected version", async () => {
+    const release = signedRelease();
+    const urls = [];
+    let deployedConfig;
+    await bootstrap({
+      expectedVersion: version,
+      publicKeyBase64: release.publicKeyBase64,
+      fetcher: async (url) => {
+        urls.push(String(url));
+        return urls.length === 1
+          ? new Response(JSON.stringify(release.envelope))
+          : new Response(release.artifact);
+      },
+      run: (command, args) => {
+        if (command === process.execPath) deployedConfig = args.at(-1);
+      }
+    });
+    expect(urls).toEqual([
+      `https://github.com/HQBase/hqbase/releases/download/v${version}/manifest-${version}.json`,
+      release.manifest.artifact.url
+    ]);
+    expect(deployedConfig).toBe(resolve("wrangler.jsonc"));
+  });
+
+  it("passes verified local release files and the exact customer config to the release updater", async () => {
+    const workspace = mkdtempSync(resolve(tmpdir(), "hqbase-bootstrap-test-"));
+    const release = signedRelease();
+    const manifestFile = resolve(workspace, "manifest.json");
+    const artifactFile = resolve(workspace, "release.tar.gz");
+    const configFile = resolve(workspace, "customer", "wrangler.jsonc");
+    writeFileSync(manifestFile, JSON.stringify(release.envelope));
+    writeFileSync(artifactFile, release.artifact);
+    const commands = [];
+
+    try {
+      await expect(
+        bootstrap({
+          artifactFile,
+          configFile,
+          expectedVersion: version,
+          manifestFile,
+          publicKeyBase64: release.publicKeyBase64,
+          run: (command, args, options) => {
+            commands.push({ command, args, options });
+            if (command !== process.execPath) return;
+            expect(args.slice(-2)).toEqual(["--config", configFile]);
+            expect(options.env.HQBASE_EXPECTED_RELEASE_VERSION).toBe(version);
+            expect(existsSync(options.env.HQBASE_RELEASE_ARTIFACT_FILE)).toBe(true);
+            expect(
+              JSON.parse(readFileSync(options.env.HQBASE_RELEASE_MANIFEST_FILE, "utf8"))
+            ).toEqual(release.envelope);
+          }
+        })
+      ).resolves.toEqual({ version });
+      expect(commands.map(({ command }) => command)).toEqual(["tar", process.execPath]);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("installs frozen dependencies before importing the extracted updater on Windows", async () => {
+    const release = signedRelease();
+    const commands = [];
+
+    await bootstrap({
+      expectedVersion: version,
+      fetcher: async (url) =>
+        String(url).includes("manifest-")
+          ? new Response(JSON.stringify(release.envelope))
+          : new Response(release.artifact),
+      platform: "win32",
+      publicKeyBase64: release.publicKeyBase64,
+      run: (command, args, options) => commands.push({ command, args, options }),
+      windowsShell: "C:\\Windows\\System32\\cmd.exe"
+    });
+
+    expect(commands.map(({ command }) => command)).toEqual([
+      "tar",
+      "C:\\Windows\\System32\\cmd.exe",
+      process.execPath
+    ]);
+    expect(commands[1]?.args).toEqual(["/d", "/s", "/c", "pnpm install --frozen-lockfile"]);
+    expect(commands[1]?.options.cwd).toBe(commands[2]?.options.cwd);
+  });
+
+  it("rejects a wrong version and tampered release bytes before it runs commands", async () => {
+    const workspace = mkdtempSync(resolve(tmpdir(), "hqbase-bootstrap-test-"));
+    const release = signedRelease();
+    const manifestFile = resolve(workspace, "manifest.json");
+    const artifactFile = resolve(workspace, "release.tar.gz");
+    writeFileSync(manifestFile, JSON.stringify(release.envelope));
+    writeFileSync(artifactFile, release.artifact);
+    let commandCount = 0;
+    const options = {
+      artifactFile,
+      manifestFile,
+      publicKeyBase64: release.publicKeyBase64,
+      run: () => {
+        commandCount += 1;
+      }
+    };
+
+    try {
+      await expect(bootstrap({ ...options, expectedVersion: "1.3.4" })).rejects.toThrow(
+        "Expected signed HQBase 1.3.4"
+      );
+      writeFileSync(artifactFile, "tampered");
+      await expect(bootstrap({ ...options, expectedVersion: version })).rejects.toThrow(
+        "artifact integrity"
+      );
+      expect(commandCount).toBe(0);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("requires signed protocol-2 updater metadata while old deployment verification stays compatible", () => {
+    const release = signedRelease();
+    expect(
+      verifyBootstrapManifest(release.envelope, version, release.publicKeyBase64)
+    ).toMatchObject({ updater: { protocol: 2, size: 123 } });
+    const invalidSignature = `${release.envelope.signature.startsWith("A") ? "B" : "A"}${release.envelope.signature.slice(1)}`;
+    expect(() =>
+      verifyBootstrapManifest(
+        { ...release.envelope, signature: invalidSignature },
+        version,
+        release.publicKeyBase64
+      )
+    ).toThrow("signature");
+    expect(verifyManifest(release.envelope, release.publicKeyBase64)).toMatchObject({ version });
+
+    const legacyManifest = { ...release.manifest };
+    delete legacyManifest.updater;
+    const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+    const legacyPayload = Buffer.from(JSON.stringify(legacyManifest)).toString("base64url");
+    const legacyEnvelope = {
+      payload: legacyPayload,
+      signature: sign(null, Buffer.from(legacyPayload, "base64url"), privateKey).toString(
+        "base64url"
+      )
+    };
+    const legacyKey = publicKey.export({ type: "spki", format: "der" }).toString("base64");
+    expect(verifyManifest(legacyEnvelope, legacyKey)).toMatchObject({ version });
+    expect(() => verifyBootstrapManifest(legacyEnvelope, version, legacyKey)).toThrow(
+      "managed updater"
+    );
+  });
+
+  it("packages bootstrap bytes from the exact Git commit named by signed metadata", () => {
+    const sourceCommitPlaceholder = ["$", "{sourceCommit}"].join("");
+    const source = readFileSync(
+      new URL("../../../scripts/release/package.mjs", import.meta.url),
+      "utf8"
+    );
+    expect(source).toContain(
+      `["show", \`${sourceCommitPlaceholder}:scripts/release/bootstrap.mjs\`]`
+    );
+    expect(source).toContain(
+      `https://raw.githubusercontent.com/HQBase/hqbase/${sourceCommitPlaceholder}/scripts/release/bootstrap.mjs`
+    );
+    expect(source).toContain('createHash("sha256").update(updaterBytes).digest("hex")');
+    expect(source).toContain("size: updaterBytes.length");
+  });
+});

--- a/test/unit/scripts/bootstrap.test.mjs
+++ b/test/unit/scripts/bootstrap.test.mjs
@@ -2,13 +2,15 @@ import { createHash, generateKeyPairSync, sign } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { bootstrap, verifyBootstrapManifest } from "../../../scripts/release/bootstrap.mjs";
 import { verifyManifest } from "../../../scripts/release/manifest.mjs";
 
 const version = "1.3.3";
 const sourceCommit = "a".repeat(40);
+
+afterEach(() => vi.unstubAllEnvs());
 
 function signedRelease(artifact = Buffer.from("signed release")) {
   const { privateKey, publicKey } = generateKeyPairSync("ed25519");
@@ -53,8 +55,10 @@ describe("signed release bootstrap", () => {
     const release = signedRelease();
     const urls = [];
     let deployedConfig;
+    vi.stubEnv("HQBASE_UPDATER_CONFIG_FILE", "  ");
     await bootstrap({
       expectedVersion: version,
+      platform: "linux",
       publicKeyBase64: release.publicKeyBase64,
       fetcher: async (url) => {
         urls.push(String(url));
@@ -113,6 +117,7 @@ describe("signed release bootstrap", () => {
   it("installs frozen dependencies before importing the extracted updater on Windows", async () => {
     const release = signedRelease();
     const commands = [];
+    vi.stubEnv("SystemRoot", "C:\\Windows");
 
     await bootstrap({
       expectedVersion: version,
@@ -127,7 +132,7 @@ describe("signed release bootstrap", () => {
     });
 
     expect(commands.map(({ command }) => command)).toEqual([
-      "tar",
+      "C:\\Windows\\System32\\tar.exe",
       "C:\\Windows\\System32\\cmd.exe",
       process.execPath
     ]);

--- a/test/unit/scripts/d1-migrations.test.mjs
+++ b/test/unit/scripts/d1-migrations.test.mjs
@@ -2,7 +2,6 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, resolve } from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
 
 import { applyLocalMigrations, applyMigrationPhase } from "../../../scripts/d1-migrations.mjs";
@@ -135,91 +134,166 @@ describe("two-phase D1 migrations", () => {
     expect(cleanupMigrationSource).toContain("installed_schema_version = 3");
   });
 
-  it("verifies the latest pending retry when a newer update is already verified", () => {
+  it("creates a fresh checkpoint and a distinct same-version history row before repair", () => {
     const commands = [];
-    let bookkeepingSql;
+    const recovery = [];
+    const sql = [];
+
+    const result = completeActiveReleaseRetry(
+      "/release",
+      { schemaVersion: 16, version: "1.2.3" },
+      () => commands.push("record-worker"),
+      {
+        activeRelease: { versionId: "worker-current" },
+        afterDeployState: { phase: "S0", pendingUpdate: null },
+        applyMigrationPhase: (cwd, phase, options) =>
+          commands.push(`migrate:${cwd}:${phase}:${options.target}`),
+        configFile: "/customer/wrangler.jsonc",
+        createRecoveryBookmark: () => {
+          commands.push("checkpoint");
+          return "bookmark-fresh";
+        },
+        executeSql: (cwd, statement) => {
+          commands.push(`sql:${cwd}`);
+          sql.push(statement);
+        },
+        onRecovery: (checkpoint) => recovery.push(checkpoint),
+        randomUUID: () => "repair-update",
+        workerName: "hqbase"
+      }
+    );
+
+    expect(commands).toEqual([
+      "checkpoint",
+      "sql:/release",
+      "record-worker",
+      "migrate:/release:normal:remote",
+      "migrate:/release:after-deploy:remote",
+      "sql:/release"
+    ]);
+    expect(sql[0]).toContain(
+      "VALUES ('repair-update', '1.2.3', '1.2.3', 'bookmark-fresh', 'worker-current', 'started'"
+    );
+    expect(sql[1]).toContain("WHERE id = 'repair-update' AND state IN ('started', 'deployed')");
+    expect(sql[1]).not.toContain("SELECT id FROM update_history");
+    expect(recovery).toHaveLength(1);
+    expect(recovery[0]).toMatchObject({
+      bookmark: "bookmark-fresh",
+      cleanupComplete: true,
+      configFile: "/customer/wrangler.jsonc",
+      name: "hqbase",
+      workerVersion: "worker-current"
+    });
+    expect(result).toEqual({ phase: "S0", repaired: true, workerRecorded: true });
+  });
+
+  it.each(["S1", "S2"])("resumes the exact pending %s repair row", (phase) => {
+    const commands = [];
+    const sql = [];
+    const checkpoint = vi.fn();
 
     completeActiveReleaseRetry(
       "/release",
       { schemaVersion: 16, version: "1.2.3" },
       () => commands.push("record-worker"),
       {
-        applyMigrationPhase: (cwd, phase, options) =>
-          commands.push(`migrate:${cwd}:${phase}:${options.target}`),
-        executeSql: (cwd, sql) => {
-          commands.push(`bookkeeping:${cwd}`);
-          bookkeepingSql = sql;
-        }
+        activeRelease: { versionId: "worker-current" },
+        afterDeployState: {
+          phase,
+          pendingUpdate: {
+            checkpoint_bookmark: "bookmark-original",
+            from_version: "1.2.3",
+            id: "repair-original",
+            state: "started",
+            to_version: "1.2.3",
+            worker_version: "worker-original"
+          }
+        },
+        applyMigrationPhase: (cwd, migrationPhase, options) =>
+          commands.push(`migrate:${cwd}:${migrationPhase}:${options.target}`),
+        createRecoveryBookmark: checkpoint,
+        executeSql: (_cwd, statement) => sql.push(statement)
       }
     );
 
+    expect(checkpoint).not.toHaveBeenCalled();
     expect(commands).toEqual([
       "record-worker",
       "migrate:/release:normal:remote",
-      "migrate:/release:after-deploy:remote",
-      "bookkeeping:/release"
+      "migrate:/release:after-deploy:remote"
     ]);
-    expect(bookkeepingSql).toContain(
-      "UPDATE release_state SET installed_version = '1.2.3', installed_schema_version = 16"
-    );
-    expect(bookkeepingSql).toContain(
-      "UPDATE update_history SET state = 'verified', completed_at = datetime('now')"
-    );
-    expect(bookkeepingSql).toContain(
-      "WHERE state IN ('started', 'deployed') AND id = (SELECT id FROM update_history WHERE to_version = '1.2.3' AND state IN ('started', 'deployed')"
-    );
-    expect(bookkeepingSql).toContain("ORDER BY started_at DESC, rowid DESC LIMIT 1");
+    expect(sql).toHaveLength(1);
+    expect(sql[0]).toContain("WHERE id = 'repair-original'");
+  });
 
-    const database = new DatabaseSync(":memory:");
-    try {
-      database.exec(`
-        CREATE TABLE release_state (
-          singleton INTEGER PRIMARY KEY,
-          installed_version TEXT NOT NULL,
-          installed_schema_version INTEGER NOT NULL,
-          updated_at TEXT NOT NULL
-        );
-        INSERT INTO release_state VALUES (1, '1.2.2', 15, 'before');
-        CREATE TABLE update_history (
-          id TEXT PRIMARY KEY,
-          to_version TEXT NOT NULL,
-          state TEXT NOT NULL,
-          started_at TEXT NOT NULL,
-          completed_at TEXT
-        );
-        INSERT INTO update_history VALUES
-          ('older-target', '1.2.3', 'started', '2026-08-23 10:00:00', NULL),
-          ('latest-target', '1.2.3', 'verified', '2026-08-23 11:00:00', '2026-08-23 11:01:00'),
-          ('other-target', '1.2.4', 'started', '2026-08-23 12:00:00', NULL);
-      `);
+  it("leaves a complete S3 database unchanged and finalizes only its pending repair row", () => {
+    const recordWorker = vi.fn();
+    const migrate = vi.fn();
+    const execute = vi.fn();
+    const complete = { phase: "S3", pendingUpdate: null };
 
-      database.exec(bookkeepingSql);
-      expect(
-        database
-          .prepare(
-            "SELECT installed_version, installed_schema_version FROM release_state WHERE singleton = 1"
-          )
-          .get()
-      ).toEqual({ installed_schema_version: 16, installed_version: "1.2.3" });
-      expect(
-        database.prepare("SELECT id, state FROM update_history ORDER BY started_at").all()
-      ).toEqual([
-        { id: "older-target", state: "verified" },
-        { id: "latest-target", state: "verified" },
-        { id: "other-target", state: "started" }
-      ]);
+    expect(
+      completeActiveReleaseRetry(
+        "/release",
+        { schemaVersion: 16, version: "1.2.3" },
+        recordWorker,
+        {
+          afterDeployState: complete,
+          applyMigrationPhase: migrate,
+          executeSql: execute
+        }
+      )
+    ).toEqual({ phase: "S3", repaired: false, workerRecorded: false });
+    expect(recordWorker).not.toHaveBeenCalled();
+    expect(migrate).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
 
-      database.exec(bookkeepingSql);
-      expect(
-        database.prepare("SELECT id, state FROM update_history ORDER BY started_at").all()
-      ).toEqual([
-        { id: "older-target", state: "verified" },
-        { id: "latest-target", state: "verified" },
-        { id: "other-target", state: "started" }
-      ]);
-    } finally {
-      database.close();
-    }
+    completeActiveReleaseRetry("/release", { schemaVersion: 16, version: "1.2.3" }, recordWorker, {
+      afterDeployState: {
+        phase: "S3",
+        pendingUpdate: {
+          checkpoint_bookmark: "bookmark-original",
+          from_version: "1.2.3",
+          id: "repair-original",
+          state: "started",
+          to_version: "1.2.3",
+          worker_version: "worker-original"
+        }
+      },
+      applyMigrationPhase: migrate,
+      executeSql: execute
+    });
+    expect(recordWorker).toHaveBeenCalledOnce();
+    expect(migrate).not.toHaveBeenCalled();
+    expect(execute).toHaveBeenCalledOnce();
+    expect(execute.mock.calls[0][1]).toContain("WHERE id = 'repair-original'");
+  });
+
+  it("does not mutate anything when state inspection fails", () => {
+    const recordWorker = vi.fn();
+    const migrate = vi.fn();
+    const execute = vi.fn();
+    const checkpoint = vi.fn();
+
+    expect(() =>
+      completeActiveReleaseRetry(
+        "/release",
+        { schemaVersion: 16, version: "1.2.3" },
+        recordWorker,
+        {
+          applyMigrationPhase: migrate,
+          createRecoveryBookmark: checkpoint,
+          executeSql: execute,
+          inspectAfterDeployState: () => {
+            throw new Error("inconsistent post-deploy state");
+          }
+        }
+      )
+    ).toThrow("inconsistent post-deploy state");
+    expect(recordWorker).not.toHaveBeenCalled();
+    expect(migrate).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+    expect(checkpoint).not.toHaveBeenCalled();
   });
 
   it("orders each remote phase around the active Worker cutover", () => {
@@ -239,7 +313,7 @@ describe("two-phase D1 migrations", () => {
       "const bookmark = findString"
     );
     expectOrder(retry, [
-      "completeActiveReleaseRetry(source, manifest, recordWorkerDeployed)",
+      "completeActiveReleaseRetry(source, manifest, recordWorkerDeployed, {",
       "console.log(`HQBase"
     ]);
 

--- a/test/unit/scripts/deploy.test.mjs
+++ b/test/unit/scripts/deploy.test.mjs
@@ -28,9 +28,23 @@ import {
   assertRequiredWorkerConfig,
   prepareRequiredWorkerConfig
 } from "../../../scripts/release/prepare-worker-config.mjs";
+import {
+  encodeVapidPrivateKey,
+  generateVapidKeys
+} from "../../../scripts/release/worker-deploy.mjs";
 import { foreignTrustees } from "../../../scripts/secure-directory.mjs";
 
 describe("HQBase release deployment", () => {
+  it("generates a standard P-256 VAPID key pair without package dependencies", () => {
+    const keys = generateVapidKeys();
+    expect(Buffer.from(keys.publicKey, "base64url")).toHaveLength(65);
+    expect(Buffer.from(keys.privateKey, "base64url")).toHaveLength(32);
+    expect(Buffer.from(keys.publicKey, "base64url")[0]).toBe(4);
+    expect(Buffer.from(encodeVapidPrivateKey(Buffer.alloc(31, 1)), "base64url")).toEqual(
+      Buffer.concat([Buffer.alloc(1), Buffer.alloc(31, 1)])
+    );
+  });
+
   it("verifies product-bound manifests", () => {
     const { privateKey, publicKey } = generateKeyPairSync("ed25519");
     const manifest = {

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -114,19 +114,106 @@ describe("staging workflow lifecycle record", () => {
     expect(waitStep).toContain("candidate=$CANDIDATE_VERSION&attempt=$attempt");
   });
 
-  it("runs the previous updater against its own deployment root", () => {
+  it("uses the oldest supported updater for the previous release and candidate", () => {
+    const previousRelease = releaseWorkflow.indexOf(
+      "      - name: Install the previous stable release with the oldest supported updater"
+    );
+    const bootstrapData = releaseWorkflow.indexOf(
+      "      - name: Bootstrap persistent N-1 staging data"
+    );
+    const oauth = releaseWorkflow.indexOf(
+      "      - name: Configure customer OAuth for the candidate"
+    );
+    const legacyConfig = releaseWorkflow.indexOf(
+      "      - name: Reproduce the legacy Worker configuration"
+    );
+    const candidate = releaseWorkflow.indexOf("      - name: Apply the exact signed candidate");
+
+    expect(previousRelease).toBeGreaterThan(-1);
+    expect(bootstrapData).toBeGreaterThan(previousRelease);
+    expect(oauth).toBeGreaterThan(bootstrapData);
+    expect(legacyConfig).toBeGreaterThan(oauth);
+    expect(candidate).toBeGreaterThan(legacyConfig);
+    expect(releaseWorkflow).toContain("OLDEST_UPDATER_TAG: v1.0.0");
+    expect(releaseWorkflow.slice(legacyConfig, candidate)).toContain(
+      "delete config.durable_objects"
+    );
+    expect(releaseWorkflow.slice(legacyConfig, candidate)).toContain("delete config.migrations");
     expect(releaseWorkflow).toContain(
-      'previous_deployment="$previous_source/.hqbase/deployments/$DEPLOYMENT_NAME"'
+      'oldest_deployment="$oldest_source/.hqbase/deployments/$DEPLOYMENT_NAME"'
     );
     expect(releaseWorkflow).toContain(
-      'ln -s "$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME" "$previous_deployment"'
+      'ln -s "$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME" "$oldest_deployment"'
     );
-    expect(releaseWorkflow).toContain('previous_config="$previous_deployment/wrangler.jsonc"');
-    expect(releaseWorkflow).toContain('node "$previous_updater" --config "$previous_config"');
+    expect(releaseWorkflow).toContain('oldest_config="$oldest_deployment/wrangler.jsonc"');
+    expect(releaseWorkflow).toContain('node "$oldest_updater" --config "$oldest_config"');
     expect(releaseWorkflow).toContain(
-      `config="\${HQBASE_PREVIOUS_CONFIG:-$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc}"`
+      'node "$HQBASE_OLDEST_UPDATER" --config "$HQBASE_OLDEST_CONFIG"'
     );
-    expect(releaseWorkflow).toContain('node "$updater" --config "$config"');
+  });
+
+  it("proves the stale state before the canonical repair and its retry", () => {
+    const candidate = releaseWorkflow.indexOf("      - name: Apply the exact signed candidate");
+    const stale = releaseWorkflow.indexOf(
+      "      - name: Verify the candidate restored the binding while the database remained at S0"
+    );
+    const repair = releaseWorkflow.indexOf(
+      "      - name: Finish the candidate through its canonical signed bootstrap"
+    );
+    const final = releaseWorkflow.indexOf(
+      "      - name: Verify exact migration ledgers, final schema, and preserved data"
+    );
+    const retry = releaseWorkflow.indexOf(
+      "      - name: Prove the canonical same-version retry is idempotent"
+    );
+    const bindings = releaseWorkflow.indexOf("      - name: Verify active Worker bindings");
+    const lifecycle = releaseWorkflow.indexOf(
+      "      - name: Verify PWA, app shell, access, and operator lifecycle"
+    );
+    const backup = releaseWorkflow.indexOf(
+      "      - name: Exercise populated remote backup and restore"
+    );
+
+    expect(candidate).toBeGreaterThan(-1);
+    expect(stale).toBeGreaterThan(candidate);
+    expect(repair).toBeGreaterThan(stale);
+    expect(final).toBeGreaterThan(repair);
+    expect(retry).toBeGreaterThan(final);
+    expect(bindings).toBeGreaterThan(retry);
+    expect(lifecycle).toBeGreaterThan(bindings);
+    expect(backup).toBeGreaterThan(lifecycle);
+    expect(releaseWorkflow.slice(stale, repair)).toContain("after_deploy_ledger_table_count:0");
+    expect(releaseWorkflow.slice(stale, repair)).toContain("alias_table_count:2");
+    expect(releaseWorkflow.slice(stale, repair)).toContain("transition_guard_count:11");
+    expect(releaseWorkflow.slice(stale, repair)).toContain('index("MAIL_EVENTS") != null');
+    expect(releaseWorkflow.slice(stale, repair)).toContain("pnpm test:e2e:staging:event-socket");
+    expect(releaseWorkflow.slice(repair, final)).toContain(
+      'node "$GITHUB_WORKSPACE/scripts/release/bootstrap.mjs" --config "$config"'
+    );
+    expect(releaseWorkflow.slice(final, retry)).toContain(
+      "SELECT name FROM d1_migrations ORDER BY id"
+    );
+    expect(releaseWorkflow.slice(final, retry)).toContain(
+      "SELECT name FROM d1_migrations_after_deploy ORDER BY id"
+    );
+    expect(releaseWorkflow.slice(final, retry)).toContain("repair_history_count:1");
+    expect(releaseWorkflow.slice(final, retry)).toContain("PRAGMA foreign_key_check");
+    expect(releaseWorkflow.slice(final, retry)).toContain("hqbase-pre-repair-data.json");
+    expect(releaseWorkflow.slice(retry, bindings)).toContain(
+      'node "$GITHUB_WORKSPACE/scripts/release/bootstrap.mjs" --config "$config"'
+    );
+  });
+
+  it("keeps the customer source checkout unchanged", () => {
+    expect(releaseWorkflow).toContain(
+      "      - name: Verify the customer source checkout starts unchanged"
+    );
+    expect(releaseWorkflow).toContain(
+      "      - name: Verify the customer source checkout stayed unchanged"
+    );
+    expect(releaseWorkflow.match(/git diff --quiet/g)).toHaveLength(2);
+    expect(releaseWorkflow.match(/git diff --cached --quiet/g)).toHaveLength(2);
+    expect(releaseWorkflow.match(/git ls-files --others --exclude-standard/g)).toHaveLength(2);
   });
 
   it("moves the Deploy Button source before publication and verifies the exact commit", () => {
@@ -157,6 +244,13 @@ describe("staging workflow lifecycle record", () => {
     expect(releaseWorkflow).toContain("-F force=true");
     expect(releaseWorkflow).toContain('test "$tag_commit" = "$RELEASE_COMMIT"');
     expect(releaseWorkflow).toContain('test "$deploy_commit" = "$RELEASE_COMMIT"');
+    expect(releaseWorkflow).toContain("manifest.updater?.protocol !== 2");
+    expect(releaseWorkflow).toContain(["manifest-$", '{HQBASE_RELEASE_VERSION}.json"'].join(""));
+    expect(releaseWorkflow).toContain("Published stable and versioned manifests do not match.");
+    expect(releaseWorkflow).toContain("manifest.updater.sourceUrl !== expectedUpdaterUrl");
+    expect(releaseWorkflow).toContain("await fetch(manifest.updater.sourceUrl)");
+    expect(releaseWorkflow).toContain("manifest.updater.sha256");
+    expect(releaseWorkflow).toContain("manifest.updater.size");
     expect(readme).toContain("HQBase%2Fhqbase%2Ftree%2Fdeploy");
   });
 });

--- a/test/unit/worker/features/updates/migration-state.test.ts
+++ b/test/unit/worker/features/updates/migration-state.test.ts
@@ -1,0 +1,161 @@
+import {
+  afterDeployMigrationNames,
+  classifyManagedMigrationState,
+  type ManagedMigrationSnapshot,
+  normalMigrationNames,
+  transitionGuards
+} from "@worker/features/updates/migration-state";
+import { describe, expect, it } from "vitest";
+
+describe("managed update migration state", () => {
+  it.each([
+    [0, "stale", true],
+    [1, "partial", true],
+    [2, "partial", true],
+    [3, "clean", false]
+  ] as const)("accepts the exact S%s migration state", (completed, state, repairRequired) => {
+    expect(classifyManagedMigrationState(snapshot(completed), "1.3.3", 3)).toEqual({
+      completedAfterDeployMigrations: completed,
+      repairRequired,
+      state
+    });
+  });
+
+  it("accepts an empty after-deploy ledger as S0", () => {
+    expect(
+      classifyManagedMigrationState({ ...snapshot(0), afterDeployLedger: [] }, "1.3.3", 3)
+    ).toMatchObject({ completedAfterDeployMigrations: 0, repairRequired: true });
+  });
+
+  it("offers a retry for exact pending bookkeeping after schema cleanup", () => {
+    expect(
+      classifyManagedMigrationState(
+        {
+          ...snapshot(3),
+          pendingUpdates: [pendingUpdate()],
+          releaseState: {
+            channel: "stable",
+            installed_schema_version: 3,
+            installed_version: "1.3.2",
+            product: "hqbase"
+          }
+        },
+        "1.3.3",
+        3
+      )
+    ).toEqual({
+      completedAfterDeployMigrations: 3,
+      repairRequired: true,
+      state: "partial"
+    });
+  });
+
+  it.each([
+    ["an incomplete normal ledger", { normalLedger: normalMigrationNames.slice(0, -1) }],
+    ["a non-prefix after-deploy ledger", { afterDeployLedger: [afterDeployMigrationNames[1]] }],
+    [
+      "a missing ledger with partially cleaned aliases",
+      {
+        afterDeployLedger: null,
+        tables: [],
+        transitionGuards: [],
+        columns: snapshot(1).columns
+      }
+    ],
+    ["a completed ledger with legacy principal columns", { columns: snapshot(1).columns }],
+    ["a completed ledger without the final draft-label foreign key", { draftLabelForeignKeys: [] }]
+  ])("rejects %s", (_label, replacement) => {
+    expect(() =>
+      classifyManagedMigrationState({ ...snapshot(3), ...replacement }, "1.3.3", 3)
+    ).toThrow("HQBASE_MANAGED_MIGRATION_STATE_INVALID");
+  });
+
+  it.each([
+    ["multiple pending rows", { pendingUpdates: [pendingUpdate(), pendingUpdate("second")] }],
+    [
+      "a malformed pending row",
+      { pendingUpdates: [{ ...pendingUpdate(), checkpoint_bookmark: "" }] }
+    ],
+    [
+      "a release marker for an unrelated version",
+      {
+        pendingUpdates: [pendingUpdate()],
+        releaseState: {
+          channel: "stable",
+          installed_schema_version: 3,
+          installed_version: "1.2.0",
+          product: "hqbase"
+        }
+      }
+    ],
+    [
+      "a clean release with a stale schema marker",
+      {
+        releaseState: {
+          channel: "stable",
+          installed_schema_version: 2,
+          installed_version: "1.3.3",
+          product: "hqbase"
+        }
+      }
+    ]
+  ])("rejects %s", (_label, replacement) => {
+    expect(() =>
+      classifyManagedMigrationState({ ...snapshot(3), ...replacement }, "1.3.3", 3)
+    ).toThrow("HQBASE_MANAGED_MIGRATION_STATE_INVALID");
+  });
+});
+
+function snapshot(completed: 0 | 1 | 2 | 3): ManagedMigrationSnapshot {
+  const aliasesAreLegacy = completed === 0;
+  const principalsAreLegacy = completed < 2;
+  return {
+    afterDeployLedger: completed === 0 ? null : [...afterDeployMigrationNames.slice(0, completed)],
+    columns: {
+      draft_changes: ["sequence", "principal_id", ...(principalsAreLegacy ? ["user_id"] : [])],
+      drafts: ["id", "principal_id", ...(principalsAreLegacy ? ["user_id"] : [])],
+      mailbox_grants: [
+        "mailbox_id",
+        "principal_id",
+        ...(principalsAreLegacy ? ["created_by", "user_id"] : [])
+      ],
+      messages: [
+        "id",
+        "delivered_to_address",
+        ...(aliasesAreLegacy ? ["delivered_to_address_id", "sent_from_address_id"] : [])
+      ]
+    },
+    draftLabelForeignKeys:
+      completed === 3
+        ? [
+            {
+              from: "draft_id",
+              on_delete: "CASCADE",
+              table: "drafts",
+              to: "id"
+            }
+          ]
+        : [],
+    normalLedger: [...normalMigrationNames],
+    pendingUpdates: [],
+    releaseState: {
+      channel: "stable",
+      installed_schema_version: 3,
+      installed_version: "1.3.3",
+      product: "hqbase"
+    },
+    tables: aliasesAreLegacy ? ["mailbox_address_migration", "mailbox_addresses"] : [],
+    transitionGuards: aliasesAreLegacy ? [...transitionGuards] : []
+  };
+}
+
+function pendingUpdate(id = "repair-update") {
+  return {
+    checkpoint_bookmark: "bookmark-before-update",
+    from_version: "1.3.2",
+    id,
+    state: "started",
+    to_version: "1.3.3",
+    worker_version: "worker-before-update"
+  };
+}

--- a/test/unit/worker/features/updates/service.test.ts
+++ b/test/unit/worker/features/updates/service.test.ts
@@ -1,10 +1,27 @@
 import { generateKeyPairSync, sign } from "node:crypto";
-import { compareVersions, getUpdateStatus, triggerUpdate } from "@worker/features/updates/service";
+import {
+  afterDeployMigrationNames,
+  normalMigrationNames,
+  transitionGuards
+} from "@worker/features/updates/migration-state";
+import {
+  compareVersions,
+  getUpdateStatus,
+  isManagedDeployCommand,
+  managedDeployCommand,
+  triggerUpdate
+} from "@worker/features/updates/service";
 import type { WorkerEnv } from "@worker/lib/env";
 import { describe, expect, it, vi } from "vitest";
 
 const { privateKey, publicKey } = generateKeyPairSync("ed25519");
 const publicKeyBase64 = publicKey.export({ type: "spki", format: "der" }).toString("base64");
+const updater = {
+  protocol: 2 as const,
+  sourceUrl: `https://raw.githubusercontent.com/HQBase/hqbase/${"a".repeat(40)}/scripts/release/bootstrap.mjs`,
+  sha256: "b".repeat(64),
+  size: 1234
+};
 const payload = Buffer.from(
   JSON.stringify({
     format: "hqbase-release-v1",
@@ -21,6 +38,7 @@ const payload = Buffer.from(
       sha256: "0".repeat(64),
       size: 0
     },
+    updater,
     keyId: "hqbase-release-2026-01"
   })
 ).toString("base64url");
@@ -31,19 +49,27 @@ const envelope = {
 
 describe("HQBase updates", () => {
   it("verifies signed manifests", async () => {
-    const status = await getUpdateStatus(
-      { HQBASE_RELEASE_PUBLIC_KEY: publicKeyBase64 } as WorkerEnv,
-      async () => Response.json(envelope)
-    );
+    const environment = updateEnvironment("0.1.1");
+    const status = await getUpdateStatus(environment, async () => Response.json(envelope));
     expect(status).toMatchObject({
       product: "hqbase",
       installedVersion: "0.1.1",
       installedSchemaVersion: 3,
       available: false,
-      compatible: true
+      compatible: true,
+      repairRequired: false
     });
     expect(status.release.notes).toEqual(["Add a signed changelog."]);
     expect(compareVersions("0.2.0", "0.1.9")).toBeGreaterThan(0);
+  });
+  it("does not require the current release ledger before a supported older version updates", async () => {
+    const environment = updateEnvironment("0.0.9");
+    const prepare = vi.spyOn(environment.DB, "prepare");
+
+    await expect(
+      getUpdateStatus(environment, async () => Response.json(envelope))
+    ).resolves.toMatchObject({ available: true, repairRequired: false });
+    expect(prepare).not.toHaveBeenCalled();
   });
   it("rejects a tampered manifest", async () => {
     const replacement = envelope.signature.startsWith("A") ? "B" : "A";
@@ -71,6 +97,55 @@ describe("HQBase updates", () => {
       JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.1.0" } })
     ]);
     expect(fetcher.mock.calls.some(([, init]) => init?.method === "DELETE")).toBe(false);
+    const commandRequests = fetcher.mock.calls.filter(
+      ([input, init]) =>
+        String(input).endsWith("/builds/triggers/trigger") && init?.method === "PATCH"
+    );
+    expect(commandRequests.map(([, init]) => init?.body)).toEqual([
+      JSON.stringify({ deploy_command: managedDeployCommand(updater) })
+    ]);
+  });
+  it("offers and starts an authorized repair for the already active signed release", async () => {
+    const environment = updateEnvironment("0.1.0", 0);
+    const fetcher = cloudflareUpdateFetcher();
+
+    await expect(getUpdateStatus(environment, fetcher as typeof fetch)).resolves.toMatchObject({
+      available: true,
+      repairRequired: true,
+      release: { version: "0.1.0" }
+    });
+    await expect(
+      triggerUpdate(
+        environment,
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).resolves.toEqual({ buildId: "build-id", status: "queued" });
+  });
+  it("offers a retry when schema cleanup finished but bookkeeping is pending", async () => {
+    const environment = updateEnvironment("0.1.0", 3, true);
+
+    await expect(
+      getUpdateStatus(environment, cloudflareUpdateFetcher() as typeof fetch)
+    ).resolves.toMatchObject({
+      available: true,
+      repairRequired: true,
+      release: { version: "0.1.0" }
+    });
+  });
+  it("accepts only the exact canonical updater command", () => {
+    const command = managedDeployCommand(updater);
+    const previousReleaseCommand = managedDeployCommand({
+      ...updater,
+      sha256: "c".repeat(64)
+    });
+    expect(isManagedDeployCommand(command)).toBe(true);
+    expect(isManagedDeployCommand(previousReleaseCommand)).toBe(true);
+    expect(isManagedDeployCommand(`${command} && pnpm deploy`)).toBe(false);
+    expect(
+      isManagedDeployCommand(command.replace("HQBase updater verification failed.", "skip"))
+    ).toBe(false);
   });
   it("rejects an overlapping update before it can replace the shared release pin", async () => {
     let firstPinStarted: (() => void) | undefined;
@@ -309,6 +384,14 @@ describe("HQBase updates", () => {
       JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.1.0" } }),
       JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.0.8" } })
     ]);
+    const commandRequests = fetcher.mock.calls.filter(
+      ([input, init]) =>
+        String(input).endsWith("/builds/triggers/trigger") && init?.method === "PATCH"
+    );
+    expect(commandRequests.map(([, init]) => init?.body)).toEqual([
+      JSON.stringify({ deploy_command: managedDeployCommand(updater) }),
+      JSON.stringify({ deploy_command: "pnpm deploy" })
+    ]);
   });
   it("removes a new release pin when the build does not start", async () => {
     const fetcher = cloudflareUpdateFetcher({ buildFails: true });
@@ -329,7 +412,7 @@ describe("HQBase updates", () => {
       )
     ).toBe(true);
   });
-  it("preserves the build error when release pin rollback fails", async () => {
+  it("reports an incomplete build-configuration rollback", async () => {
     const fetcher = cloudflareUpdateFetcher({
       buildFails: true,
       rollbackFails: true,
@@ -345,16 +428,33 @@ describe("HQBase updates", () => {
         "0.1.0",
         fetcher as typeof fetch
       )
-    ).rejects.toThrow("Build could not start");
+    ).rejects.toMatchObject({ code: "UPDATE_TRIGGER_ROLLBACK_FAILED", status: 502 });
+    const commandRequests = fetcher.mock.calls.filter(
+      ([input, init]) =>
+        String(input).endsWith("/builds/triggers/trigger") && init?.method === "PATCH"
+    );
+    expect(commandRequests.map(([, init]) => init?.body)).toEqual([
+      JSON.stringify({ deploy_command: managedDeployCommand(updater) })
+    ]);
   });
 });
 
-function updateEnvironment(): WorkerEnv {
+function updateEnvironment(
+  installedVersion = "0.0.9",
+  migrationStage: 0 | 3 = 3,
+  pendingBookkeeping = false
+): WorkerEnv {
   const raw = vi.fn().mockResolvedValue([[JSON.stringify("mail.example.com")]]);
   let lockValue: string | null = null;
   const db = {
     prepare: vi.fn((query: string) => ({
+      all: vi.fn(async () =>
+        migrationQueryResult(query, migrationStage, installedVersion, pendingBookkeeping)
+      ),
       bind: vi.fn((...values: unknown[]) => ({
+        all: vi.fn(async () =>
+          migrationQueryResult(query, migrationStage, installedVersion, pendingBookkeeping, values)
+        ),
         first: vi.fn(async () => {
           if (!query.includes("INSERT INTO app_settings")) return null;
           if (lockValue) return null;
@@ -373,10 +473,104 @@ function updateEnvironment(): WorkerEnv {
   } as unknown as D1Database;
   return {
     DB: db,
-    HQBASE_APP_VERSION: "0.0.9",
+    HQBASE_APP_VERSION: installedVersion,
     HQBASE_RELEASE_PUBLIC_KEY: publicKeyBase64,
     HQBASE_WORKER_NAME: "hqbase"
   } as WorkerEnv;
+}
+
+function migrationQueryResult(
+  query: string,
+  stage: 0 | 3,
+  installedVersion: string,
+  pendingBookkeeping: boolean,
+  values: unknown[] = []
+): { results: unknown[] } {
+  if (query.includes("FROM sqlite_schema")) {
+    return {
+      results: [
+        { name: "d1_migrations", type: "table" },
+        ...(stage === 3
+          ? [{ name: "d1_migrations_after_deploy", type: "table" }]
+          : [
+              { name: "mailbox_address_migration", type: "table" },
+              { name: "mailbox_addresses", type: "table" },
+              ...transitionGuards.map((name) => ({ name, type: "trigger" }))
+            ])
+      ]
+    };
+  }
+  if (query.includes("FROM d1_migrations_after_deploy")) {
+    return { results: afterDeployMigrationNames.map((name) => ({ name })) };
+  }
+  if (query.includes("FROM d1_migrations")) {
+    return { results: normalMigrationNames.map((name) => ({ name })) };
+  }
+  if (query === "PRAGMA table_info(messages)") {
+    return {
+      results: [
+        "id",
+        "delivered_to_address",
+        ...(stage === 0 ? ["delivered_to_address_id", "sent_from_address_id"] : [])
+      ].map((name) => ({ name }))
+    };
+  }
+  if (query === "PRAGMA table_info(mailbox_grants)") {
+    return {
+      results: [
+        "mailbox_id",
+        "principal_id",
+        ...(stage === 0 ? ["created_by", "user_id"] : [])
+      ].map((name) => ({ name }))
+    };
+  }
+  if (query === "PRAGMA table_info(drafts)") {
+    return {
+      results: ["id", "principal_id", ...(stage === 0 ? ["user_id"] : [])].map((name) => ({ name }))
+    };
+  }
+  if (query === "PRAGMA table_info(draft_changes)") {
+    return {
+      results: ["sequence", "principal_id", ...(stage === 0 ? ["user_id"] : [])].map((name) => ({
+        name
+      }))
+    };
+  }
+  if (query === "PRAGMA foreign_key_list(draft_labels)") {
+    return {
+      results:
+        stage === 3 ? [{ from: "draft_id", on_delete: "CASCADE", table: "drafts", to: "id" }] : []
+    };
+  }
+  if (query.includes("FROM release_state")) {
+    return {
+      results: [
+        {
+          channel: "stable",
+          installed_schema_version: 2,
+          installed_version: installedVersion,
+          product: "hqbase"
+        }
+      ]
+    };
+  }
+  if (query.includes("FROM update_history")) {
+    return {
+      results: pendingBookkeeping
+        ? [
+            {
+              checkpoint_bookmark: "bookmark-before-update",
+              from_version: "0.0.9",
+              id: "pending-update",
+              state: "deployed",
+              to_version: String(values[0]),
+              worker_version: "worker-before-update"
+            }
+          ]
+        : []
+    };
+  }
+  return { results: [] };
 }
 
 function cloudflareUpdateFetcher(

--- a/worker/features/updates/migration-state.ts
+++ b/worker/features/updates/migration-state.ts
@@ -1,0 +1,298 @@
+export const normalMigrationNames = [
+  "0001_initial.sql",
+  "0002_workspace.sql",
+  "0003_oauth_resources.sql",
+  "0004_conversations.sql",
+  "0005_rebuild_threads.sql",
+  "0006_push_notifications.sql",
+  "0007_user_mail_preferences.sql",
+  "0008_user_onboarding.sql",
+  "0009_login_email_domain_isolation.sql",
+  "0010_oauth_device_authorization.sql",
+  "0011_latest_password_reset_token.sql",
+  "0012_message_activity_index.sql",
+  "0013_message_changes.sql",
+  "0014_unassigned_messages.sql",
+  "0015_draft_changes.sql",
+  "0016_one_address_per_mailbox.sql",
+  "0017_agent_principals.sql",
+  "0018_mailbox_lifecycle.sql",
+  "0019_contacts.sql",
+  "0020_labels.sql",
+  "0021_email_signatures.sql",
+  "0022_login_email_domain_exact_match.sql",
+  "0023_message_sender_names.sql",
+  "0024_draft_inline_images.sql",
+  "0025_activate_catch_all_policy.sql",
+  "0026_domain_disconnect.sql",
+  "0027_message_attachment_disposition.sql",
+  "0028_draft_labels.sql"
+] as const;
+
+export const afterDeployMigrationNames = [
+  "0001_remove_mailbox_alias_storage.sql",
+  "0002_finalize_agent_principals.sql",
+  "0003_finalize_draft_labels.sql"
+] as const;
+
+const aliasTables = ["mailbox_address_migration", "mailbox_addresses"] as const;
+const aliasMessageColumns = ["delivered_to_address_id", "sent_from_address_id"] as const;
+const principalLegacyColumns = {
+  draft_changes: ["user_id"],
+  drafts: ["user_id"],
+  mailbox_grants: ["created_by", "user_id"]
+} as const;
+export const transitionGuards = [
+  "mailbox_addresses_transition_delete_guard",
+  "mailbox_addresses_transition_insert_guard",
+  "mailbox_addresses_transition_update_guard",
+  "mailbox_grants_transition_delete_guard",
+  "mailbox_grants_transition_insert_guard",
+  "mailbox_grants_transition_update_guard",
+  "mailboxes_transition_delete_guard",
+  "mailboxes_transition_update_guard",
+  "retention_policies_transition_delete_guard",
+  "retention_policies_transition_insert_guard",
+  "retention_policies_transition_update_guard"
+] as const;
+
+export type ManagedMigrationState = {
+  completedAfterDeployMigrations: 0 | 1 | 2 | 3;
+  repairRequired: boolean;
+  state: "stale" | "partial" | "clean";
+};
+
+export type ManagedMigrationSnapshot = {
+  afterDeployLedger: string[] | null;
+  columns: Record<"draft_changes" | "drafts" | "mailbox_grants" | "messages", string[]>;
+  draftLabelForeignKeys: Array<{
+    from: string;
+    on_delete: string;
+    table: string;
+    to: string;
+  }>;
+  normalLedger: string[];
+  pendingUpdates: Array<{
+    checkpoint_bookmark: string;
+    from_version: string;
+    id: string;
+    state: string;
+    to_version: string;
+    worker_version: string;
+  }>;
+  releaseState: {
+    channel: string;
+    installed_schema_version: number;
+    installed_version: string;
+    product: string;
+  } | null;
+  tables: string[];
+  transitionGuards: string[];
+};
+
+export async function inspectManagedMigrationState(
+  database: D1Database,
+  expectedVersion: string,
+  expectedSchemaVersion: number
+): Promise<ManagedMigrationState> {
+  const objects = await database
+    .prepare(
+      `SELECT type, name
+       FROM sqlite_schema
+       WHERE name IN (
+         'd1_migrations',
+         'd1_migrations_after_deploy',
+         'mailbox_address_migration',
+         'mailbox_addresses',
+         ${transitionGuards.map((name) => `'${name}'`).join(", ")}
+       )`
+    )
+    .all<{ name: string; type: string }>();
+  const foundTables = objects.results
+    .filter(({ type }) => type === "table")
+    .map(({ name }) => name);
+  if (!foundTables.includes("d1_migrations")) {
+    throw inconsistentState();
+  }
+
+  const normalLedger = await migrationLedger(database, "d1_migrations");
+  const afterDeployLedger = foundTables.includes("d1_migrations_after_deploy")
+    ? await migrationLedger(database, "d1_migrations_after_deploy")
+    : null;
+  const columns = {
+    draft_changes: await tableColumns(database, "draft_changes"),
+    drafts: await tableColumns(database, "drafts"),
+    mailbox_grants: await tableColumns(database, "mailbox_grants"),
+    messages: await tableColumns(database, "messages")
+  };
+  const foreignKeys = await database
+    .prepare("PRAGMA foreign_key_list(draft_labels)")
+    .all<{ from: string; on_delete: string; table: string; to: string }>();
+  const releaseState = await database
+    .prepare(
+      "SELECT product, installed_version, installed_schema_version, channel FROM release_state WHERE singleton = 1"
+    )
+    .all<{
+      channel: string;
+      installed_schema_version: number;
+      installed_version: string;
+      product: string;
+    }>();
+  const pendingUpdates = await database
+    .prepare(
+      `SELECT id, from_version, to_version, checkpoint_bookmark, worker_version, state
+       FROM update_history
+       WHERE to_version = ? AND state IN ('started', 'deployed')
+       ORDER BY started_at, rowid`
+    )
+    .bind(expectedVersion)
+    .all<{
+      checkpoint_bookmark: string;
+      from_version: string;
+      id: string;
+      state: string;
+      to_version: string;
+      worker_version: string;
+    }>();
+
+  return classifyManagedMigrationState(
+    {
+      afterDeployLedger,
+      columns,
+      draftLabelForeignKeys: foreignKeys.results,
+      normalLedger,
+      pendingUpdates: pendingUpdates.results,
+      releaseState: releaseState.results.length === 1 ? (releaseState.results[0] ?? null) : null,
+      tables: foundTables.filter((name) =>
+        aliasTables.includes(name as (typeof aliasTables)[number])
+      ),
+      transitionGuards: objects.results
+        .filter(({ type }) => type === "trigger")
+        .map(({ name }) => name)
+    },
+    expectedVersion,
+    expectedSchemaVersion
+  );
+}
+
+export function classifyManagedMigrationState(
+  snapshot: ManagedMigrationSnapshot,
+  expectedVersion: string,
+  expectedSchemaVersion: number
+): ManagedMigrationState {
+  if (!same(snapshot.normalLedger, normalMigrationNames)) throw inconsistentState();
+  if (snapshot.pendingUpdates.length > 1) throw inconsistentState();
+  const pendingUpdate = snapshot.pendingUpdates[0] ?? null;
+  if (
+    pendingUpdate &&
+    (pendingUpdate.to_version !== expectedVersion ||
+      !stableVersion.test(pendingUpdate.from_version) ||
+      !["started", "deployed"].includes(pendingUpdate.state) ||
+      [pendingUpdate.id, pendingUpdate.checkpoint_bookmark, pendingUpdate.worker_version].some(
+        (value) => typeof value !== "string" || !value
+      ))
+  ) {
+    throw inconsistentState();
+  }
+  const releaseState = snapshot.releaseState;
+  const releaseMarkerMatches =
+    releaseState?.product === "hqbase" &&
+    releaseState.channel === "stable" &&
+    Number.isInteger(releaseState.installed_schema_version) &&
+    releaseState.installed_schema_version > 0 &&
+    (pendingUpdate === null
+      ? releaseState.installed_schema_version === expectedSchemaVersion
+      : releaseState.installed_schema_version <= expectedSchemaVersion) &&
+    (releaseState.installed_version === expectedVersion ||
+      (pendingUpdate !== null && releaseState.installed_version === pendingUpdate.from_version));
+  if (!releaseMarkerMatches) throw inconsistentState();
+  const ledger = snapshot.afterDeployLedger ?? [];
+  const completed = afterDeployMigrationNames.findIndex((name, index) => ledger[index] !== name);
+  const completedCount = completed === -1 ? afterDeployMigrationNames.length : completed;
+  if (ledger.length !== completedCount) throw inconsistentState();
+
+  const aliasLegacy =
+    includesExactly(snapshot.tables, aliasTables) &&
+    includesAll(snapshot.columns.messages, aliasMessageColumns) &&
+    includesExactly(snapshot.transitionGuards, transitionGuards);
+  const aliasFinal =
+    includesNone(snapshot.tables, aliasTables) &&
+    includesNone(snapshot.columns.messages, aliasMessageColumns) &&
+    includesNone(snapshot.transitionGuards, transitionGuards);
+  const principalLegacy = Object.entries(principalLegacyColumns).every(([table, columns]) =>
+    includesAll(snapshot.columns[table as keyof typeof principalLegacyColumns], columns)
+  );
+  const principalFinal = Object.entries(principalLegacyColumns).every(([table, columns]) =>
+    includesNone(snapshot.columns[table as keyof typeof principalLegacyColumns], columns)
+  );
+  const draftForeignKeys = snapshot.draftLabelForeignKeys.filter(
+    (foreignKey) => foreignKey.from === "draft_id"
+  );
+  const hasFinalDraftLabelForeignKey =
+    draftForeignKeys.length === 1 &&
+    draftForeignKeys.some(
+      (foreignKey) =>
+        foreignKey.table === "drafts" &&
+        foreignKey.from === "draft_id" &&
+        foreignKey.to === "id" &&
+        foreignKey.on_delete.toUpperCase() === "CASCADE"
+    );
+  const baseSchemaPresent =
+    includesAll(snapshot.columns.messages, ["id", "delivered_to_address"]) &&
+    includesAll(snapshot.columns.mailbox_grants, ["mailbox_id", "principal_id"]) &&
+    includesAll(snapshot.columns.drafts, ["id", "principal_id"]) &&
+    includesAll(snapshot.columns.draft_changes, ["sequence", "principal_id"]);
+
+  const valid =
+    baseSchemaPresent &&
+    ((completedCount === 0 && aliasLegacy && principalLegacy && draftForeignKeys.length === 0) ||
+      (completedCount === 1 && aliasFinal && principalLegacy && draftForeignKeys.length === 0) ||
+      (completedCount === 2 && aliasFinal && principalFinal && draftForeignKeys.length === 0) ||
+      (completedCount === 3 && aliasFinal && principalFinal && hasFinalDraftLabelForeignKey));
+  if (!valid) throw inconsistentState();
+
+  return {
+    completedAfterDeployMigrations: completedCount as 0 | 1 | 2 | 3,
+    repairRequired: completedCount < afterDeployMigrationNames.length || pendingUpdate !== null,
+    state:
+      completedCount === 0
+        ? "stale"
+        : completedCount === 3 && pendingUpdate === null
+          ? "clean"
+          : "partial"
+  };
+}
+
+const stableVersion = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+async function migrationLedger(database: D1Database, table: string): Promise<string[]> {
+  const result = await database
+    .prepare(`SELECT name FROM ${table} ORDER BY id`)
+    .all<{ name: string }>();
+  return result.results.map(({ name }) => name);
+}
+
+async function tableColumns(database: D1Database, table: string): Promise<string[]> {
+  const result = await database.prepare(`PRAGMA table_info(${table})`).all<{ name: string }>();
+  return result.results.map(({ name }) => name);
+}
+
+function same(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function includesAll(values: readonly string[], expected: readonly string[]): boolean {
+  return expected.every((value) => values.includes(value));
+}
+
+function includesNone(values: readonly string[], expected: readonly string[]): boolean {
+  return expected.every((value) => !values.includes(value));
+}
+
+function includesExactly(values: readonly string[], expected: readonly string[]): boolean {
+  return values.length === expected.length && includesAll(values, expected);
+}
+
+function inconsistentState(): Error {
+  return new Error("HQBASE_MANAGED_MIGRATION_STATE_INVALID");
+}

--- a/worker/features/updates/service.ts
+++ b/worker/features/updates/service.ts
@@ -5,11 +5,12 @@ import { AppError } from "../../lib/errors";
 import { hqbaseProductConfig } from "../../lib/product-config";
 import { withUpdateBuildLock } from "./build-lock";
 import { cloudflare } from "./cloudflare";
+import { inspectManagedMigrationState, type ManagedMigrationState } from "./migration-state";
 import type { ReleaseManifest, UpdateStatus } from "./types";
 
 const expectedReleaseVariable = "HQBASE_EXPECTED_RELEASE_VERSION";
 const forceSourceDeployVariable = "HQBASE_FORCE_SOURCE_DEPLOY";
-const managedDeployCommands = new Set(["pnpm deploy", "pnpm run deploy"]);
+const legacyManagedDeployCommands = new Set(["pnpm deploy", "pnpm run deploy"]);
 const envelopeSchema = z.object({ payload: z.string().min(1), signature: z.string().min(1) });
 const manifestSchema = z.object({
   format: z.literal("hqbase-release-v1"),
@@ -25,6 +26,16 @@ const manifestSchema = z.object({
     url: z.string().url(),
     sha256: z.string().regex(/^[a-f0-9]{64}$/),
     size: z.number().int().nonnegative()
+  }),
+  updater: z.object({
+    protocol: z.literal(2),
+    sourceUrl: z
+      .string()
+      .regex(
+        /^https:\/\/raw\.githubusercontent\.com\/HQBase\/hqbase\/[a-f0-9]{40}\/scripts\/release\/bootstrap\.mjs$/
+      ),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    size: z.number().int().positive()
   }),
   keyId: z.literal("hqbase-release-2026-01")
 });
@@ -49,14 +60,33 @@ export async function getUpdateStatus(
   )
     throw new AppError("UPDATE_SIGNATURE_INVALID", "Release signature verification failed.", 503);
   const release = manifestSchema.parse(JSON.parse(decodeBase64Url(envelope.payload)));
+  const releaseComparison = compareVersions(release.version, installedVersion);
+  let migrationState: ManagedMigrationState | null = null;
+  if (releaseComparison === 0) {
+    try {
+      migrationState = await inspectManagedMigrationState(
+        env.DB,
+        release.version,
+        release.schemaVersion
+      );
+    } catch {
+      throw new AppError(
+        "UPDATE_SCHEMA_INCONSISTENT",
+        "HQBase cannot verify this installation's database migration state. Run the signed deployment diagnostic before updating.",
+        503
+      );
+    }
+  }
+  const repairRequired = migrationState?.repairRequired ?? false;
   return {
     product: "hqbase",
     installedVersion,
     installedSchemaVersion: 3,
     channel: "stable",
     checkedAt: new Date().toISOString(),
-    available: compareVersions(release.version, installedVersion) > 0,
+    available: releaseComparison > 0 || repairRequired,
     compatible: compareVersions(installedVersion, release.minVersion) >= 0,
+    repairRequired,
     release: release as ReleaseManifest
   };
 }
@@ -149,6 +179,7 @@ export async function triggerUpdate(
       502
     );
   return withUpdateBuildLock(env.DB, triggerId, async () => {
+    const triggerUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${triggerId}`;
     const variablesUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${triggerId}/environment_variables`;
     const variables = await cloudflare<{
       result: Record<string, { is_secret: boolean; value?: string | null }>;
@@ -169,7 +200,14 @@ export async function triggerUpdate(
         409
       );
     }
+    const previousDeployCommand = trigger.deploy_command?.trim() ?? "";
+    const nextDeployCommand = managedDeployCommand(update.release.updater);
+    let deployCommandChanged = false;
     try {
+      if (previousDeployCommand !== nextDeployCommand) {
+        await setBuildDeployCommand(triggerUrl, nextDeployCommand, headers, fetcher);
+        deployCommandChanged = true;
+      }
       await setBuildVersionPin(variablesUrl, expectedVersion, headers, fetcher);
       const build = await cloudflare<{
         result: { build_uuid?: string; id?: string; status?: string };
@@ -187,9 +225,28 @@ export async function triggerUpdate(
         );
       return { buildId, status: build.result.status ?? "queued" };
     } catch (error) {
-      await restoreBuildVersionPin(variablesUrl, previousPin, headers, fetcher).catch(
-        () => undefined
-      );
+      let rollbackFailed = false;
+      let releasePinRestored = false;
+      try {
+        await restoreBuildVersionPin(variablesUrl, previousPin, headers, fetcher);
+        releasePinRestored = true;
+      } catch {
+        rollbackFailed = true;
+      }
+      if (deployCommandChanged && releasePinRestored) {
+        try {
+          await setBuildDeployCommand(triggerUrl, previousDeployCommand, headers, fetcher);
+        } catch {
+          rollbackFailed = true;
+        }
+      }
+      if (rollbackFailed) {
+        throw new AppError(
+          "UPDATE_TRIGGER_ROLLBACK_FAILED",
+          "The build did not start, and HQBase could not restore the previous Cloudflare build configuration. Review the production Workers Builds trigger before trying again.",
+          502
+        );
+      }
       throw error;
     }
   });
@@ -199,15 +256,46 @@ function assertManagedTrigger(trigger: {
   deploy_command?: string | null;
   root_directory?: string | null;
 }): void {
-  const command = trigger.deploy_command?.trim().replace(/\s+/g, " ") ?? "";
+  const command = trigger.deploy_command?.trim() ?? "";
   const root = trigger.root_directory?.trim() ?? "";
-  if (!managedDeployCommands.has(command) || !["", "/", ".", "./"].includes(root)) {
+  if (!isManagedDeployCommand(command) || !["", "/", ".", "./"].includes(root)) {
     throw new AppError(
       "UPDATE_TRIGGER_UNMANAGED",
-      "Signed updates require a repository-root Workers Builds trigger that runs pnpm deploy. Use the custom-source deployment process instead.",
+      "Signed updates require a repository-root Workers Builds trigger that uses the HQBase updater. Use the custom-source deployment process instead.",
       409
     );
   }
+}
+
+export function managedDeployCommand(updater: NonNullable<ReleaseManifest["updater"]>): string {
+  const { sha256, size, sourceUrl } = updater;
+  return `node --input-type=module --eval 'const u="${sourceUrl}";const h="${sha256}";const n=${size};const r=await fetch(u);if(!r.ok)throw new Error("HQBase updater download failed.");const b=Buffer.from(await r.arrayBuffer());const {createHash}=await import("node:crypto");if(b.length!==n||createHash("sha256").update(b).digest("hex")!==h)throw new Error("HQBase updater verification failed.");await import("data:text/javascript;base64,"+b.toString("base64"));'`;
+}
+
+export function isManagedDeployCommand(command: string): boolean {
+  if (legacyManagedDeployCommands.has(command.trim().replace(/\s+/g, " "))) return true;
+  const match = command.match(
+    /^node --input-type=module --eval 'const u="(https:\/\/raw\.githubusercontent\.com\/HQBase\/hqbase\/[a-f0-9]{40}\/scripts\/release\/bootstrap\.mjs)";const h="([a-f0-9]{64})";const n=([1-9]\d*);/
+  );
+  if (!match) return false;
+  const sourceUrl = match[1];
+  const sha256 = match[2];
+  const size = match[3];
+  if (!sourceUrl || !sha256 || !size) return false;
+  return command === managedDeployCommand({ protocol: 2, sha256, size: Number(size), sourceUrl });
+}
+
+async function setBuildDeployCommand(
+  url: string,
+  deployCommand: string,
+  headers: Record<string, string>,
+  fetcher: typeof fetch
+): Promise<void> {
+  await cloudflare(
+    url,
+    { method: "PATCH", headers, body: JSON.stringify({ deploy_command: deployCommand }) },
+    fetcher
+  );
 }
 
 async function setBuildVersionPin(

--- a/worker/features/updates/types.ts
+++ b/worker/features/updates/types.ts
@@ -9,6 +9,7 @@ export type ReleaseManifest = {
   notes: string[];
   notesUrl: string;
   artifact: { url: string; sha256: string; size: number };
+  updater: { protocol: 2; sourceUrl: string; sha256: string; size: number };
   keyId: string;
 };
 
@@ -20,5 +21,6 @@ export type UpdateStatus = {
   checkedAt: string;
   available: boolean;
   compatible: boolean;
+  repairRequired: boolean;
   release: ReleaseManifest;
 };


### PR DESCRIPTION
## Summary

- add a signed protocol-2 updater that replaces the frozen customer-repository bootstrap without changing customer source
- detect and repair each exact unfinished post-deploy D1 state from a fresh recovery checkpoint
- preserve and verify required Worker bindings, including `MAIL_EVENTS`, and test authenticated event WebSockets
- test the release through the oldest supported updater before publication

## Verification

- `CI=true pnpm check`
- `CI=true pnpm deploy:dry-run`
- 832 unit tests passed (2 skipped)
- 193 Worker integration tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added installation repair support for incomplete or same-version updates.
  - Update status now identifies when database repair is required and provides repair-specific guidance and actions.
  - Release updates now verify signed artifacts and updater metadata for safer deployments.
  - Improved recovery for interrupted deployments while preserving customer data and configuration.

- **Bug Fixes**
  - Improved validation of migrations, schema state, bindings, event connections, and repeat update attempts.
  - Improved rollback and retry handling for failed or incomplete releases.

- **Documentation**
  - Added release notes for version 1.3.3, including recovery and verification improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->