### PR TITLE
ci: enable frozen updater secrets path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,7 @@ jobs:
           else
             echo "HQBASE_STAGING_PREVIOUS_HAS_CATCH_ALL_POLICY=0" >> "$GITHUB_ENV"
           fi
+          WORKERS_CI=1 \
           HQBASE_AUTH_SECRET="$HQBASE_STAGING_AUTH_SECRET" \
           HQBASE_EXPECTED_RELEASE_VERSION="$previous_version" \
           HQBASE_RELEASE_ARTIFACT_FILE="$previous_archive" \
@@ -271,6 +272,7 @@ jobs:
           jq -e 'has("durable_objects") == false and has("migrations") == false' "$config"
       - name: Apply the exact signed candidate
         run: |
+          WORKERS_CI=1 \
           HQBASE_AUTH_SECRET="$HQBASE_STAGING_AUTH_SECRET" \
           HQBASE_EXPECTED_RELEASE_VERSION="$CANDIDATE_VERSION" \
           HQBASE_RELEASE_ARTIFACT_FILE="$GITHUB_WORKSPACE/release/hqbase-${CANDIDATE_VERSION}.tar.gz" \

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -128,6 +128,9 @@ describe("staging workflow lifecycle record", () => {
       "      - name: Reproduce the legacy Worker configuration"
     );
     const candidate = releaseWorkflow.indexOf("      - name: Apply the exact signed candidate");
+    const candidateWait = releaseWorkflow.indexOf("      - name: Wait for the signed candidate");
+    const previousInstall = releaseWorkflow.slice(previousRelease, bootstrapData);
+    const candidateInstall = releaseWorkflow.slice(candidate, candidateWait);
 
     expect(previousRelease).toBeGreaterThan(-1);
     expect(bootstrapData).toBeGreaterThan(previousRelease);
@@ -150,6 +153,8 @@ describe("staging workflow lifecycle record", () => {
     expect(releaseWorkflow).toContain(
       'node "$HQBASE_OLDEST_UPDATER" --config "$HQBASE_OLDEST_CONFIG"'
     );
+    expect(previousInstall).toContain("WORKERS_CI=1");
+    expect(candidateInstall).toContain("WORKERS_CI=1");
   });
 
   it("proves the stale state before the canonical repair and its retry", () => {

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -131,6 +131,7 @@ describe("staging workflow lifecycle record", () => {
     const candidateWait = releaseWorkflow.indexOf("      - name: Wait for the signed candidate");
     const previousInstall = releaseWorkflow.slice(previousRelease, bootstrapData);
     const candidateInstall = releaseWorkflow.slice(candidate, candidateWait);
+    const workersCiAssignment = "WORKERS_CI=1 \\";
 
     expect(previousRelease).toBeGreaterThan(-1);
     expect(bootstrapData).toBeGreaterThan(previousRelease);
@@ -153,8 +154,8 @@ describe("staging workflow lifecycle record", () => {
     expect(releaseWorkflow).toContain(
       'node "$HQBASE_OLDEST_UPDATER" --config "$HQBASE_OLDEST_CONFIG"'
     );
-    expect(previousInstall).toContain("WORKERS_CI=1");
-    expect(candidateInstall).toContain("WORKERS_CI=1");
+    expect(previousInstall.split("\n").map((line) => line.trim())).toContain(workersCiAssignment);
+    expect(candidateInstall.split("\n").map((line) => line.trim())).toContain(workersCiAssignment);
   });
 
   it("proves the stale state before the canonical repair and its retry", () => {


### PR DESCRIPTION
## Summary

- Enable the frozen v1.0.0 updater's CI secrets path in signed-release staging.
- Cover both the previous-stable and candidate invocations.
- Prevent the first-deploy secret failure found by [release run #23](https://github.com/HQBase/hqbase/actions/runs/33514537925).

## Verification

- `CI=true pnpm check`
- `CI=true pnpm deploy:dry-run`
- `CI=true pnpm vitest run test/unit/scripts/staging-workflow.test.mjs`

## Release evidence

- [Release run #23](https://github.com/HQBase/hqbase/actions/runs/33514537925) passed its candidate job.
- Staging stopped before product validation because the first Worker deploy did not receive `BETTER_AUTH_SECRET`.
- The failed draft and all disposable resources were cleaned up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved staging release updates to run consistently for both previous stable releases and signed candidate deployments.
  - Ensured the required update setting is applied during each relevant installation step for more reliable release testing.

- **Tests**
  - Expanded release workflow validation to verify the setting is configured correctly in both installation sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->