### PR TITLE
fix: recover empty Worker installations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,7 @@ jobs:
       # This frozen bootstrap is independent of the active-release compatibility floor.
       OLDEST_UPDATER_TAG: v1.0.0
       DEPLOYMENT_NAME: release-${{ github.run_id }}
+      STAGING_WORKER_NAME: hqbase-release-${{ github.run_id }}
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
@@ -180,7 +181,7 @@ jobs:
         run: >-
           pnpm hqbase install
           --name "$DEPLOYMENT_NAME"
-          --worker-name hqbase-e2e-staging
+          --worker-name "$STAGING_WORKER_NAME"
           --domain "$HQBASE_STAGING_EMAIL_DOMAIN"
           --no-email
           --app-domain "${HQBASE_STAGING_URL#https://}"
@@ -299,11 +300,11 @@ jobs:
           config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
           database="hqbase-$DEPLOYMENT_NAME"
           status="$(pnpm exec wrangler deployments status \
-            --name hqbase-e2e-staging --json --config "$config")"
+            --name "$STAGING_WORKER_NAME" --json --config "$config")"
           version_id="$(jq -er '.versions[] | select(.percentage == 100) | .version_id' \
             <<<"$status")"
           worker="$(pnpm exec wrangler versions view "$version_id" \
-            --name hqbase-e2e-staging --json --config "$config")"
+            --name "$STAGING_WORKER_NAME" --json --config "$config")"
           jq -e '[.resources.bindings[].name] | index("MAIL_EVENTS") != null' <<<"$worker"
           expected_normal_count="$(find migrations -maxdepth 1 -type f -name '*.sql' | wc -l | tr -d ' ')"
           expected_schema_version="$(node --input-type=module -e '
@@ -390,11 +391,11 @@ jobs:
         run: |
           config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
           status="$(pnpm exec wrangler deployments status \
-            --name hqbase-e2e-staging --json --config "$config")"
+            --name "$STAGING_WORKER_NAME" --json --config "$config")"
           version_id="$(jq -er '.versions[] | select(.percentage == 100) | .version_id' \
             <<<"$status")"
           version="$(pnpm exec wrangler versions view "$version_id" \
-            --name hqbase-e2e-staging --json --config "$config")"
+            --name "$STAGING_WORKER_NAME" --json --config "$config")"
           jq -e '
             [.resources.bindings[].name] as $names |
             (["DB", "MAIL_OBJECTS", "HQBASE_JOBS", "MAIL_SENDER", "MAIL_EVENTS"] - $names) |
@@ -429,6 +430,34 @@ jobs:
           path: .hqbase/deployments/release-${{ github.run_id }}/manifest.json
           if-no-files-found: warn
           retention-days: 30
+      - name: Remove an empty disposable Worker service
+        if: always()
+        run: |
+          manifest=".hqbase/deployments/$DEPLOYMENT_NAME/manifest.json"
+          if test ! -f "$manifest"; then
+            exit 0
+          fi
+          worker_name="$(jq -er '.worker.name' "$manifest")"
+          worker_deployed="$(jq -r '.worker.deployed' "$manifest")"
+          test "$worker_name" = "$STAGING_WORKER_NAME"
+          case "$worker_deployed" in
+            true) exit 0 ;;
+            false) ;;
+            *) printf '%s\n' "Invalid Worker deployment state." >&2; exit 1 ;;
+          esac
+          config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          if output="$(NO_COLOR=1 pnpm exec wrangler delete "$worker_name" \
+            --force --config "$config" 2>&1)"; then
+            printf '%s\n' "$output"
+            exit 0
+          fi
+          if grep -Eq '^Worker ".+" not found\.$' <<<"$output" ||
+             grep -Fq 'This Worker does not exist on your account.' <<<"$output" ||
+             grep -Eq 'code.*(10007|10090)' <<<"$output"; then
+            exit 0
+          fi
+          printf '%s\n' "$output" >&2
+          exit 1
       - name: Destroy disposable resources
         if: always()
         run: pnpm hqbase destroy --name "$DEPLOYMENT_NAME" --scope all --yes

