### PR TITLE
Prove signed release WebSocket handoff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: hqbase-release
+  group: hqbase-staging-resources
+  queue: max
   cancel-in-progress: false
 
 jobs:
@@ -422,21 +423,16 @@ jobs:
           git diff --quiet
           git diff --cached --quiet
           test -z "$(git ls-files --others --exclude-standard)"
-      - name: Upload non-secret deployment record
+      - name: Reconcile disposable Worker lifecycle record
         if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: hqbase-release-staging-manifest-${{ github.run_id }}
-          path: .hqbase/deployments/release-${{ github.run_id }}/manifest.json
-          if-no-files-found: warn
-          retention-days: 30
-      - name: Remove an empty disposable Worker service
-        if: always()
+        id: reconcile_worker
         run: |
           manifest=".hqbase/deployments/$DEPLOYMENT_NAME/manifest.json"
           if test ! -f "$manifest"; then
+            echo "manifest_present=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "manifest_present=true" >> "$GITHUB_OUTPUT"
           worker_name="$(jq -er '.worker.name' "$manifest")"
           worker_deployed="$(jq -r '.worker.deployed' "$manifest")"
           test "$worker_name" = "$STAGING_WORKER_NAME"
@@ -446,20 +442,54 @@ jobs:
             *) printf '%s\n' "Invalid Worker deployment state." >&2; exit 1 ;;
           esac
           config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
-          if output="$(NO_COLOR=1 pnpm exec wrangler delete "$worker_name" \
-            --force --config "$config" 2>&1)"; then
-            printf '%s\n' "$output"
+          if output="$(NO_COLOR=1 pnpm exec wrangler deployments status \
+            --name "$worker_name" --json --config "$config" 2>&1)"; then
+            CONFIG_FILE="$config" WORKER_NAME="$worker_name" node --input-type=module -e '
+              import { recordWorkerDeployedForConfig } from "./scripts/hqbase/manifest.mjs";
+              const manifest = recordWorkerDeployedForConfig(
+                process.env.CONFIG_FILE,
+                process.env.WORKER_NAME
+              );
+              if (manifest?.worker?.deployed !== true) {
+                throw new Error("The active staging Worker was not recorded.");
+              }
+            '
             exit 0
           fi
-          if grep -Eq '^Worker ".+" not found\.$' <<<"$output" ||
+          if grep -Fxq "The Worker $worker_name has no deployments." <<<"$output"; then
+            if delete_output="$(NO_COLOR=1 pnpm exec wrangler delete "$worker_name" \
+              --force --config "$config" 2>&1)"; then
+              printf '%s\n' "$delete_output"
+              exit 0
+            fi
+            if grep -Fxq "Worker \"$worker_name\" not found." <<<"$delete_output" ||
+               grep -Fq 'This Worker does not exist on your account.' <<<"$delete_output" ||
+               grep -Eq 'code.*(10007|10090)' <<<"$delete_output"; then
+              exit 0
+            fi
+            printf '%s\n' "$delete_output" >&2
+            exit 1
+          fi
+          if grep -Fxq "Worker \"$worker_name\" not found." <<<"$output" ||
              grep -Fq 'This Worker does not exist on your account.' <<<"$output" ||
              grep -Eq 'code.*(10007|10090)' <<<"$output"; then
             exit 0
           fi
           printf '%s\n' "$output" >&2
           exit 1
-      - name: Destroy disposable resources
+      - name: Upload non-secret deployment record
         if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: hqbase-release-staging-manifest-${{ github.run_id }}
+          path: .hqbase/deployments/release-${{ github.run_id }}/manifest.json
+          if-no-files-found: warn
+          retention-days: 30
+      - name: Destroy disposable resources
+        if: >-
+          always() &&
+          steps.reconcile_worker.outcome == 'success' &&
+          steps.reconcile_worker.outputs.manifest_present == 'true'
         run: pnpm hqbase destroy --name "$DEPLOYMENT_NAME" --scope all --yes
 
   publish:

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -14,7 +14,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: hqbase-staging-e2e
+  group: hqbase-staging-resources
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/test/e2e/staging/event-socket.spec.ts
+++ b/test/e2e/staging/event-socket.spec.ts
@@ -1,8 +1,27 @@
+import { createHash, randomBytes } from "node:crypto";
+import { request as httpsRequest } from "node:https";
+
 import { expect, test } from "@playwright/test";
 
+const accessClientId = required("HQBASE_STAGING_ACCESS_CLIENT_ID");
+const accessClientSecret = required("HQBASE_STAGING_ACCESS_CLIENT_SECRET");
 const email = required("HQBASE_STAGING_OWNER_EMAIL");
 const password = required("HQBASE_STAGING_OWNER_PASSWORD");
 const stagingUrl = required("HQBASE_STAGING_URL");
