### PR TITLE
Fix remote D1 schema inspection limit

### DIFF
--- a/scripts/release/after-deploy-state.mjs
+++ b/scripts/release/after-deploy-state.mjs
@@ -1,7 +1,7 @@
 import { readdirSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { capture } from "./command.mjs";
+import { attemptRun, emitCommandOutput } from "./command.mjs";
 
 const afterDeployMigrations = [
   "0001_remove_mailbox_alias_storage.sql",
@@ -104,52 +104,66 @@ const inspectedTriggers = [
   ...principalTransitionTriggers
 ];
 
-export const afterDeploySchemaSql = `
-SELECT 'table:' || name AS item
-FROM sqlite_master
-WHERE type = 'table' AND name IN (${sqlList(inspectedTables)})
-UNION ALL
-SELECT 'trigger:' || name AS item
-FROM sqlite_master
-WHERE type = 'trigger' AND name IN (${sqlList(inspectedTriggers)})
-UNION ALL
-SELECT 'column:messages.' || name AS item
-FROM pragma_table_info('messages')
-WHERE name IN ('mailbox_id', 'delivered_to_address', 'delivered_to_address_id', 'sent_from_address_id')
-UNION ALL
-SELECT 'column:mailbox_grants.' || name AS item
-FROM pragma_table_info('mailbox_grants')
-WHERE name IN ('mailbox_id', 'user_id', 'principal_id', 'created_by', 'created_by_principal_id')
-UNION ALL
-SELECT 'column:drafts.' || name AS item
-FROM pragma_table_info('drafts')
-WHERE name IN ('id', 'user_id', 'principal_id')
-UNION ALL
-SELECT 'column:draft_changes.' || name AS item
-FROM pragma_table_info('draft_changes')
-WHERE name IN ('sequence', 'draft_id', 'user_id', 'principal_id')
-UNION ALL
-SELECT 'column:draft_labels.' || name AS item
-FROM pragma_table_info('draft_labels')
-WHERE name IN ('draft_id', 'label_id', 'assigned_by_principal_id')
-UNION ALL
-SELECT 'foreign-key:mailbox_grants.' || "from" || '->' || "table" || '.' || "to" || ':' || "on_delete" AS item
-FROM pragma_foreign_key_list('mailbox_grants')
-WHERE "from" IN ('mailbox_id', 'user_id', 'principal_id', 'created_by', 'created_by_principal_id')
-UNION ALL
-SELECT 'foreign-key:drafts.' || "from" || '->' || "table" || '.' || "to" || ':' || "on_delete" AS item
-FROM pragma_foreign_key_list('drafts')
-WHERE "from" IN ('user_id', 'principal_id')
-UNION ALL
-SELECT 'foreign-key:draft_labels.' || "from" || '->' || "table" || '.' || "to" || ':' || "on_delete" AS item
-FROM pragma_foreign_key_list('draft_labels')
-WHERE "from" = 'draft_id'
-ORDER BY item
-`.trim();
+// Remote D1 rejects a compound SELECT with more than five terms. One Wrangler command keeps both
+// statements in the same D1 batch while parseD1Rows combines their result sets.
+export const afterDeploySchemaSqlStatements = [
+  `
+  SELECT 'table:' || name AS item
+  FROM sqlite_master
+  WHERE type = 'table' AND name IN (${sqlList(inspectedTables)})
+  UNION ALL
+  SELECT 'trigger:' || name AS item
+  FROM sqlite_master
+  WHERE type = 'trigger' AND name IN (${sqlList(inspectedTriggers)})
+  UNION ALL
+  SELECT 'column:messages.' || name AS item
+  FROM pragma_table_info('messages')
+  WHERE name IN ('mailbox_id', 'delivered_to_address', 'delivered_to_address_id', 'sent_from_address_id')
+  UNION ALL
+  SELECT 'column:mailbox_grants.' || name AS item
+  FROM pragma_table_info('mailbox_grants')
+  WHERE name IN ('mailbox_id', 'user_id', 'principal_id', 'created_by', 'created_by_principal_id')
+  UNION ALL
+  SELECT 'column:drafts.' || name AS item
+  FROM pragma_table_info('drafts')
+  WHERE name IN ('id', 'user_id', 'principal_id')
+  ORDER BY item
+  `.trim(),
+  `
+  SELECT 'column:draft_changes.' || name AS item
+  FROM pragma_table_info('draft_changes')
+  WHERE name IN ('sequence', 'draft_id', 'user_id', 'principal_id')
+  UNION ALL
+  SELECT 'column:draft_labels.' || name AS item
+  FROM pragma_table_info('draft_labels')
+  WHERE name IN ('draft_id', 'label_id', 'assigned_by_principal_id')
+  UNION ALL
+  SELECT 'foreign-key:mailbox_grants.' || "from" || '->' || "table" || '.' || "to" || ':' || "on_delete" AS item
+  FROM pragma_foreign_key_list('mailbox_grants')
+  WHERE "from" IN ('mailbox_id', 'user_id', 'principal_id', 'created_by', 'created_by_principal_id')
+  UNION ALL
+  SELECT 'foreign-key:drafts.' || "from" || '->' || "table" || '.' || "to" || ':' || "on_delete" AS item
+  FROM pragma_foreign_key_list('drafts')
+  WHERE "from" IN ('user_id', 'principal_id')
+  UNION ALL
+  SELECT 'foreign-key:draft_labels.' || "from" || '->' || "table" || '.' || "to" || ':' || "on_delete" AS item
+  FROM pragma_foreign_key_list('draft_labels')
+  WHERE "from" = 'draft_id'
+  ORDER BY item
+  `.trim()
+];
+
+export const afterDeploySchemaSql = afterDeploySchemaSqlStatements.join(";\n");
 
 export function inspectRemoteAfterDeployState(source, version, options = {}) {
   const query =
-    options.query ?? ((sql) => queryRemoteD1(source, sql, { capture: options.capture ?? capture }));
+    options.query ??
+    ((sql) =>
+      queryRemoteD1(source, sql, {
+        attempt: options.attempt ?? attemptRun,
+        capture: options.capture,
+        emit: options.emit ?? emitCommandOutput
+      }));
   const expectedNormalMigrations = migrationNames(resolve(source, "migrations"));
   const packagedAfterDeployMigrations = migrationNames(resolve(source, "migrations-after-deploy"));
   if (!sameList(packagedAfterDeployMigrations, afterDeployMigrations)) {
@@ -239,24 +253,30 @@ export function classifyAfterDeployState({
 }
 
 export function queryRemoteD1(source, sql, options = {}) {
-  const output = (options.capture ?? capture)(
-    "pnpm",
-    [
-      "exec",
-      "wrangler",
-      "d1",
-      "execute",
-      "DB",
-      "--remote",
-      "--json",
-      "--command",
-      sql,
-      "--config",
-      "wrangler.jsonc"
-    ],
-    source
-  );
-  return parseD1Rows(output);
+  const args = [
+    "exec",
+    "wrangler",
+    "d1",
+    "execute",
+    "DB",
+    "--remote",
+    "--json",
+    "--command",
+    sql,
+    "--config",
+    "wrangler.jsonc"
+  ];
+  if (options.capture) return parseD1Rows(options.capture("pnpm", args, source));
+
+  const result = (options.attempt ?? attemptRun)("pnpm", args, source);
+  if (result.error || result.status !== 0) {
+    (options.emit ?? emitCommandOutput)(result);
+    throw (
+      result.error ??
+      new Error(`wrangler d1 inspection exited with status ${result.status ?? "signal"}.`)
+    );
+  }
+  return parseD1Rows(result.stdout);
 }
 
 export function parseD1Rows(output) {
@@ -266,9 +286,12 @@ export function parseD1Rows(output) {
   } catch {
     throw new Error("Wrangler returned invalid D1 inspection JSON.");
   }
-  const rows = findResultRows(parsed);
-  if (!rows) throw new Error("Wrangler returned no D1 inspection results.");
-  return rows;
+  const inspection = findResultSets(parsed);
+  if (inspection.failed) throw new Error("Wrangler reported a failed D1 inspection statement.");
+  if (inspection.resultSets.length === 0) {
+    throw new Error("Wrangler returned no D1 inspection results.");
+  }
+  return inspection.resultSets.flat();
 }
 
 function expectedSchemaItems(appliedCount, hasAfterDeployLedger) {
@@ -323,14 +346,17 @@ function sameSet(left, right) {
   return left.size === right.size && [...left].every((value) => right.has(value));
 }
 
-function findResultRows(value) {
-  if (!value || typeof value !== "object") return null;
-  if (Array.isArray(value.results)) return value.results;
-  for (const child of Array.isArray(value) ? value : Object.values(value)) {
-    const rows = findResultRows(child);
-    if (rows) return rows;
+function findResultSets(value, inspection = { failed: false, resultSets: [] }) {
+  if (!value || typeof value !== "object") return inspection;
+  if (!Array.isArray(value) && value.success === false) inspection.failed = true;
+  if (!Array.isArray(value) && Array.isArray(value.results)) {
+    inspection.resultSets.push(value.results);
+    return inspection;
   }
-  return null;
+  for (const child of Array.isArray(value) ? value : Object.values(value)) {
+    findResultSets(child, inspection);
+  }
+  return inspection;
 }
 
 function inconsistentState(detail) {

--- a/test/unit/scripts/after-deploy-state.test.mjs
+++ b/test/unit/scripts/after-deploy-state.test.mjs
@@ -5,8 +5,10 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   afterDeploySchemaSql,
+  afterDeploySchemaSqlStatements,
   classifyAfterDeployState,
-  parseD1Rows
+  parseD1Rows,
+  queryRemoteD1
 } from "../../../scripts/release/after-deploy-state.mjs";
 
 const migrationsDirectory = resolve(import.meta.dirname, "../../../migrations");
@@ -111,7 +113,70 @@ describe("after-deploy state inspection", () => {
     expect(
       parseD1Rows(JSON.stringify({ result: [{ results: [{ item: "table:drafts" }] }] }))
     ).toEqual([{ item: "table:drafts" }]);
+    expect(
+      parseD1Rows(
+        JSON.stringify([
+          { results: [{ item: "table:drafts" }] },
+          { results: [{ item: "column:drafts.id" }] }
+        ])
+      )
+    ).toEqual([{ item: "table:drafts" }, { item: "column:drafts.id" }]);
+    expect(() => parseD1Rows(JSON.stringify([{ results: [], success: false }]))).toThrow(
+      "failed D1 inspection statement"
+    );
     expect(() => parseD1Rows("{}")).toThrow("no D1 inspection results");
+  });
+
+  it("keeps remote schema inspection within the D1 compound-select limit", () => {
+    expect(afterDeploySchemaSqlStatements).toHaveLength(2);
+    for (const statement of afterDeploySchemaSqlStatements) {
+      expect(statement.split(/\b(?:UNION(?:\s+ALL)?|INTERSECT|EXCEPT)\b/i)).toHaveLength(5);
+    }
+    expect(afterDeploySchemaSql).toBe(afterDeploySchemaSqlStatements.join(";\n"));
+  });
+
+  it("sends both schema statements in one remote command and surfaces a failure", () => {
+    const attempts = [];
+    expect(
+      queryRemoteD1("/source", afterDeploySchemaSql, {
+        attempt(command, args, cwd) {
+          attempts.push({ args, command, cwd });
+          return {
+            status: 0,
+            stderr: "",
+            stdout: JSON.stringify([
+              { results: [{ item: "table:drafts" }] },
+              { results: [{ item: "column:drafts.id" }] }
+            ])
+          };
+        }
+      })
+    ).toEqual([{ item: "table:drafts" }, { item: "column:drafts.id" }]);
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0]).toMatchObject({ command: "pnpm", cwd: "/source" });
+    expect(attempts[0].args[attempts[0].args.indexOf("--command") + 1]).toBe(afterDeploySchemaSql);
+
+    const captures = [];
+    expect(
+      queryRemoteD1("/source", "SELECT 1", {
+        capture(command, args, cwd) {
+          captures.push({ args, command, cwd });
+          return JSON.stringify([{ results: [{ item: "table:drafts" }] }]);
+        }
+      })
+    ).toEqual([{ item: "table:drafts" }]);
+    expect(captures).toHaveLength(1);
+
+    let emitted;
+    expect(() =>
+      queryRemoteD1("/source", "SELECT 1", {
+        attempt: () => ({ status: 1, stderr: "D1 error 7500", stdout: "" }),
+        emit: (result) => {
+          emitted = result;
+        }
+      })
+    ).toThrow("wrangler d1 inspection exited with status 1");
+    expect(emitted?.stderr).toBe("D1 error 7500");
   });
 });
 
@@ -171,8 +236,10 @@ function classify(database, normal, hasAfterDeployLedger, pendingUpdates = []) {
 }
 
 function inspectSchema(database) {
-  return database
-    .prepare(afterDeploySchemaSql)
-    .all()
-    .map(({ item }) => item);
+  return afterDeploySchemaSqlStatements.flatMap((statement) =>
+    database
+      .prepare(statement)
+      .all()
+      .map(({ item }) => item)
+  );
 }


### PR DESCRIPTION
## Summary

- split the remote D1 schema inspection into two five-term statements in one Wrangler command
- combine all returned D1 result sets and fail closed on an explicit statement failure
- print Wrangler diagnostics when remote inspection fails
- add regression coverage for the D1 compound-select limit and command behavior

Canonical behavior was specified first in HQBase/hqbase-site#46.

## Verification

- focused after-deploy and deploy tests: 27 passed
- `pnpm check`: 841 unit tests passed, 2 skipped; 193 Worker tests passed
- `pnpm deploy:dry-run`: passed with all required bindings, including `MAIL_EVENTS`
- two independent code reviews: no remaining findings