### PR TITLE
fix: retry Cloudflare resource verification

### DIFF
--- a/scripts/hqbase/provision.mjs
+++ b/scripts/hqbase/provision.mjs
@@ -2,10 +2,16 @@ import { parseD1DatabaseId, run } from "./command.mjs";
 import { writeManifest } from "./manifest.mjs";
 import { inspectD1, inspectQueue, inspectR2, wrangler } from "./resources.mjs";
 
+const postCreateReadDelaysMs = [1_000, 2_000, 4_000, 8_000, 15_000];
+
 export function provisionResources(manifest, options = {}) {
   const checkpoint = options.checkpoint ?? writeManifest;
   const runCommand = options.runCommand ?? run;
   const dryRun = options.dryRun ?? false;
+  const verification = {
+    delaysMs: options.postCreateReadDelaysMs,
+    sleep: options.sleep
+  };
 
   if (dryRun) {
     const commands = [
@@ -43,7 +49,11 @@ export function provisionResources(manifest, options = {}) {
       stdoutOnly: false
     });
     const id = parseD1DatabaseId(output);
-    inspectD1(manifest, { ...manifest.d1, id, ownership: "created" }, { runCommand });
+    verifyCreatedResource(
+      `D1 database "${manifest.d1.name}"`,
+      () => inspectD1(manifest, { ...manifest.d1, id, ownership: "created" }, { runCommand }),
+      verification
+    );
     manifest.d1.id = id;
     finishCreate(manifest, manifest.d1, checkpoint);
   }
@@ -54,7 +64,11 @@ export function provisionResources(manifest, options = {}) {
       quiet: false,
       runCommand
     });
-    inspectR2(manifest, { ...manifest.r2, ownership: "created" }, { runCommand });
+    verifyCreatedResource(
+      `R2 bucket "${manifest.r2.bucket}"`,
+      () => inspectR2(manifest, { ...manifest.r2, ownership: "created" }, { runCommand }),
+      verification
+    );
     finishCreate(manifest, manifest.r2, checkpoint);
   }
 
@@ -64,10 +78,42 @@ export function provisionResources(manifest, options = {}) {
     }
     beginCreate(manifest, queue, checkpoint);
     wrangler(manifest, ["queues", "create", queue.name], { quiet: false, runCommand });
-    const identity = inspectQueue(manifest, { ...queue, ownership: "created" }, { runCommand });
+    const identity = verifyCreatedResource(
+      `Queue "${queue.name}"`,
+      () => inspectQueue(manifest, { ...queue, ownership: "created" }, { runCommand }),
+      verification
+    );
     queue.id = identity.id;
     finishCreate(manifest, queue, checkpoint);
   }