+const maxErrorBodyBytes = 8_192;
+const webSocketAcceptGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+type ProbeOutcome =
+  | { kind: "open"; requestId: string | null }
+  | {
+      kind: "rejected";
+      status: number;
+      cfRay: string | null;
+      requestId: string | null;
+      appErrorCode: string | null;
+    }
+  | { kind: "invalid-handshake"; status: number; requestId: string | null }
+  | { kind: "network-error"; code: string };
 
 test("authenticated event WebSocket opens", async ({ page }) => {
   const login = await page.context().request.post("/api/auth/sign-in/email", {
@@ -11,29 +30,117 @@ test("authenticated event WebSocket opens", async ({ page }) => {
   });
   expect(login.ok(), await login.text()).toBeTruthy();
 
-  await page.goto("/offline.html", { waitUntil: "domcontentloaded" });
-  const outcome = await page.evaluate(
-    () =>
-      new Promise<"failed" | "open">((resolve) => {
-        const url = new URL("/api/v2/events", window.location.href);
-        url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
-        const socket = new WebSocket(url);
-        let finished = false;
-        const finish = (value: "failed" | "open"): void => {
-          if (finished) return;
-          finished = true;
-          socket.close();
-          resolve(value);
-        };
-        socket.addEventListener("open", () => finish("open"));
-        socket.addEventListener("error", () => finish("failed"));
-        socket.addEventListener("close", () => finish("failed"));
-        window.setTimeout(() => finish("failed"), 30_000);
-      })
-  );
+  const cookies = await page.context().cookies(stagingUrl);
+  const cookieHeader = cookies.map(({ name, value }) => `${name}=${value}`).join("; ");
+  expect(cookieHeader, "HQBase sign-in did not create a session cookie.").not.toBe("");
 
-  expect(outcome).toBe("open");
+  const outcome = await probeEventWebSocket(cookieHeader);
+  expect(outcome, `WebSocket upgrade failed: ${JSON.stringify(outcome)}`).toMatchObject({
+    kind: "open",
+    requestId: expect.any(String)
+  });
 });
+
+function probeEventWebSocket(cookie: string): Promise<ProbeOutcome> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (outcome: ProbeOutcome): void => {
+      if (settled) return;
+      settled = true;
+      resolve(outcome);
+    };
+    const webSocketKey = randomBytes(16).toString("base64");
+    const expectedAccept = createHash("sha1")
+      .update(`${webSocketKey}${webSocketAcceptGuid}`)
+      .digest("base64");
+    const request = httpsRequest(new URL("/api/v2/events", stagingUrl), {
+      method: "GET",
+      headers: {
+        connection: "Upgrade",
+        cookie,
+        "cf-access-client-id": accessClientId,
+        "cf-access-client-secret": accessClientSecret,
+        origin: new URL(stagingUrl).origin,
+        "sec-websocket-key": webSocketKey,
+        "sec-websocket-version": "13",
+        upgrade: "websocket"
+      }
+    });
+
+    request.once("upgrade", (response, socket) => {
+      socket.destroy();
+      if (
+        response.statusCode !== 101 ||
+        !headerHasToken(response.headers.upgrade, "websocket") ||
+        !headerHasToken(response.headers.connection, "upgrade") ||
+        firstHeader(response.headers["sec-websocket-accept"]) !== expectedAccept
+      ) {
+        finish({
+          kind: "invalid-handshake",
+          status: response.statusCode ?? 0,
+          requestId: firstHeader(response.headers["x-request-id"])
+        });
+        return;
+      }
+      finish({ kind: "open", requestId: firstHeader(response.headers["x-request-id"]) });
+    });
+    request.once("response", (response) => {
+      const chunks: Buffer[] = [];
+      let size = 0;
+      response.on("data", (chunk) => {
+        if (size >= maxErrorBodyBytes) return;
+        const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        const kept = bytes.subarray(0, maxErrorBodyBytes - size);
+        chunks.push(kept);
+        size += kept.length;
+      });
+      response.once("end", () => {
+        finish({
+          kind: "rejected",
+          status: response.statusCode ?? 0,
+          cfRay: firstHeader(response.headers["cf-ray"]),
+          requestId: firstHeader(response.headers["x-request-id"]),
+          appErrorCode: readAppErrorCode(Buffer.concat(chunks).toString("utf8"))
+        });
+      });
+    });
+    request.once("error", (error: Error & { code?: string }) => {
+      finish({ kind: "network-error", code: error.code ?? error.name });
+    });
+    request.setTimeout(30_000, () => {
+      request.destroy(
+        Object.assign(new Error("WebSocket probe timed out."), { code: "ETIMEDOUT" })
+      );
+    });
+    request.end();
+  });
+}
+
+function firstHeader(value: string | string[] | undefined): string | null {
+  return Array.isArray(value) ? (value[0] ?? null) : (value ?? null);
+}
+
+function headerHasToken(value: string | string[] | undefined, expected: string): boolean {
+  return (Array.isArray(value) ? value : [value]).some((header) =>
+    header
+      ?.split(",")
+      .map((token) => token.trim().toLowerCase())
+      .includes(expected)
+  );
+}
+
+function readAppErrorCode(body: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (!parsed || typeof parsed !== "object") return null;
+    const error = (parsed as { error?: unknown }).error;
+    if (!error || typeof error !== "object") return null;
+    const code = (error as { code?: unknown }).code;
+    return typeof code === "string" ? code : null;
+  } catch {
+    return null;
+  }
+}
 
 function required(name: string): string {
   const value = process.env[name]?.trim();

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -161,10 +161,16 @@ describe("staging workflow lifecycle record", () => {
   it("isolates and cleans the signed-release staging Worker", () => {
     const create = releaseWorkflow.indexOf("      - name: Create disposable customer resources");
     const cleanup = releaseWorkflow.indexOf(
-      "      - name: Remove an empty disposable Worker service"
+      "      - name: Reconcile disposable Worker lifecycle record"
     );
+    const upload = releaseWorkflow.indexOf("      - name: Upload non-secret deployment record");
     const destroy = releaseWorkflow.indexOf("      - name: Destroy disposable resources");
-    const cleanupStep = releaseWorkflow.slice(cleanup, destroy);
+    const cleanupStep = releaseWorkflow.slice(cleanup, upload);
+    const destroyStep = releaseWorkflow.slice(destroy, releaseWorkflow.indexOf("\n\n", destroy));
+    const inspectWorker = cleanupStep.indexOf("wrangler deployments status");
+    const recordWorker = cleanupStep.indexOf("recordWorkerDeployedForConfig");
+    const emptyWorker = cleanupStep.indexOf("The Worker $worker_name has no deployments.");
+    const deleteWorker = cleanupStep.indexOf('wrangler delete "$worker_name"');
 
     expect(releaseWorkflow).toMatch(
       /STAGING_WORKER_NAME: hqbase-release-\$\{\{ github\.run_id \}\}/
@@ -173,8 +179,12 @@ describe("staging workflow lifecycle record", () => {
     expect(releaseWorkflow.match(/--name "\$STAGING_WORKER_NAME"/g)).toHaveLength(4);
     expect(releaseWorkflow).not.toContain("hqbase-e2e-staging");
     expect(cleanup).toBeGreaterThan(create);
-    expect(destroy).toBeGreaterThan(cleanup);
+    expect(upload).toBeGreaterThan(cleanup);
+    expect(destroy).toBeGreaterThan(upload);
     expect(cleanupStep).toContain("if: always()");
+    expect(cleanupStep).toContain("id: reconcile_worker");
+    expect(cleanupStep).toContain('echo "manifest_present=false" >> "$GITHUB_OUTPUT"');
+    expect(cleanupStep).toContain('echo "manifest_present=true" >> "$GITHUB_OUTPUT"');
     expect(cleanupStep).toContain('manifest=".hqbase/deployments/$DEPLOYMENT_NAME/manifest.json"');
     expect(cleanupStep).toContain(`worker_name="$(jq -er '.worker.name' "$manifest")"`);
     expect(cleanupStep).toContain(`worker_deployed="$(jq -r '.worker.deployed' "$manifest")"`);
@@ -183,9 +193,21 @@ describe("staging workflow lifecycle record", () => {
     expect(cleanupStep).toContain("true) exit 0 ;;");
     expect(cleanupStep).toContain("false) ;;");
     expect(cleanupStep).toContain("Invalid Worker deployment state.");
-    expect(cleanupStep).toContain('wrangler delete "$worker_name"');
+    expect(inspectWorker).toBeGreaterThan(-1);
+    expect(recordWorker).toBeGreaterThan(inspectWorker);
+    expect(emptyWorker).toBeGreaterThan(inspectWorker);
+    expect(deleteWorker).toBeGreaterThan(emptyWorker);
     expect(cleanupStep).toContain("This Worker does not exist on your account.");
     expect(cleanupStep).toContain("exit 1");
+    expect(destroyStep).toContain("steps.reconcile_worker.outcome == 'success'");
+    expect(destroyStep).toContain("steps.reconcile_worker.outputs.manifest_present == 'true'");
+  });
+
+  it("serializes workflows that own the protected staging hostname", () => {
+    expect(workflow).toContain("group: hqbase-staging-resources");
+    expect(workflow).toContain("queue: max");
+    expect(releaseWorkflow).toContain("group: hqbase-staging-resources");
+    expect(releaseWorkflow).toContain("queue: max");
   });
 
   it("proves the stale state before the canonical repair and its retry", () => {


### PR DESCRIPTION
## Summary

- send Cloudflare Access credentials and the HQBase session cookie on the staging WebSocket upgrade
- validate the complete WebSocket handshake and emit only safe rejection diagnostics
- reconcile active run Workers before manifest-scoped cleanup
- serialize and queue workflows that share the protected staging hostname

## Documentation

- HQBase/hqbase-site#45

## Verification

- `pnpm check`
- `pnpm deploy:dry-run`
- two independent read-only reviews after fixes