--- a/scripts/release/active-version.mjs
+++ b/scripts/release/active-version.mjs
@@ -111,6 +111,7 @@ export function isWorkerNotFound(result) {
   return (
     /Worker ".+"(?: \(env: .+\))? not found\./s.test(output) ||
     /This Worker does not exist on your account\./i.test(output) ||
+    /^The Worker [^\r\n]+ has no deployments\.$/m.test(output) ||
     /workers\.api\.error\.script_not_found|code["': ]+(?:10007|10090)/i.test(output)
   );
 }

--- a/test/unit/scripts/deploy.test.mjs
+++ b/test/unit/scripts/deploy.test.mjs
@@ -306,6 +306,24 @@ describe("HQBase release deployment", () => {
     expect(
       inspectActiveRelease("/release", "customer-worker", {
         attempt: () => ({
+          status: 1,
+          stdout: "",
+          stderr: "The Worker customer-worker has no deployments."
+        })
+      })
+    ).toBeNull();
+    expect(() =>
+      inspectActiveRelease("/release", "customer-worker", {
+        attempt: () => ({
+          status: 1,
+          stdout: "",
+          stderr: "Cloudflare API authentication failed"
+        })
+      })
+    ).toThrow("wrangler deployments status exited with 1");
+    expect(
+      inspectActiveRelease("/release", "customer-worker", {
+        attempt: () => ({
           status: 0,
           stdout: JSON.stringify({
             versions: [{ version_id: "active-version", percentage: 100 }]

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -158,6 +158,36 @@ describe("staging workflow lifecycle record", () => {
     expect(candidateInstall.split("\n").map((line) => line.trim())).toContain(workersCiAssignment);
   });
 
+  it("isolates and cleans the signed-release staging Worker", () => {
+    const create = releaseWorkflow.indexOf("      - name: Create disposable customer resources");
+    const cleanup = releaseWorkflow.indexOf(
+      "      - name: Remove an empty disposable Worker service"
+    );
+    const destroy = releaseWorkflow.indexOf("      - name: Destroy disposable resources");
+    const cleanupStep = releaseWorkflow.slice(cleanup, destroy);
+
+    expect(releaseWorkflow).toMatch(
+      /STAGING_WORKER_NAME: hqbase-release-\$\{\{ github\.run_id \}\}/
+    );
+    expect(releaseWorkflow).toContain('--worker-name "$STAGING_WORKER_NAME"');
+    expect(releaseWorkflow.match(/--name "\$STAGING_WORKER_NAME"/g)).toHaveLength(4);
+    expect(releaseWorkflow).not.toContain("hqbase-e2e-staging");
+    expect(cleanup).toBeGreaterThan(create);
+    expect(destroy).toBeGreaterThan(cleanup);
+    expect(cleanupStep).toContain("if: always()");
+    expect(cleanupStep).toContain('manifest=".hqbase/deployments/$DEPLOYMENT_NAME/manifest.json"');
+    expect(cleanupStep).toContain(`worker_name="$(jq -er '.worker.name' "$manifest")"`);
+    expect(cleanupStep).toContain(`worker_deployed="$(jq -r '.worker.deployed' "$manifest")"`);
+    expect(cleanupStep).toContain('test "$worker_name" = "$STAGING_WORKER_NAME"');
+    expect(cleanupStep).toContain('case "$worker_deployed" in');
+    expect(cleanupStep).toContain("true) exit 0 ;;");
+    expect(cleanupStep).toContain("false) ;;");
+    expect(cleanupStep).toContain("Invalid Worker deployment state.");
+    expect(cleanupStep).toContain('wrangler delete "$worker_name"');
+    expect(cleanupStep).toContain("This Worker does not exist on your account.");
+    expect(cleanupStep).toContain("exit 1");
+  });
+
   it("proves the stale state before the canonical repair and its retry", () => {
     const candidate = releaseWorkflow.indexOf("      - name: Apply the exact signed candidate");
     const stale = releaseWorkflow.indexOf(


### PR DESCRIPTION
## Summary

- Treat Wrangler's exact zero-deployment Worker response as an uninstalled Worker so the canonical updater can recover.
- Give each signed-release staging run its own Worker name.
- Remove only the exact manifest-recorded empty Worker shell during cleanup; keep all other state errors fail-closed.
- Keep the frozen v1.0.0 updater unchanged.

## Why

Signed release run [#25](https://github.com/HQBase/hqbase/actions/runs/33520492577) proved the resource verification retry, then found an empty Worker service left by an earlier failed first deploy. The frozen updater could not pass that state. The current updater had the same recovery gap.

## Verification

- [x] Focused regression tests: 31 passed
- [x] `pnpm check`: 838 unit tests and 193 Worker tests passed
- [x] `pnpm deploy:dry-run`: passed with `MAIL_EVENTS`
- [x] Independent read-only review: no remaining issues
- [x] Product and staging contract: HQBase/hqbase-site#44 (merged)