+}
+
+function verifyCreatedResource(label, inspect, options = {}) {
+  const delaysMs = options.delaysMs ?? postCreateReadDelaysMs;
+  const sleep = options.sleep ?? sleepSync;
+  let lastError;
+
+  for (let attempt = 0; attempt <= delaysMs.length; attempt += 1) {
+    try {
+      return inspect();
+    } catch (error) {
+      lastError = error;
+      if (attempt < delaysMs.length) {
+        sleep(delaysMs[attempt]);
+      }
+    }
+  }
+
+  const detail = lastError instanceof Error ? lastError.message : String(lastError);
+  const delaySeconds = delaysMs.reduce((total, delayMs) => total + delayMs, 0) / 1_000;
+  throw new Error(
+    `Cloudflare accepted creation of ${label}, but HQBase could not verify its identity after ${delaysMs.length + 1} checks and ${delaySeconds} seconds of retry delays. The deployment record remains in the unfinished "creating" state. Verify the Cloudflare resource before retrying. Last check: ${detail}`,
+    { cause: lastError }
+  );
+}
+
+function sleepSync(delayMs) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
 }
 
 function beginCreate(manifest, resource, checkpoint) {

--- a/test/unit/scripts/resources.test.mjs
+++ b/test/unit/scripts/resources.test.mjs
@@ -34,6 +34,14 @@ function markCreated(value, completed) {
 
 function cloudflareRunner(overrides = {}) {
   const calls = [];
+  const readAttempts = new Map();
+  const failTransientRead = (key) => {
+    const attempt = (readAttempts.get(key) ?? 0) + 1;
+    readAttempts.set(key, attempt);
+    if (attempt <= (overrides.transientReadFailures?.[key] ?? 0)) {
+      throw new Error(`Transient ${key} identity read ${attempt}`);
+    }
+  };
   const runCommand = (_command, args) => {
     const wranglerArgs = args.slice(2);
     calls.push(wranglerArgs);
@@ -43,6 +51,7 @@ function cloudflareRunner(overrides = {}) {
       return `database_id = "${d1Id}"`;
     }
     if (operation === "d1 list") {
+      failTransientRead("d1");
       return JSON.stringify(
         [{ name: overrides.d1Name ?? "hqbase-recovery", uuid: d1Id }].filter(
           () => !overrides.missingD1
@@ -53,6 +62,7 @@ function cloudflareRunner(overrides = {}) {
       return "";
     }
     if (wranglerArgs.slice(0, 3).join(" ") === "r2 bucket info") {
+      failTransientRead("r2");
       return JSON.stringify({ name: overrides.r2Name ?? "hqbase-recovery-mail" });
     }
     if (operation === "queues create") {
@@ -60,6 +70,8 @@ function cloudflareRunner(overrides = {}) {
     }
     if (operation === "queues info") {
       const name = wranglerArgs[2];
+      const key = name.endsWith("-dlq") ? "queue.deadLetter" : "queue.primary";
+      failTransientRead(key);
       const expectedId = name.endsWith("-dlq") ? deadLetterQueueId : primaryQueueId;
       const id = overrides.queueId ?? expectedId;
       return `Queue Name: ${overrides.queueName ?? name}\nQueue ID: ${id}\n`;
@@ -67,6 +79,10 @@ function cloudflareRunner(overrides = {}) {
     throw new Error(`Unexpected Wrangler operation: ${wranglerArgs.join(" ")}`);
   };
   return { calls, runCommand };
+}
+
+function startsWith(actual, expected) {
+  return expected.every((value, index) => actual[index] === value);
 }
 
 describe("operator resource recovery", () => {
@@ -117,6 +133,100 @@ describe("operator resource recovery", () => {
       id: deadLetterQueueId,
       ownership: "created"
     });
+  });
+
+  it.each([
+    {
+      create: ["d1", "create", "hqbase-recovery"],
+      key: "d1",
+      read: ["d1", "list"],
+      resource: (current) => current.d1
+    },
+    {
+      create: ["r2", "bucket", "create", "hqbase-recovery-mail"],
+      key: "r2",
+      read: ["r2", "bucket", "info", "hqbase-recovery-mail"],
+      resource: (current) => current.r2
+    },
+    {
+      create: ["queues", "create", "hqbase-recovery-jobs"],
+      key: "queue.primary",
+      read: ["queues", "info", "hqbase-recovery-jobs"],
+      resource: (current) => current.queue.primary
+    },
+    {
+      create: ["queues", "create", "hqbase-recovery-jobs-dlq"],
+      key: "queue.deadLetter",
+      read: ["queues", "info", "hqbase-recovery-jobs-dlq"],
+      resource: (current) => current.queue.deadLetter
+    }
+  ])("retries a transient $key identity read without repeating its create", (testCase) => {
+    const current = manifest();
+    const cloudflare = cloudflareRunner({
+      transientReadFailures: { [testCase.key]: 1 }
+    });
+    const checkpoints = [];
+    const sleeps = [];
+
+    provisionResources(current, {
+      checkpoint: (next) => checkpoints.push(structuredClone(next)),
+      postCreateReadDelaysMs: [10, 20],
+      runCommand: cloudflare.runCommand,
+      sleep: (delayMs) => sleeps.push(delayMs)
+    });
+
+    expect(cloudflare.calls.filter((args) => startsWith(args, testCase.create))).toHaveLength(1);
+    expect(cloudflare.calls.filter((args) => startsWith(args, testCase.read))).toHaveLength(2);
+    expect(sleeps).toEqual([10]);
+    expect(testCase.resource(current).ownership).toBe("created");
+    const states = checkpoints.map((entry) => testCase.resource(entry).ownership);
+    const creating = states.indexOf("creating");
+    expect(states.slice(creating, creating + 2)).toEqual(["creating", "created"]);
+  });
+
+  it("keeps a Queue create ambiguous when bounded identity reads do not converge", () => {
+    const current = markCreated(manifest(), 2);
+    const cloudflare = cloudflareRunner({
+      transientReadFailures: { "queue.primary": 3 }
+    });
+    const sleeps = [];
+    let failure;
+
+    try {
+      provisionResources(current, {
+        postCreateReadDelaysMs: [10, 20],
+        runCommand: cloudflare.runCommand,
+        sleep: (delayMs) => sleeps.push(delayMs)
+      });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    expect(failure.message).toMatch(/Queue "hqbase-recovery-jobs"/);
+    expect(failure.message).toMatch(/3 checks and 0.03 seconds/);
+    expect(failure.cause).toEqual(new Error("Transient queue.primary identity read 3"));
+    expect(sleeps).toEqual([10, 20]);
+    expect(current.queue.primary).toEqual({
+      name: "hqbase-recovery-jobs",
+      id: null,
+      ownership: "creating"
+    });
+    expect(
+      cloudflare.calls.filter((args) =>
+        startsWith(args, ["queues", "create", "hqbase-recovery-jobs"])
+      )
+    ).toHaveLength(1);
+    expect(
+      cloudflare.calls.filter((args) =>
+        startsWith(args, ["queues", "info", "hqbase-recovery-jobs"])
+      )
+    ).toHaveLength(3);
+    expect(
+      cloudflare.calls.some((args) =>
+        startsWith(args, ["queues", "create", "hqbase-recovery-jobs-dlq"])
+      )
+    ).toBe(false);
   });
 
   it("fails closed instead of adopting an ambiguous create result", () => {


### PR DESCRIPTION
## Summary

- Retry exact, read-only identity checks after a successful D1, R2, or Queue create request.
- Never retry a create request, and record ownership only after the resource identity matches.
- Keep ambiguous ownership fail closed when bounded verification retries expire.
- Add regression tests for transient Cloudflare control-plane lag and persistent read failures.

## Verification

- [x] `CI=true pnpm check`
- [x] `CI=true pnpm deploy:dry-run`
- [x] Durable Object binding present in the dry-run bundle

## Evidence

Signed release [run #24](https://github.com/HQBase/hqbase/actions/runs/33517115398) created its primary Queue once, then an immediate exact read did not see it. The matching specification change is merged in [HQBase/hqbase-site#43](https://github.com/HQBase/hqbase-site/pull/43).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when verifying newly created D1, R2, and queue resources.
  * Added bounded retries for temporary inspection failures, with configurable retry delays.
  * Resources remain marked as “creating” when verification ultimately fails, with clearer error details.
  * Prevented duplicate resource creation and downstream provisioning after verification failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->