### PR TITLE
Fix signed update repair trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@v6
         with:
           version: 11.7.0
@@ -145,6 +147,8 @@ jobs:
       HQBASE_STAGING_OWNER_EMAIL: ${{ secrets.HQBASE_E2E_OWNER_EMAIL }}
       HQBASE_STAGING_OWNER_PASSWORD: ${{ secrets.HQBASE_E2E_OWNER_PASSWORD }}
       HQBASE_STAGING_OAUTH_CLIENT_ID: ${{ vars.HQBASE_E2E_OAUTH_CLIENT_ID }}
+      HQBASE_E2E_REPO_CONNECTION_UUID: ${{ vars.HQBASE_E2E_REPO_CONNECTION_UUID }}
+      HQBASE_E2E_BUILD_TOKEN_UUID: ${{ vars.HQBASE_E2E_BUILD_TOKEN_UUID }}
       HQBASE_STAGING_SENDER: hello@${{ secrets.HQBASE_E2E_EMAIL_DOMAIN }}
       HQBASE_STAGING_URL: https://${{ secrets.HQBASE_E2E_APP_HOSTNAME }}
       # This frozen bootstrap is independent of the active-release compatibility floor.
@@ -260,6 +264,8 @@ jobs:
           --auth-url "$HQBASE_STAGING_URL"
           --client-id "$HQBASE_STAGING_OAUTH_CLIENT_ID"
           --skip-deploy
+      - name: Prepare the deployed update-action release gate
+        run: node scripts/release/staging-update-gate.mjs prepare
       - name: Reproduce the legacy Worker configuration
         run: |
           config="$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
@@ -328,6 +334,10 @@ jobs:
             --command "SELECT (SELECT COUNT(*) FROM \"user\") AS user_count, (SELECT COUNT(*) FROM mailboxes) AS mailbox_count, (SELECT value_json FROM app_settings WHERE key = 'release-updater-bridge-probe') AS probe")"
           jq -c '.[0].results[0]' <<<"$snapshot" > /tmp/hqbase-pre-repair-data.json
           pnpm test:e2e:staging:event-socket
+      - name: Exercise the deployed update action without deployment
+        env:
+          HQBASE_E2E_UPDATE_API_TOKEN: ${{ secrets.HQBASE_E2E_UPDATE_API_TOKEN }}
+        run: node scripts/release/staging-update-gate.mjs probe
       - name: Finish the candidate through its canonical signed bootstrap
         run: |
           config="$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
@@ -423,6 +433,10 @@ jobs:
           git diff --quiet
           git diff --cached --quiet
           test -z "$(git ls-files --others --exclude-standard)"
+      - name: Reconcile deployed update-action gate resources
+        if: always()
+        id: reconcile_update_gate
+        run: node scripts/release/staging-update-gate.mjs cleanup
       - name: Reconcile disposable Worker lifecycle record
         if: always()
         id: reconcile_worker
@@ -488,6 +502,7 @@ jobs:
       - name: Destroy disposable resources
         if: >-
           always() &&
+          steps.reconcile_update_gate.outcome == 'success' &&
           steps.reconcile_worker.outcome == 'success' &&
           steps.reconcile_worker.outputs.manifest_present == 'true'
         run: pnpm hqbase destroy --name "$DEPLOYMENT_NAME" --scope all --yes
@@ -604,6 +619,7 @@ jobs:
             import { readFileSync, statSync } from "node:fs";
             const version = process.env.HQBASE_RELEASE_VERSION;
             const config = JSON.parse(readFileSync("config/product.json", "utf8"));
+            const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
             const envelope = JSON.parse(readFileSync("/tmp/stable.json", "utf8"));
             const versionEnvelope = JSON.parse(readFileSync("/tmp/version-manifest.json", "utf8"));
             if (versionEnvelope.payload !== envelope.payload ||
@@ -623,9 +639,21 @@ jobs:
               throw new Error("Published stable manifest identity is invalid.");
             }
             const expectedArtifactUrl = `https://github.com/HQBase/hqbase/releases/download/v${version}/hqbase-${version}.tar.gz`;
-            const expectedUpdaterUrl = `https://raw.githubusercontent.com/HQBase/hqbase/${process.env.RELEASE_COMMIT}/scripts/release/bootstrap.mjs`;
+            const configuredUpdaterCommit = packageJson.hqbaseRelease?.updaterCommit;
+            const updaterCommitVersion = packageJson.hqbaseRelease?.updaterCommitVersion;
+            if (Boolean(configuredUpdaterCommit) !== Boolean(updaterCommitVersion) ||
+                (configuredUpdaterCommit && updaterCommitVersion !== version)) {
+              throw new Error("Committed release updater override is not approved for this version.");
+            }
+            const updaterCommit = configuredUpdaterCommit ?? process.env.RELEASE_COMMIT;
+            if (!/^[a-f0-9]{40}$/.test(updaterCommit)) {
+              throw new Error("Committed release updater commit is invalid.");
+            }
+            const expectedUpdaterUrl = `https://raw.githubusercontent.com/HQBase/hqbase/${updaterCommit}/scripts/release/bootstrap.mjs`;
+            const immutableUpdaterUrl = /^https:\/\/raw\.githubusercontent\.com\/HQBase\/hqbase\/[a-f0-9]{40}\/scripts\/release\/bootstrap\.mjs$/;
             if (manifest.artifact.url !== expectedArtifactUrl ||
                 manifest.updater?.protocol !== 2 ||
+                !immutableUpdaterUrl.test(manifest.updater.sourceUrl) ||
                 manifest.updater.sourceUrl !== expectedUpdaterUrl) {
               throw new Error("Published stable manifest sources are invalid.");
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.3.4
+
+### Fixed
+
+- Start managed updates with a short Workers Builds deploy command and a verified updater-loader
+  variable. This prevents the **Invalid request body** failure after HQBase 1.3.4 is installed and
+  does not change customer source repositories. An affected HQBase 1.3.3 installation that still
+  uses `pnpm deploy` needs the documented one-time Cloudflare recovery to reach this release.
+- Report the exact failed Cloudflare operation after authorization, restore verified trigger changes
+  when setup is rejected, and reconcile an uncertain build response before reporting its result.
+- Test the deployed update action with a real disposable Workers Builds trigger and build request
+  before a signed release is published. The release gate now covers the Cloudflare configuration and
+  build-dispatch boundary that was not tested in 1.3.3.
+
 ## 1.3.3
 
 ### Fixed

--- a/app/features/updates/update-settings.tsx
+++ b/app/features/updates/update-settings.tsx
@@ -103,7 +103,7 @@ export function UpdateSettings({
       ) : null}
       {applyError ? (
         <Alert variant="destructive">
-          <AlertTitle>Update authorization unavailable</AlertTitle>
+          <AlertTitle>Update could not start</AlertTitle>
           <AlertDescription>{applyError}</AlertDescription>
         </Alert>
       ) : null}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "hqbase",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "hqbaseRelease": {
-    "minimumVersion": "1.0.0"
+    "minimumVersion": "1.0.0",
+    "updaterCommit": "7d67e4ae54fe4deafba41c0b5daab5a34cdfe4f9",
+    "updaterCommitVersion": "1.3.4"
   },
   "scripts": {
     "dev": "node scripts/dev.mjs",

--- a/scripts/hqbase/lifecycle-manifest.mjs
+++ b/scripts/hqbase/lifecycle-manifest.mjs
@@ -1,6 +1,7 @@
 const accountIdPattern = /^[0-9a-f]{32}$/i;
 const d1IdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const queueIdPattern = /^[0-9a-f]{32}$/i;
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ownershipStates = new Set(["unclaimed", "creating", "created", "reused", "removed"]);
 const placeholderD1Id = "00000000-0000-0000-0000-000000000000";
 
@@ -42,6 +43,9 @@ export function assertCurrentManifest(manifest, options = {}) {
     } else if (resource.id !== null) {
       throw new Error(`Refusing to continue: an unowned queue must have a null "${path}.id".`);
     }
+  }
+  if (manifest.releaseGate !== undefined) {
+    assertReleaseGate(manifest.releaseGate);
   }
 }
 
@@ -104,6 +108,16 @@ export function assertUnambiguousManifest(manifest, options = {}) {
       );
     }
   }
+  for (const [path, resource] of [
+    ["releaseGate.candidateManifest", manifest.releaseGate?.candidateManifest],
+    ["releaseGate.workersBuild", manifest.releaseGate?.workersBuild]
+  ]) {
+    if (resource && resource.ownership !== "removed") {
+      throw new Error(
+        `Refusing to continue: manifest field "${path}.ownership" is "${resource.ownership}", so the signed-release staging gate still owns a Cloudflare resource. Reconcile the gate before any other lifecycle command.`
+      );
+    }
+  }
 }
 
 export function assertD1Id(id) {
@@ -142,5 +156,125 @@ function assertQueueId(id, path) {
     throw new Error(
       `Refusing to continue: manifest field "${path}.id" must be a 32-character queue ID.`
     );
+  }
+}
+
+function assertReleaseGate(gate) {
+  const candidate = gate?.candidateManifest;
+  const build = gate?.workersBuild;
+  assertOwnership(candidate, "releaseGate.candidateManifest");
+  assertOwnership(build, "releaseGate.workersBuild");
+  assertNonEmptyString(candidate?.name, "releaseGate.candidateManifest.name");
+  assertNonEmptyString(candidate?.path, "releaseGate.candidateManifest.path");
+  assertNonEmptyString(candidate?.url, "releaseGate.candidateManifest.url");
+  if (!/^[a-f0-9]{64}$/.test(candidate?.sha256 ?? "")) {
+    throw new Error(
+      'Refusing to continue: manifest field "releaseGate.candidateManifest.sha256" must be a SHA-256 digest.'
+    );
+  }
+  if (candidate?.workerTag !== null && !accountIdPattern.test(candidate?.workerTag ?? "")) {
+    throw new Error(
+      'Refusing to continue: manifest field "releaseGate.candidateManifest.workerTag" must be null or a 32-character Worker tag.'
+    );
+  }
+  if (candidate.ownership === "created" && candidate.workerTag === null) {
+    throw new Error(
+      'Refusing to continue: a created release-gate manifest Worker must record "releaseGate.candidateManifest.workerTag".'
+    );
+  }
+  let candidateUrl;
+  try {
+    candidateUrl = new URL(candidate.url);
+  } catch {
+    throw new Error(
+      'Refusing to continue: manifest field "releaseGate.candidateManifest.url" must be a valid URL.'
+    );
+  }
+  if (candidateUrl.protocol !== "https:" || candidateUrl.pathname !== candidate.path) {
+    throw new Error(
+      "Refusing to continue: the release-gate manifest URL must be HTTPS and match its recorded path."
+    );
+  }
+
+  assertNonEmptyString(build?.triggerName, "releaseGate.workersBuild.triggerName");
+  if (!accountIdPattern.test(build?.workerTag ?? "")) {
+    throw new Error(
+      'Refusing to continue: manifest field "releaseGate.workersBuild.workerTag" must be a 32-character Worker tag.'
+    );
+  }
+  for (const field of ["repoConnectionUuid", "buildTokenUuid"]) {
+    if (!uuidPattern.test(build?.[field] ?? "")) {
+      throw new Error(
+        `Refusing to continue: manifest field "releaseGate.workersBuild.${field}" must be a UUID.`
+      );
+    }
+  }
+  for (const field of ["triggerUuid", "buildUuid"]) {
+    if (build?.[field] !== null && !uuidPattern.test(build?.[field] ?? "")) {
+      throw new Error(
+        `Refusing to continue: manifest field "releaseGate.workersBuild.${field}" must be null or a UUID.`
+      );
+    }
+  }
+  if (build.ownership === "created" && build.triggerUuid === null) {
+    throw new Error(
+      'Refusing to continue: a created release-gate trigger must record "releaseGate.workersBuild.triggerUuid".'
+    );
+  }
+  for (const [field, expected] of [
+    ["branch", "main"],
+    ["buildCommand", "sleep 600"],
+    ["initialDeployCommand", "pnpm deploy"],
+    ["rootDirectory", "/"]
+  ]) {
+    if (build?.[field] !== expected) {
+      throw new Error(
+        `Refusing to continue: manifest field "releaseGate.workersBuild.${field}" must be "${expected}".`
+      );
+    }
+  }
+  if (
+    !Array.isArray(build?.pathIncludes) ||
+    build.pathIncludes.length !== 1 ||
+    build.pathIncludes[0] !== ".hqbase-release-gate-never"
+  ) {
+    throw new Error(
+      'Refusing to continue: manifest field "releaseGate.workersBuild.pathIncludes" must record the release-gate path.'
+    );
+  }
+  if (
+    build?.buildOutcome !== null &&
+    build.buildOutcome !== "cancelled" &&
+    build.buildOutcome !== "terminated"
+  ) {
+    throw new Error(
+      'Refusing to continue: manifest field "releaseGate.workersBuild.buildOutcome" must be null or a cancellation outcome.'
+    );
+  }
+  if ((build?.stoppedOn === null) !== (build?.buildOutcome === null)) {
+    throw new Error(
+      "Refusing to continue: the release-gate build outcome and stop time must be recorded together."
+    );
+  }
+  if (build?.dispatchStartedAt !== null && !Number.isFinite(Date.parse(build.dispatchStartedAt))) {
+    throw new Error(
+      'Refusing to continue: manifest field "releaseGate.workersBuild.dispatchStartedAt" must be null or an ISO date.'
+    );
+  }
+  if (build?.buildUuid !== null && build?.dispatchStartedAt === null) {
+    throw new Error(
+      "Refusing to continue: a release-gate build UUID requires its recorded dispatch start time."
+    );
+  }
+  if (build?.stoppedOn !== null && !Number.isFinite(Date.parse(build.stoppedOn))) {
+    throw new Error(
+      'Refusing to continue: manifest field "releaseGate.workersBuild.stoppedOn" must be an ISO date.'
+    );
+  }
+}
+
+function assertNonEmptyString(value, path) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Refusing to continue: manifest field "${path}" must be a non-empty string.`);
   }
 }

--- a/scripts/release/package.mjs
+++ b/scripts/release/package.mjs
@@ -40,10 +40,38 @@ const sourceCommit = execFileSync("git", ["rev-parse", "HEAD"], {
 if (!/^[a-f0-9]{40}$/.test(sourceCommit)) {
   throw new Error("Release source commit is invalid.");
 }
+const configuredUpdaterCommit = packageJson.hqbaseRelease?.updaterCommit;
+const updaterCommitVersion = packageJson.hqbaseRelease?.updaterCommitVersion;
+if (Boolean(configuredUpdaterCommit) !== Boolean(updaterCommitVersion)) {
+  throw new Error("Release updater override needs both a commit and a version.");
+}
+if (configuredUpdaterCommit && updaterCommitVersion !== version) {
+  throw new Error("Release updater override is not approved for this version.");
+}
+const updaterCommit = configuredUpdaterCommit ?? sourceCommit;
+if (!/^[a-f0-9]{40}$/.test(updaterCommit)) {
+  throw new Error("Release updater commit is invalid.");
+}
+let resolvedUpdaterCommit;
+try {
+  resolvedUpdaterCommit = execFileSync(
+    "git",
+    ["rev-parse", "--verify", `${updaterCommit}^{commit}`],
+    {
+      cwd: root,
+      encoding: "utf8"
+    }
+  ).trim();
+} catch {
+  throw new Error("Release updater commit is not available in the checkout.");
+}
+if (resolvedUpdaterCommit !== updaterCommit) {
+  throw new Error("Release updater commit must identify a commit.");
+}
 // Hash the committed source that the URL serves, never uncommitted working-tree bytes.
 const updaterBytes = execFileSync(
   "git",
-  ["show", `${sourceCommit}:scripts/release/bootstrap.mjs`],
+  ["show", `${updaterCommit}:scripts/release/bootstrap.mjs`],
   { cwd: root }
 );
 const manifest = {
@@ -63,7 +91,7 @@ const manifest = {
   },
   updater: {
     protocol: 2,
-    sourceUrl: `https://raw.githubusercontent.com/HQBase/hqbase/${sourceCommit}/scripts/release/bootstrap.mjs`,
+    sourceUrl: `https://raw.githubusercontent.com/HQBase/hqbase/${updaterCommit}/scripts/release/bootstrap.mjs`,
     sha256: createHash("sha256").update(updaterBytes).digest("hex"),
     size: updaterBytes.length
   },

--- a/scripts/release/staging-update-gate-app.mjs
+++ b/scripts/release/staging-update-gate-app.mjs
@@ -1,0 +1,115 @@
+import { cloudflareHeaders, cloudflareResult } from "./staging-update-gate-shared.mjs";
+
+export async function verifyUpdateTokenActive(context, dependencies) {
+  const result = await cloudflareResult(
+    "/user/tokens/verify",
+    { headers: cloudflareHeaders(context.updateToken) },
+    dependencies.fetcher
+  );
+  if (result?.status !== "active") {
+    throw new Error(
+      "The deployed update action revoked the persistent staging API token. Replace the staging token before another release."
+    );
+  }
+}
+
+export async function installationSnapshot(manifest, context, dependencies) {
+  const [deployment, query] = await Promise.all([
+    cloudflareResult(
+      `/accounts/${context.accountId}/workers/scripts/${encodeURIComponent(context.workerName)}/deployments`,
+      { headers: cloudflareHeaders(context.cleanupToken) },
+      dependencies.fetcher
+    ),
+    cloudflareResult(
+      `/accounts/${context.accountId}/d1/database/${manifest.d1.id}/query`,
+      {
+        body: JSON.stringify({
+          sql: `SELECT (SELECT installed_version FROM release_state WHERE singleton = 1) AS installed_version, (SELECT installed_schema_version FROM release_state WHERE singleton = 1) AS installed_schema_version, (SELECT COUNT(*) FROM d1_migrations) AS normal_migration_count, (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'd1_migrations_after_deploy') AS after_deploy_ledger_table_count, (SELECT COUNT(*) FROM update_history) AS update_history_count, (SELECT COUNT(*) FROM app_settings WHERE key LIKE 'update_build_lock:%') AS update_build_lock_count, (SELECT COUNT(*) FROM "user") AS user_count, (SELECT COUNT(*) FROM mailboxes) AS mailbox_count, (SELECT COUNT(*) FROM drafts) AS draft_count, (SELECT COUNT(*) FROM messages) AS message_count, (SELECT value_json FROM app_settings WHERE key = 'release-updater-bridge-probe') AS probe`
+        }),
+        headers: cloudflareHeaders(context.cleanupToken, true),
+        method: "POST"
+      },
+      dependencies.fetcher
+    )
+  ]);
+  const versions = (deployment?.deployments ?? []).flatMap((item) => item.versions ?? []);
+  const active = versions.find((version) => version.percentage === 100);
+  const row = query?.[0]?.results?.[0];
+  if (!active?.version_id || !row || row.update_build_lock_count !== 0) {
+    throw new Error("Cloudflare did not return a clean active Worker and D1 staging snapshot.");
+  }
+  return { d1: row, workerVersionId: active.version_id };
+}
+
+export async function signIn(context, fetcher) {
+  const response = await appRequest(
+    context,
+    "/api/auth/sign-in/email",
+    {
+      body: JSON.stringify({
+        email: context.ownerEmail,
+        password: context.ownerPassword,
+        rememberMe: false
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST"
+    },
+    fetcher
+  );
+  if (!response.ok) {
+    throw new Error(`Staging owner sign-in returned HTTP ${response.status}.`);
+  }
+  const cookies = setCookieValues(response.headers)
+    .map((value) => value.split(";", 1)[0])
+    .filter(Boolean);
+  if (cookies.length === 0)
+    throw new Error("Staging owner sign-in did not return a session cookie.");
+  return cookies;
+}
+
+export async function appRequest(context, pathname, init, fetcher) {
+  return fetcher(new URL(pathname, context.appUrl), {
+    ...init,
+    headers: {
+      accept: "application/json",
+      "CF-Access-Client-Id": context.accessClientId,
+      "CF-Access-Client-Secret": context.accessClientSecret,
+      origin: context.appUrl,
+      ...init.headers
+    },
+    redirect: "manual",
+    signal: AbortSignal.timeout(30_000)
+  });
+}
+
+export async function requireAppJson(response, status, operation) {
+  if (response.status !== status) {
+    throw new Error(
+      `${operation} returned HTTP ${response.status} (${await appErrorCode(response)}).`
+    );
+  }
+  return parseJson(response, operation);
+}
+
+export async function appErrorCode(response) {
+  try {
+    const body = await response.clone().json();
+    return typeof body?.error?.code === "string" ? body.error.code : "unknown error";
+  } catch {
+    return "invalid response";
+  }
+}
+
+export async function parseJson(response, operation) {
+  try {
+    return await response.json();
+  } catch {
+    throw new Error(`${operation} returned invalid JSON.`);
+  }
+}
+
+export function setCookieValues(headers) {
+  if (typeof headers.getSetCookie === "function") return headers.getSetCookie();
+  const value = headers.get("set-cookie");
+  return value ? [value] : [];
+}

--- a/scripts/release/staging-update-gate-resources.mjs
+++ b/scripts/release/staging-update-gate-resources.mjs
@@ -1,0 +1,322 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  assertExactTrigger,
+  branch,
+  cloudflareHeaders,
+  cloudflareResult,
+  initialBuildCommand,
+  initialDeployCommand,
+  listTriggers,
+  listWorkers,
+  managedCommand,
+  managedUpdaterLoader,
+  repositoryRoot,
+  terminalOutcomes,
+  triggerCreateBody,
+  uuidPattern,
+  workerTagPattern
+} from "./staging-update-gate-shared.mjs";
+
+export async function ensureCandidateManifestWorker(manifest, body, context, dependencies) {
+  const record = manifest.releaseGate.candidateManifest;
+  const existing = (await listWorkers(context, dependencies)).find(
+    (item) => item.id === record.name
+  );
+  if (existing) {
+    if (record.workerTag && existing.tag !== record.workerTag) {
+      throw new Error("The candidate-manifest Worker tag does not match its lifecycle record.");
+    }
+    await verifyCandidateResponse(record, body, dependencies);
+    record.workerTag = existing.tag;
+    record.ownership = "created";
+    dependencies.writeManifest(manifest);
+    return;
+  }
+
+  record.ownership = "creating";
+  dependencies.writeManifest(manifest);
+  const temporary = fs.mkdtempSync(path.join(os.tmpdir(), "hqbase-release-gate-"));
+  try {
+    const sourceFile = path.join(temporary, "worker.mjs");
+    const configFile = path.join(temporary, "wrangler.jsonc");
+    fs.writeFileSync(
+      sourceFile,
+      `const body=${JSON.stringify(body)};const pathname=${JSON.stringify(record.path)};export default{fetch(request){const url=new URL(request.url);if(request.method!=="GET"||url.pathname!==pathname)return new Response(null,{status:404});return new Response(body,{headers:{"cache-control":"no-store","content-type":"application/json"}})}};\n`
+    );
+    fs.writeFileSync(
+      configFile,
+      `${JSON.stringify(
+        {
+          compatibility_date: "2025-01-01",
+          main: "worker.mjs",
+          name: record.name,
+          preview_urls: false,
+          workers_dev: true
+        },
+        null,
+        2
+      )}\n`
+    );
+    dependencies.runCommand(
+      "pnpm",
+      ["exec", "wrangler", "deploy", "--config", configFile],
+      repositoryRoot
+    );
+  } finally {
+    fs.rmSync(temporary, { force: true, recursive: true });
+  }
+  await verifyCandidateResponse(record, body, dependencies);
+  const created = (await listWorkers(context, dependencies)).find(
+    (item) => item.id === record.name
+  );
+  if (!workerTagPattern.test(created?.tag ?? "")) {
+    throw new Error("Cloudflare did not confirm the candidate-manifest Worker identity.");
+  }
+  record.workerTag = created.tag;
+  record.ownership = "created";
+  dependencies.writeManifest(manifest);
+}
+
+async function verifyCandidateResponse(record, body, dependencies) {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      const response = await dependencies.fetcher(record.url, {
+        headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(5_000)
+      });
+      if (response.ok && (await response.text()) === body) return;
+    } catch {
+      // A new workers.dev route can need a short propagation period.
+    }
+    await dependencies.sleep(1_000);
+  }
+  throw new Error("The candidate-manifest Worker did not serve the exact signed envelope.");
+}
+
+export async function ensureBuildTrigger(manifest, context, dependencies) {
+  const record = manifest.releaseGate.workersBuild;
+  const triggers = await listTriggers(record.workerTag, context, dependencies);
+  const matches = triggers.filter((trigger) => trigger.trigger_name === record.triggerName);
+  if (
+    matches.length > 1 ||
+    triggers.some((trigger) => trigger.trigger_name !== record.triggerName)
+  ) {
+    throw new Error("The disposable staging Worker has an unexpected Workers Builds trigger.");
+  }
+  if (matches.length === 1) {
+    assertExactTrigger(matches[0], record, [initialDeployCommand]);
+    record.triggerUuid = matches[0].trigger_uuid;
+    record.ownership = "created";
+    dependencies.writeManifest(manifest);
+    return;
+  }
+
+  record.ownership = "creating";
+  dependencies.writeManifest(manifest);
+  const created = await cloudflareResult(
+    `/accounts/${context.accountId}/builds/triggers`,
+    {
+      body: JSON.stringify(triggerCreateBody(record)),
+      headers: cloudflareHeaders(context.cleanupToken, true),
+      method: "POST"
+    },
+    dependencies.fetcher
+  );
+  assertExactTrigger(created, record, [initialDeployCommand]);
+  record.triggerUuid = created.trigger_uuid;
+  record.ownership = "created";
+  dependencies.writeManifest(manifest);
+}
+
+export async function verifyAcceptedBuild(manifest, release, context, dependencies) {
+  const record = manifest.releaseGate.workersBuild;
+  const triggers = await listTriggers(record.workerTag, context, dependencies);
+  const trigger = triggers.find((item) => item.trigger_uuid === record.triggerUuid);
+  assertExactTrigger(trigger, record, [managedCommand]);
+  const variables = await cloudflareResult(
+    `/accounts/${context.accountId}/builds/triggers/${record.triggerUuid}/environment_variables`,
+    { headers: cloudflareHeaders(context.cleanupToken) },
+    dependencies.fetcher
+  );
+  if (
+    variables?.HQBASE_UPDATER_LOADER?.is_secret !== false ||
+    variables.HQBASE_UPDATER_LOADER.value !== managedUpdaterLoader(release.updater) ||
+    variables?.HQBASE_EXPECTED_RELEASE_VERSION?.is_secret !== false ||
+    variables.HQBASE_EXPECTED_RELEASE_VERSION.value !== context.candidateVersion ||
+    variables?.HQBASE_FORCE_SOURCE_DEPLOY !== undefined
+  ) {
+    throw new Error("The accepted build did not keep the exact signed updater variables.");
+  }
+  const build = await waitForBuild(record.buildUuid, context, dependencies);
+  const metadata = build.build_trigger_metadata ?? {};
+  if (
+    build.build_uuid !== record.buildUuid ||
+    build.trigger?.trigger_uuid !== record.triggerUuid ||
+    metadata.branch !== branch ||
+    !["api", "manual"].includes(metadata.build_trigger_source) ||
+    metadata.build_command !== initialBuildCommand ||
+    metadata.deploy_command !== managedCommand ||
+    metadata.environment_variables?.HQBASE_UPDATER_LOADER !==
+      managedUpdaterLoader(release.updater) ||
+    metadata.environment_variables?.HQBASE_EXPECTED_RELEASE_VERSION !== context.candidateVersion ||
+    metadata.build_token_uuid !== record.buildTokenUuid ||
+    metadata.root_directory !== "/"
+  ) {
+    throw new Error("Cloudflare did not record the exact release-gate build configuration.");
+  }
+}
+
+export async function reconcileAndCancelBuild(manifest, context, dependencies) {
+  const record = manifest.releaseGate.workersBuild;
+  if (!record.buildUuid && record.dispatchStartedAt && record.triggerUuid) {
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      const result = await cloudflareResult(
+        `/accounts/${context.accountId}/builds/workers/${record.workerTag}/builds`,
+        { headers: cloudflareHeaders(context.cleanupToken) },
+        dependencies.fetcher
+      );
+      const builds = Array.isArray(result) ? result : Object.values(result?.builds ?? {});
+      const earliest = Date.parse(record.dispatchStartedAt) - 5_000;
+      const matches = builds.filter((build) => {
+        const source = build.build_trigger_metadata?.build_trigger_source;
+        return (
+          build.trigger?.trigger_uuid === record.triggerUuid &&
+          build.build_trigger_metadata?.branch === branch &&
+          ["api", "manual"].includes(source) &&
+          Number.isFinite(Date.parse(build.created_on ?? "")) &&
+          Date.parse(build.created_on) >= earliest
+        );
+      });
+      if (matches.length > 1) {
+        throw new Error("Cloudflare returned more than one build for the recorded gate dispatch.");
+      }
+      if (matches.length === 1) {
+        if (!uuidPattern.test(matches[0].build_uuid ?? "")) {
+          throw new Error("Cloudflare returned an invalid build identity during reconciliation.");
+        }
+        record.buildUuid = matches[0].build_uuid;
+        dependencies.writeManifest(manifest);
+        break;
+      }
+      await dependencies.sleep(1_000);
+    }
+  }
+  if (record.buildUuid && !record.buildOutcome) {
+    await cancelRecordedBuild(manifest, context, dependencies);
+  }
+}
+
+export async function cancelRecordedBuild(manifest, context, dependencies) {
+  const record = manifest.releaseGate.workersBuild;
+  let build = await waitForBuild(record.buildUuid, context, dependencies);
+  if (build.status !== "stopped") {
+    await cloudflareResult(
+      `/accounts/${context.accountId}/builds/builds/${record.buildUuid}/cancel`,
+      { headers: cloudflareHeaders(context.cleanupToken), method: "PUT" },
+      dependencies.fetcher
+    );
+    build = await waitForBuild(record.buildUuid, context, dependencies, true);
+  }
+  if (
+    build.status !== "stopped" ||
+    !terminalOutcomes.has(build.build_outcome) ||
+    !Number.isFinite(Date.parse(build.stopped_on ?? ""))
+  ) {
+    throw new Error("The release-gate build did not stop with a verified cancellation outcome.");
+  }
+  record.buildOutcome = build.build_outcome;
+  record.stoppedOn = build.stopped_on;
+  dependencies.writeManifest(manifest);
+}
+
+async function waitForBuild(buildUuid, context, dependencies, requireStopped = false) {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const result = await cloudflareResult(
+      `/accounts/${context.accountId}/builds/builds/${buildUuid}`,
+      { headers: cloudflareHeaders(context.cleanupToken) },
+      dependencies.fetcher,
+      { allowNotFound: true }
+    );
+    if (result && (!requireStopped || result.status === "stopped")) return result;
+    await dependencies.sleep(1_000);
+  }
+  throw new Error("Cloudflare did not return the release-gate build in time.");
+}
+
+export async function removeBuildTrigger(manifest, context, dependencies) {
+  const record = manifest.releaseGate.workersBuild;
+  if (record.ownership === "removed") return;
+  const triggers = await listTriggers(record.workerTag, context, dependencies);
+  const named = triggers.filter((trigger) => trigger.trigger_name === record.triggerName);
+  const exact = record.triggerUuid
+    ? triggers.find((trigger) => trigger.trigger_uuid === record.triggerUuid)
+    : named[0];
+  if (!exact) {
+    if (named.length > 0) {
+      throw new Error("The release-gate trigger name now belongs to a different trigger UUID.");
+    }
+    record.ownership = "removed";
+    dependencies.writeManifest(manifest);
+    return;
+  }
+  if (named.length !== 1) {
+    throw new Error("Cloudflare returned an ambiguous release-gate trigger identity.");
+  }
+  assertExactTrigger(exact, record, [initialDeployCommand, managedCommand]);
+  if (!record.triggerUuid) {
+    record.triggerUuid = exact.trigger_uuid;
+    record.ownership = "created";
+    dependencies.writeManifest(manifest);
+  }
+  await cloudflareResult(
+    `/accounts/${context.accountId}/builds/triggers/${record.triggerUuid}`,
+    { headers: cloudflareHeaders(context.cleanupToken), method: "DELETE" },
+    dependencies.fetcher
+  );
+  const remaining = await listTriggers(record.workerTag, context, dependencies);
+  if (
+    remaining.some(
+      (trigger) =>
+        trigger.trigger_uuid === record.triggerUuid || trigger.trigger_name === record.triggerName
+    )
+  ) {
+    throw new Error("Cloudflare still reports the exact release-gate trigger after deletion.");
+  }
+  record.ownership = "removed";
+  dependencies.writeManifest(manifest);
+}
+
+export async function removeCandidateManifestWorker(manifest, context, dependencies) {
+  const record = manifest.releaseGate.candidateManifest;
+  if (record.ownership === "removed") return;
+  let current = (await listWorkers(context, dependencies)).find((item) => item.id === record.name);
+  if (!current) {
+    record.ownership = "removed";
+    dependencies.writeManifest(manifest);
+    return;
+  }
+  if (record.workerTag && current.tag !== record.workerTag) {
+    throw new Error("The candidate-manifest Worker name now belongs to a different Worker tag.");
+  }
+  if (!record.workerTag) {
+    if (!workerTagPattern.test(current.tag ?? "")) {
+      throw new Error("Cloudflare returned an invalid candidate-manifest Worker tag.");
+    }
+    record.workerTag = current.tag;
+    dependencies.writeManifest(manifest);
+  }
+  await cloudflareResult(
+    `/accounts/${context.accountId}/workers/scripts/${encodeURIComponent(record.name)}`,
+    { headers: cloudflareHeaders(context.cleanupToken), method: "DELETE" },
+    dependencies.fetcher
+  );
+  current = (await listWorkers(context, dependencies)).find((item) => item.id === record.name);
+  if (current) {
+    throw new Error("Cloudflare still reports the exact candidate-manifest Worker after deletion.");
+  }
+  record.ownership = "removed";
+  dependencies.writeManifest(manifest);
+}

--- a/scripts/release/staging-update-gate-shared.mjs
+++ b/scripts/release/staging-update-gate-shared.mjs
@@ -1,0 +1,282 @@
+import { createCipheriv, createHash, randomBytes } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { assertCurrentManifest } from "../hqbase/lifecycle-manifest.mjs";
+import { configPath, loadManifest, manifestExists, writeManifest } from "../hqbase/manifest.mjs";
+import { run } from "./command.mjs";
+
+const apiBase = "https://api.cloudflare.com/client/v4";
+
+export const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export const workerTagPattern = /^[0-9a-f]{32}$/i;
+export const managedCommand = 'node --input-type=module --eval "$HQBASE_UPDATER_LOADER"';
+export const initialBuildCommand = "sleep 600";
+export const initialDeployCommand = "pnpm deploy";
+export const gatePath = ".hqbase-release-gate-never";
+export const branch = "main";
+export const terminalOutcomes = new Set(["cancelled", "terminated"]);
+export const repositoryRoot = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+
+export function createRuntimeGrantCookie(token, secret, iv = randomBytes(12)) {
+  const key = createHash("sha256").update(`hqbase-runtime-cloudflare-oauth:${secret}`).digest();
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(token, "utf8"),
+    cipher.final(),
+    cipher.getAuthTag()
+  ]);
+  return `hqb_cf_oauth_grant=${encodeURIComponent(`${iv.toString("base64url")}.${encrypted.toString("base64url")}`)}`;
+}
+
+export function managedUpdaterLoader(updater) {
+  const { sha256, size, sourceUrl } = updater;
+  return `const u="${sourceUrl}";const h="${sha256}";const n=${size};const r=await fetch(u);if(!r.ok)throw new Error("HQBase updater download failed.");const b=Buffer.from(await r.arrayBuffer());const {createHash}=await import("node:crypto");if(b.length!==n||createHash("sha256").update(b).digest("hex")!==h)throw new Error("HQBase updater verification failed.");await import("data:text/javascript;base64,"+b.toString("base64"));`;
+}
+
+export async function listWorkers(context, dependencies) {
+  const result = await cloudflareResult(
+    `/accounts/${context.accountId}/workers/scripts`,
+    { headers: cloudflareHeaders(context.cleanupToken) },
+    dependencies.fetcher
+  );
+  return Array.isArray(result) ? result : [];
+}
+
+export async function listTriggers(workerTag, context, dependencies) {
+  const result = await cloudflareResult(
+    `/accounts/${context.accountId}/builds/workers/${workerTag}/triggers`,
+    { headers: cloudflareHeaders(context.cleanupToken) },
+    dependencies.fetcher
+  );
+  return Array.isArray(result) ? result : [];
+}
+
+export async function cloudflareResult(pathname, init, fetcher, options = {}) {
+  const response = await fetcher(`${apiBase}${pathname}`, {
+    ...init,
+    signal: AbortSignal.timeout(30_000)
+  });
+  if (options.allowNotFound && response.status === 404) return null;
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    throw new Error(`Cloudflare returned invalid JSON for ${init.method ?? "GET"} ${pathname}.`);
+  }
+  if (!response.ok || body?.success === false) {
+    const code = body?.errors?.[0]?.code ?? "unknown";
+    throw new Error(
+      `Cloudflare rejected ${init.method ?? "GET"} ${pathname} with HTTP ${response.status} (code ${code}).`
+    );
+  }
+  return body?.result;
+}
+
+export function cloudflareHeaders(token, json = false) {
+  return {
+    accept: "application/json",
+    authorization: `Bearer ${token}`,
+    ...(json ? { "content-type": "application/json" } : {})
+  };
+}
+
+export function triggerCreateBody(record) {
+  return {
+    branch_excludes: [],
+    branch_includes: [record.branch],
+    build_caching_enabled: false,
+    build_command: record.buildCommand,
+    build_token_uuid: record.buildTokenUuid,
+    deploy_command: record.initialDeployCommand,
+    external_script_id: record.workerTag,
+    path_excludes: [],
+    path_includes: record.pathIncludes,
+    repo_connection_uuid: record.repoConnectionUuid,
+    root_directory: record.rootDirectory,
+    trigger_name: record.triggerName
+  };
+}
+
+export function assertExactTrigger(trigger, record, allowedDeployCommands) {
+  if (
+    !trigger ||
+    !uuidPattern.test(trigger.trigger_uuid ?? "") ||
+    trigger.trigger_name !== record.triggerName ||
+    trigger.external_script_id !== record.workerTag ||
+    trigger.repo_connection?.repo_connection_uuid !== record.repoConnectionUuid ||
+    trigger.build_token_uuid !== record.buildTokenUuid ||
+    trigger.build_command !== record.buildCommand ||
+    !allowedDeployCommands.includes(trigger.deploy_command) ||
+    trigger.root_directory !== record.rootDirectory ||
+    trigger.build_caching_enabled !== false ||
+    JSON.stringify(trigger.branch_includes) !== JSON.stringify([record.branch]) ||
+    JSON.stringify(trigger.branch_excludes) !== "[]" ||
+    JSON.stringify(trigger.path_includes) !== JSON.stringify(record.pathIncludes) ||
+    JSON.stringify(trigger.path_excludes) !== "[]"
+  ) {
+    throw new Error("Cloudflare returned a Workers Builds trigger that does not match the record.");
+  }
+}
+
+export function writeCandidateManifestUrl(file, url) {
+  const config = JSON.parse(fs.readFileSync(file, "utf8"));
+  config.vars = { ...config.vars, HQBASE_RELEASE_MANIFEST_URL: url };
+  fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+export function readCandidate(context, dependencies) {
+  const raw = dependencies.readFile(context.releaseManifestFile, "utf8");
+  const envelope = JSON.parse(raw);
+  const manifest = JSON.parse(Buffer.from(envelope.payload ?? "", "base64url").toString("utf8"));
+  if (
+    typeof envelope.signature !== "string" ||
+    manifest.version !== context.candidateVersion ||
+    manifest.updater?.protocol !== 2 ||
+    typeof manifest.updater?.sourceUrl !== "string" ||
+    !/^[a-f0-9]{64}$/.test(manifest.updater?.sha256 ?? "") ||
+    !Number.isInteger(manifest.updater?.size) ||
+    manifest.updater.size <= 0
+  ) {
+    throw new Error("The staging gate received an invalid signed candidate manifest.");
+  }
+  return {
+    manifest,
+    raw,
+    sha256: createHash("sha256").update(raw).digest("hex")
+  };
+}
+
+export function assertSameGateIdentity(actual, expected) {
+  const identity = (gate) => ({
+    candidateManifest: {
+      name: gate.candidateManifest.name,
+      path: gate.candidateManifest.path,
+      sha256: gate.candidateManifest.sha256,
+      url: gate.candidateManifest.url
+    },
+    workersBuild: {
+      branch: gate.workersBuild.branch,
+      buildCommand: gate.workersBuild.buildCommand,
+      buildTokenUuid: gate.workersBuild.buildTokenUuid,
+      initialDeployCommand: gate.workersBuild.initialDeployCommand,
+      pathIncludes: gate.workersBuild.pathIncludes,
+      repoConnectionUuid: gate.workersBuild.repoConnectionUuid,
+      rootDirectory: gate.workersBuild.rootDirectory,
+      triggerName: gate.workersBuild.triggerName,
+      workerTag: gate.workersBuild.workerTag
+    }
+  });
+  if (JSON.stringify(identity(actual)) !== JSON.stringify(identity(expected))) {
+    throw new Error("The existing release-gate lifecycle record does not match this workflow run.");
+  }
+}
+
+export function assertReadyGate(gate) {
+  if (
+    gate?.candidateManifest?.ownership !== "created" ||
+    gate?.workersBuild?.ownership !== "created" ||
+    !uuidPattern.test(gate.workersBuild.triggerUuid ?? "")
+  ) {
+    throw new Error("The deployed update-action release gate is not ready.");
+  }
+}
+
+export function assertDeployment(manifest, context) {
+  assertCurrentManifest(manifest);
+  if (
+    manifest.name !== context.deploymentName ||
+    manifest.accountId !== context.accountId ||
+    manifest.worker.name !== context.workerName ||
+    manifest.worker.deployed !== true
+  ) {
+    throw new Error("The staging deployment does not match the release-gate environment.");
+  }
+}
+
+export function commonContext(environment) {
+  const deploymentName = required(environment, "DEPLOYMENT_NAME");
+  const accountId = required(environment, "CLOUDFLARE_ACCOUNT_ID");
+  if (!workerTagPattern.test(accountId)) {
+    throw new Error("CLOUDFLARE_ACCOUNT_ID must be 32 hexadecimal characters.");
+  }
+  const repoConnectionUuid = required(environment, "HQBASE_E2E_REPO_CONNECTION_UUID");
+  const buildTokenUuid = required(environment, "HQBASE_E2E_BUILD_TOKEN_UUID");
+  for (const [name, value] of [
+    ["HQBASE_E2E_REPO_CONNECTION_UUID", repoConnectionUuid],
+    ["HQBASE_E2E_BUILD_TOKEN_UUID", buildTokenUuid]
+  ]) {
+    if (!uuidPattern.test(value)) throw new Error(`${name} must be a UUID.`);
+  }
+  return {
+    accountId,
+    buildTokenUuid,
+    candidateVersion: required(environment, "CANDIDATE_VERSION"),
+    cleanupToken: required(environment, "CLOUDFLARE_API_TOKEN"),
+    configFile: environment.HQBASE_STAGING_CONFIG || configPath(deploymentName),
+    deploymentName,
+    releaseManifestFile:
+      environment.HQBASE_RELEASE_MANIFEST_FILE ||
+      path.join(repositoryRoot, "release", "stable.json"),
+    repoConnectionUuid,
+    runAttempt: required(environment, "GITHUB_RUN_ATTEMPT"),
+    runId: required(environment, "GITHUB_RUN_ID"),
+    workerName: required(environment, "STAGING_WORKER_NAME")
+  };
+}
+
+export function probeContext(environment) {
+  return {
+    ...commonContext(environment),
+    accessClientId: required(environment, "HQBASE_STAGING_ACCESS_CLIENT_ID"),
+    accessClientSecret: required(environment, "HQBASE_STAGING_ACCESS_CLIENT_SECRET"),
+    appUrl: canonicalOrigin(required(environment, "HQBASE_STAGING_URL")),
+    authSecret: required(environment, "HQBASE_STAGING_AUTH_SECRET"),
+    ownerEmail: required(environment, "HQBASE_STAGING_OWNER_EMAIL"),
+    ownerPassword: required(environment, "HQBASE_STAGING_OWNER_PASSWORD"),
+    updateToken: required(environment, "HQBASE_E2E_UPDATE_API_TOKEN")
+  };
+}
+
+export function cleanupContext(environment, manifest) {
+  const accountId = required(environment, "CLOUDFLARE_ACCOUNT_ID");
+  if (accountId !== manifest.accountId) {
+    throw new Error("The cleanup account does not match the deployment lifecycle record.");
+  }
+  return {
+    accountId,
+    cleanupToken: required(environment, "CLOUDFLARE_API_TOKEN"),
+    deploymentName: manifest.name,
+    workerName: manifest.worker.name
+  };
+}
+
+function canonicalOrigin(value) {
+  const url = new URL(value);
+  if (url.protocol !== "https:" || url.pathname !== "/" || url.search || url.hash) {
+    throw new Error("HQBASE_STAGING_URL must be a canonical HTTPS origin.");
+  }
+  return url.origin;
+}
+
+function required(environment, name) {
+  const value = environment[name]?.trim();
+  if (!value) throw new Error(`${name} is required for the deployed update-action release gate.`);
+  return value;
+}
+
+export function resolveDependencies(options) {
+  return {
+    environment: options.environment ?? process.env,
+    fetcher: options.fetcher ?? fetch,
+    loadManifest: options.loadManifest ?? loadManifest,
+    manifestExists: options.manifestExists ?? manifestExists,
+    readFile: options.readFile ?? fs.readFileSync,
+    runCommand: options.runCommand ?? run,
+    sleep:
+      options.sleep ??
+      ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))),
+    writeManifest: options.writeManifest ?? writeManifest
+  };
+}

--- a/scripts/release/staging-update-gate.mjs
+++ b/scripts/release/staging-update-gate.mjs
@@ -1,0 +1,259 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { assertCurrentManifest } from "../hqbase/lifecycle-manifest.mjs";
+import {
+  appErrorCode,
+  appRequest,
+  installationSnapshot,
+  parseJson,
+  requireAppJson,
+  setCookieValues,
+  signIn,
+  verifyUpdateTokenActive
+} from "./staging-update-gate-app.mjs";
+import {
+  cancelRecordedBuild,
+  ensureBuildTrigger,
+  ensureCandidateManifestWorker,
+  reconcileAndCancelBuild,
+  removeBuildTrigger,
+  removeCandidateManifestWorker,
+  verifyAcceptedBuild
+} from "./staging-update-gate-resources.mjs";
+import {
+  assertDeployment,
+  assertReadyGate,
+  assertSameGateIdentity,
+  branch,
+  cleanupContext,
+  cloudflareHeaders,
+  cloudflareResult,
+  commonContext,
+  createRuntimeGrantCookie,
+  gatePath,
+  initialBuildCommand,
+  initialDeployCommand,
+  listWorkers,
+  managedUpdaterLoader,
+  probeContext,
+  readCandidate,
+  resolveDependencies,
+  uuidPattern,
+  workerTagPattern,
+  writeCandidateManifestUrl
+} from "./staging-update-gate-shared.mjs";
+
+export { createRuntimeGrantCookie, managedUpdaterLoader };
+
+export async function prepareStagingUpdateGate(options = {}) {
+  const dependencies = resolveDependencies(options);
+  const context = commonContext(dependencies.environment);
+  const manifest = dependencies.loadManifest(context.deploymentName);
+  assertDeployment(manifest, context);
+  const candidate = readCandidate(context, dependencies);
+  const headers = cloudflareHeaders(context.cleanupToken);
+  const subdomain = await cloudflareResult(
+    `/accounts/${context.accountId}/workers/subdomain`,
+    { headers },
+    dependencies.fetcher
+  );
+  if (typeof subdomain?.subdomain !== "string" || subdomain.subdomain.trim() === "") {
+    throw new Error("Cloudflare did not return the staging workers.dev subdomain.");
+  }
+  const scripts = await listWorkers(context, dependencies);
+  const productionWorker = scripts.find((item) => item.id === context.workerName);
+  if (!workerTagPattern.test(productionWorker?.tag ?? "")) {
+    throw new Error("Cloudflare did not return the staging Worker's immutable tag.");
+  }
+  const fixtureName = `hqbase-release-manifest-${context.runId}-${context.runAttempt}`;
+  const fixturePath = `/candidate-${createHash("sha256")
+    .update(`${context.runId}:${context.runAttempt}:${context.candidateVersion}`)
+    .digest("hex")
+    .slice(0, 24)}.json`;
+  const fixtureUrl = `https://${fixtureName}.${subdomain.subdomain}.workers.dev${fixturePath}`;
+  const triggerName = `hqbase-release-gate-${context.runId}-${context.runAttempt}`;
+  const expectedGate = {
+    candidateManifest: {
+      name: fixtureName,
+      ownership: "creating",
+      path: fixturePath,
+      sha256: candidate.sha256,
+      url: fixtureUrl,
+      workerTag: null
+    },
+    workersBuild: {
+      branch,
+      buildCommand: initialBuildCommand,
+      buildOutcome: null,
+      buildTokenUuid: context.buildTokenUuid,
+      buildUuid: null,
+      dispatchStartedAt: null,
+      initialDeployCommand,
+      ownership: "unclaimed",
+      pathIncludes: [gatePath],
+      repoConnectionUuid: context.repoConnectionUuid,
+      rootDirectory: "/",
+      stoppedOn: null,
+      triggerName,
+      triggerUuid: null,
+      workerTag: productionWorker.tag
+    }
+  };
+
+  if (manifest.releaseGate) {
+    assertSameGateIdentity(manifest.releaseGate, expectedGate);
+  } else {
+    if (scripts.some((item) => item.id === fixtureName)) {
+      throw new Error(
+        "The candidate-manifest Worker exists without this run's lifecycle record. Refusing to adopt or overwrite it."
+      );
+    }
+    manifest.releaseGate = expectedGate;
+    dependencies.writeManifest(manifest);
+  }
+
+  await ensureCandidateManifestWorker(manifest, candidate.raw, context, dependencies);
+  writeCandidateManifestUrl(context.configFile, manifest.releaseGate.candidateManifest.url);
+  await ensureBuildTrigger(manifest, context, dependencies);
+  console.log("The deployed update-action release gate is ready.");
+}
+
+export async function probeStagingUpdateGate(options = {}) {
+  const dependencies = resolveDependencies(options);
+  const context = probeContext(dependencies.environment);
+  const manifest = dependencies.loadManifest(context.deploymentName);
+  assertDeployment(manifest, context);
+  assertReadyGate(manifest.releaseGate);
+  const candidate = readCandidate(context, dependencies);
+  const sessionCookies = await signIn(context, dependencies.fetcher);
+  const grantCookie = createRuntimeGrantCookie(context.updateToken, context.authSecret);
+  const cookies = [...sessionCookies, grantCookie].join("; ");
+  const before = await installationSnapshot(manifest, context, dependencies);
+  const statusResponse = await appRequest(
+    context,
+    "/api/updates",
+    { headers: { cookie: cookies } },
+    dependencies.fetcher
+  );
+  const status = await requireAppJson(statusResponse, 200, "update status");
+  if (
+    status.installedVersion !== context.candidateVersion ||
+    status.release?.version !== context.candidateVersion ||
+    status.available !== true ||
+    status.compatible !== true ||
+    status.repairRequired !== true
+  ) {
+    throw new Error("The deployed candidate did not report the expected same-version repair.");
+  }
+
+  manifest.releaseGate.workersBuild.dispatchStartedAt = new Date().toISOString();
+  dependencies.writeManifest(manifest);
+  let applyResponse;
+  try {
+    applyResponse = await appRequest(
+      context,
+      "/api/updates/apply",
+      {
+        body: JSON.stringify({ expectedVersion: context.candidateVersion }),
+        headers: { "content-type": "application/json", cookie: cookies },
+        method: "POST"
+      },
+      dependencies.fetcher
+    );
+  } catch (error) {
+    await reconcileAndCancelBuild(manifest, context, dependencies);
+    throw error;
+  }
+  if (applyResponse.status !== 202) {
+    const code = await appErrorCode(applyResponse);
+    await reconcileAndCancelBuild(manifest, context, dependencies);
+    throw new Error(`The deployed update action returned HTTP ${applyResponse.status} (${code}).`);
+  }
+  const grantClear = setCookieValues(applyResponse.headers).find((value) =>
+    value.startsWith("hqb_cf_oauth_grant=")
+  );
+  if (!grantClear || !/Max-Age=0(?:;|$)/i.test(grantClear)) {
+    await reconcileAndCancelBuild(manifest, context, dependencies);
+    throw new Error("The deployed update action did not clear its temporary Cloudflare grant.");
+  }
+  const applied = await parseJson(applyResponse, "update action");
+  if (!uuidPattern.test(applied?.buildId ?? "")) {
+    await reconcileAndCancelBuild(manifest, context, dependencies);
+    throw new Error("The deployed update action did not return a real Workers Build UUID.");
+  }
+  manifest.releaseGate.workersBuild.buildUuid = applied.buildId;
+  dependencies.writeManifest(manifest);
+
+  let verificationError;
+  try {
+    await verifyUpdateTokenActive(context, dependencies);
+    if (applied.status !== "queued") {
+      throw new Error('The deployed update action did not report the accepted build as "queued".');
+    }
+    await verifyAcceptedBuild(manifest, candidate.manifest, context, dependencies);
+  } catch (error) {
+    verificationError = error;
+  }
+  await cancelRecordedBuild(manifest, context, dependencies);
+  const after = await installationSnapshot(manifest, context, dependencies);
+  if (JSON.stringify(after) !== JSON.stringify(before)) {
+    throw new Error(
+      "The accepted-and-cancelled update action changed the active Worker or D1 state."
+    );
+  }
+  if (verificationError) throw verificationError;
+  console.log("The deployed update action accepted and cancelled the exact candidate build.");
+}
+
+export async function cleanupStagingUpdateGate(options = {}) {
+  const dependencies = resolveDependencies(options);
+  const deploymentName = required(dependencies.environment, "DEPLOYMENT_NAME");
+  if (!dependencies.manifestExists(deploymentName)) return;
+  const manifest = dependencies.loadManifest(deploymentName);
+  assertCurrentManifest(manifest);
+  if (!manifest.releaseGate) return;
+  const context = cleanupContext(dependencies.environment, manifest);
+  const errors = [];
+  try {
+    await reconcileAndCancelBuild(manifest, context, dependencies);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    await removeBuildTrigger(manifest, context, dependencies);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    await removeCandidateManifestWorker(manifest, context, dependencies);
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "The release-gate cleanup did not reconcile every resource.");
+  }
+  console.log("The deployed update-action release gate is reconciled.");
+}
+
+function required(environment, name) {
+  const value = environment[name]?.trim();
+  if (!value) throw new Error(`${name} is required for the deployed update-action release gate.`);
+  return value;
+}
+
+async function main() {
+  const command = process.argv[2];
+  if (command === "prepare") return prepareStagingUpdateGate();
+  if (command === "probe") return probeStagingUpdateGate();
+  if (command === "cleanup") return cleanupStagingUpdateGate();
+  throw new Error("Usage: node scripts/release/staging-update-gate.mjs <prepare|probe|cleanup>");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : "The staging update gate failed.");
+    process.exitCode = 1;
+  });
+}

--- a/test/unit/app/updates/update-settings.test.tsx
+++ b/test/unit/app/updates/update-settings.test.tsx
@@ -1,7 +1,23 @@
+// @vitest-environment happy-dom
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { UpdateStatus } from "@/features/updates/types";
 import { UpdateSettings } from "@/features/updates/update-settings";
+import { renderComponent } from "../render-hook";
+
+const mocks = vi.hoisted(() => ({
+  applyUpdate: vi.fn(),
+  getUpdateStatus: vi.fn()
+}));
+
+vi.mock("@/features/updates/api", () => mocks);
+
+afterEach(() => {
+  document.body.replaceChildren();
+  window.history.replaceState(null, "", "/");
+  window.sessionStorage.clear();
+  vi.clearAllMocks();
+});
 
 const availableStatus: UpdateStatus = {
   product: "hqbase",
@@ -119,6 +135,36 @@ describe("update settings", () => {
     expect(html).toContain("will not change your source repository");
     expect(html).not.toContain("What’s changing");
     expect(html).not.toContain("Install update");
+  });
+
+  it("labels an apply failure after Cloudflare authorization as an update failure", async () => {
+    window.sessionStorage.setItem("hqb_update_expected_version", availableStatus.release.version);
+    window.sessionStorage.setItem("hqb_update_action_kind", "repair");
+    window.history.replaceState(
+      null,
+      "",
+      "/settings/updates?cloudflare=connected&settings=updates"
+    );
+    mocks.applyUpdate.mockRejectedValue(new Error("Invalid request body"));
+
+    const view = await renderComponent(
+      <UpdateSettings
+        initialStatus={{
+          ...availableStatus,
+          installedVersion: availableStatus.release.version,
+          repairRequired: true
+        }}
+        progress={null}
+        onStatusChange={() => undefined}
+        onUpdateStarted={() => undefined}
+      />
+    );
+
+    await vi.waitFor(() => expect(mocks.applyUpdate).toHaveBeenCalledWith("0.2.0"));
+    expect(view.container.textContent).toContain("Update could not start");
+    expect(view.container.textContent).toContain("Invalid request body");
+    expect(view.container.textContent).not.toContain("Update authorization unavailable");
+    await view.unmount();
   });
 });
 

--- a/test/unit/scripts/bootstrap.test.mjs
+++ b/test/unit/scripts/bootstrap.test.mjs
@@ -204,17 +204,23 @@ describe("signed release bootstrap", () => {
   });
 
   it("packages bootstrap bytes from the exact Git commit named by signed metadata", () => {
-    const sourceCommitPlaceholder = ["$", "{sourceCommit}"].join("");
+    const updaterCommitPlaceholder = ["$", "{updaterCommit}"].join("");
     const source = readFileSync(
       new URL("../../../scripts/release/package.mjs", import.meta.url),
       "utf8"
     );
     expect(source).toContain(
-      `["show", \`${sourceCommitPlaceholder}:scripts/release/bootstrap.mjs\`]`
+      `["show", \`${updaterCommitPlaceholder}:scripts/release/bootstrap.mjs\`]`
     );
     expect(source).toContain(
-      `https://raw.githubusercontent.com/HQBase/hqbase/${sourceCommitPlaceholder}/scripts/release/bootstrap.mjs`
+      `https://raw.githubusercontent.com/HQBase/hqbase/${updaterCommitPlaceholder}/scripts/release/bootstrap.mjs`
     );
+    expect(source).toContain(
+      "const configuredUpdaterCommit = packageJson.hqbaseRelease?.updaterCommit"
+    );
+    expect(source).toContain("updaterCommitVersion !== version");
+    expect(source).toContain("if (!/^[a-f0-9]{40}$/.test(updaterCommit))");
+    expect(source).toContain("Release updater commit is not available in the checkout.");
     expect(source).toContain('createHash("sha256").update(updaterBytes).digest("hex")');
     expect(source).toContain("size: updaterBytes.length");
   });

--- a/test/unit/scripts/package.test.mjs
+++ b/test/unit/scripts/package.test.mjs
@@ -7,6 +7,8 @@ import { describe, expect, it } from "vitest";
 
 const releaseFiles = ["package.mjs", "notes.mjs", "version.mjs"];
 const recoveryUpdaterCommit = "7d67e4ae54fe4deafba41c0b5daab5a34cdfe4f9";
+const recoveryUpdaterSha256 = "4f6c7d5c4b57c7211e3db047fec3766792d946b99b1075628d286a6d8b43bffe";
+const recoveryUpdaterSize = 6928;
 const repositoryRoot = resolve(import.meta.dirname, "../../..");
 
 function git(cwd, ...args) {
@@ -20,13 +22,9 @@ describe("release package", () => {
     );
     expect(packageJson.hqbaseRelease.updaterCommit).toBe(recoveryUpdaterCommit);
     expect(packageJson.hqbaseRelease.updaterCommitVersion).toBe("1.3.4");
-    const pinnedUpdater = execFileSync(
-      "git",
-      ["show", `${recoveryUpdaterCommit}:scripts/release/bootstrap.mjs`],
-      { cwd: repositoryRoot }
-    );
     const currentUpdater = readFileSync(resolve(repositoryRoot, "scripts/release/bootstrap.mjs"));
-    expect(pinnedUpdater.equals(currentUpdater)).toBe(true);
+    expect(currentUpdater.length).toBe(recoveryUpdaterSize);
+    expect(createHash("sha256").update(currentUpdater).digest("hex")).toBe(recoveryUpdaterSha256);
   });
 
   it("uses the committed updater override for signed source metadata", () => {

--- a/test/unit/scripts/package.test.mjs
+++ b/test/unit/scripts/package.test.mjs
@@ -1,0 +1,101 @@
+import { execFileSync } from "node:child_process";
+import { createHash, generateKeyPairSync } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const releaseFiles = ["package.mjs", "notes.mjs", "version.mjs"];
+const recoveryUpdaterCommit = "7d67e4ae54fe4deafba41c0b5daab5a34cdfe4f9";
+const repositoryRoot = resolve(import.meta.dirname, "../../..");
+
+function git(cwd, ...args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+describe("release package", () => {
+  it("pins the recovery release to the exact 1.3.3 updater commit", () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL("../../../package.json", import.meta.url), "utf8")
+    );
+    expect(packageJson.hqbaseRelease.updaterCommit).toBe(recoveryUpdaterCommit);
+    expect(packageJson.hqbaseRelease.updaterCommitVersion).toBe("1.3.4");
+    const pinnedUpdater = execFileSync(
+      "git",
+      ["show", `${recoveryUpdaterCommit}:scripts/release/bootstrap.mjs`],
+      { cwd: repositoryRoot }
+    );
+    const currentUpdater = readFileSync(resolve(repositoryRoot, "scripts/release/bootstrap.mjs"));
+    expect(pinnedUpdater.equals(currentUpdater)).toBe(true);
+  });
+
+  it("uses the committed updater override for signed source metadata", () => {
+    const workspace = mkdtempSync(resolve(tmpdir(), "hqbase-package-test-"));
+    const releaseDirectory = resolve(workspace, "scripts/release");
+    const oldUpdater = Buffer.from("old signed updater\n");
+    const newUpdater = Buffer.from("new release updater\n");
+
+    try {
+      mkdirSync(releaseDirectory, { recursive: true });
+      git(workspace, "init", "--quiet");
+      git(workspace, "config", "user.email", "release-test@hqbase.test");
+      git(workspace, "config", "user.name", "HQBase release test");
+      writeFileSync(resolve(releaseDirectory, "bootstrap.mjs"), oldUpdater);
+      git(workspace, "add", ".");
+      git(workspace, "commit", "--quiet", "-m", "old updater");
+      const updaterCommit = git(workspace, "rev-parse", "HEAD");
+
+      for (const file of releaseFiles) {
+        writeFileSync(
+          resolve(releaseDirectory, file),
+          readFileSync(new URL(`../../../scripts/release/${file}`, import.meta.url))
+        );
+      }
+      writeFileSync(resolve(releaseDirectory, "bootstrap.mjs"), newUpdater);
+      writeFileSync(
+        resolve(workspace, "package.json"),
+        `${JSON.stringify(
+          {
+            name: "hqbase",
+            version: "1.3.4",
+            private: true,
+            type: "module",
+            hqbaseRelease: {
+              minimumVersion: "1.0.0",
+              updaterCommit,
+              updaterCommitVersion: "1.3.4"
+            }
+          },
+          null,
+          2
+        )}\n`
+      );
+      writeFileSync(
+        resolve(workspace, "CHANGELOG.md"),
+        "# Changelog\n\n## 1.3.4\n\n- Test release.\n"
+      );
+      git(workspace, "add", ".");
+      git(workspace, "commit", "--quiet", "-m", "candidate");
+
+      const { privateKey } = generateKeyPairSync("ed25519");
+      execFileSync(process.execPath, [resolve(releaseDirectory, "package.mjs")], {
+        cwd: workspace,
+        env: {
+          ...process.env,
+          HQBASE_RELEASE_PRIVATE_KEY: privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+        }
+      });
+
+      const envelope = JSON.parse(readFileSync(resolve(workspace, "release/stable.json"), "utf8"));
+      const manifest = JSON.parse(Buffer.from(envelope.payload, "base64url").toString("utf8"));
+      expect(manifest.updater).toEqual({
+        protocol: 2,
+        sourceUrl: `https://raw.githubusercontent.com/HQBase/hqbase/${updaterCommit}/scripts/release/bootstrap.mjs`,
+        sha256: createHash("sha256").update(oldUpdater).digest("hex"),
+        size: oldUpdater.length
+      });
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/scripts/staging-update-gate.test.mjs
+++ b/test/unit/scripts/staging-update-gate.test.mjs
@@ -1,0 +1,418 @@
+import { createDecipheriv, createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  assertCurrentManifest,
+  assertUnambiguousManifest
+} from "../../../scripts/hqbase/lifecycle-manifest.mjs";
+import {
+  cleanupStagingUpdateGate,
+  createRuntimeGrantCookie,
+  managedUpdaterLoader,
+  prepareStagingUpdateGate,
+  probeStagingUpdateGate
+} from "../../../scripts/release/staging-update-gate.mjs";
+
+const accountId = "a".repeat(32);
+const productionWorkerTag = "b".repeat(32);
+const fixtureWorkerTag = "c".repeat(32);
+const repoConnectionUuid = "11111111-1111-4111-8111-111111111111";
+const buildTokenUuid = "22222222-2222-4222-8222-222222222222";
+const triggerUuid = "33333333-3333-4333-8333-333333333333";
+const buildUuid = "44444444-4444-4444-8444-444444444444";
+const versionId = "55555555-5555-4555-8555-555555555555";
+const version = "1.3.4";
+const shortCommand = 'node --input-type=module --eval "$HQBASE_UPDATER_LOADER"';
+
+function deploymentManifest() {
+  return {
+    accountId,
+    d1: {
+      id: "66666666-6666-4666-8666-666666666666",
+      name: "hqbase-release-9001",
+      ownership: "created"
+    },
+    name: "release-9001",
+    queue: {
+      deadLetter: { id: "7".repeat(32), name: "hqbase-jobs-dlq", ownership: "created" },
+      primary: { id: "8".repeat(32), name: "hqbase-jobs", ownership: "created" }
+    },
+    r2: { bucket: "hqbase-mail", ownership: "created" },
+    version: 3,
+    worker: { deployed: true, name: "hqbase-release-9001" }
+  };
+}
+
+function releaseEnvelope() {
+  const manifest = {
+    channel: "stable",
+    format: "hqbase-release-v1",
+    keyId: "hqbase-release-2026-01",
+    minVersion: "1.0.0",
+    product: "hqbase",
+    publishedAt: "2026-09-01T00:00:00.000Z",
+    schemaVersion: 3,
+    updater: {
+      protocol: 2,
+      sha256: "9".repeat(64),
+      size: 1234,
+      sourceUrl: `https://raw.githubusercontent.com/HQBase/hqbase/${"d".repeat(40)}/scripts/release/bootstrap.mjs`
+    },
+    version
+  };
+  return {
+    manifest,
+    raw: JSON.stringify({
+      payload: Buffer.from(JSON.stringify(manifest)).toString("base64url"),
+      signature: "signed-candidate"
+    })
+  };
+}
+
+function environment(workspace) {
+  return {
+    CANDIDATE_VERSION: version,
+    CLOUDFLARE_ACCOUNT_ID: accountId,
+    CLOUDFLARE_API_TOKEN: "cleanup-token",
+    DEPLOYMENT_NAME: "release-9001",
+    GITHUB_RUN_ATTEMPT: "2",
+    GITHUB_RUN_ID: "9001",
+    HQBASE_E2E_BUILD_TOKEN_UUID: buildTokenUuid,
+    HQBASE_E2E_REPO_CONNECTION_UUID: repoConnectionUuid,
+    HQBASE_E2E_UPDATE_API_TOKEN: "disposable-update-token",
+    HQBASE_RELEASE_MANIFEST_FILE: path.join(workspace, "stable.json"),
+    HQBASE_STAGING_ACCESS_CLIENT_ID: "access-id",
+    HQBASE_STAGING_ACCESS_CLIENT_SECRET: "access-secret",
+    HQBASE_STAGING_AUTH_SECRET: "auth-secret",
+    HQBASE_STAGING_CONFIG: path.join(workspace, "wrangler.jsonc"),
+    HQBASE_STAGING_OWNER_EMAIL: "owner@example.test",
+    HQBASE_STAGING_OWNER_PASSWORD: "owner-password",
+    HQBASE_STAGING_URL: "https://staging.example.test",
+    STAGING_WORKER_NAME: "hqbase-release-9001"
+  };
+}
+
+function response(result, init = {}) {
+  return new Response(JSON.stringify({ result, success: true }), {
+    headers: { "content-type": "application/json", ...init.headers },
+    status: init.status ?? 200
+  });
+}
+
+function trigger(record, deployCommand = "pnpm deploy") {
+  return {
+    branch_excludes: [],
+    branch_includes: ["main"],
+    build_caching_enabled: false,
+    build_command: "sleep 600",
+    build_token_uuid: buildTokenUuid,
+    deploy_command: deployCommand,
+    external_script_id: productionWorkerTag,
+    path_excludes: [],
+    path_includes: [".hqbase-release-gate-never"],
+    repo_connection: { repo_connection_uuid: repoConnectionUuid },
+    root_directory: "/",
+    trigger_name: record.triggerName,
+    trigger_uuid: triggerUuid
+  };
+}
+
+describe("deployed update-action release gate", () => {
+  it("records, exercises, cancels, and exactly reconciles its real Cloudflare resources", async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "hqbase-gate-test-"));
+    const candidate = releaseEnvelope();
+    fs.writeFileSync(path.join(workspace, "stable.json"), candidate.raw);
+    fs.writeFileSync(path.join(workspace, "wrangler.jsonc"), JSON.stringify({ vars: {} }));
+    const manifest = deploymentManifest();
+    const saved = [];
+    const events = [];
+    const calls = [];
+    let fixtureExists = false;
+    let buildTrigger = null;
+    let build = null;
+    let variables = {};
+    const d1 = {
+      after_deploy_ledger_table_count: 0,
+      draft_count: 0,
+      installed_schema_version: 3,
+      installed_version: version,
+      mailbox_count: 1,
+      message_count: 0,
+      normal_migration_count: 28,
+      probe: '{"state":"preserved"}',
+      update_build_lock_count: 0,
+      update_history_count: 0,
+      user_count: 1
+    };
+
+    const fetcher = vi.fn(async (input, init = {}) => {
+      const url = new URL(String(input));
+      const method = init.method ?? "GET";
+      calls.push({ body: init.body, headers: init.headers, method, pathname: url.pathname });
+      if (url.origin === "https://staging.example.test") {
+        if (url.pathname === "/api/auth/sign-in/email") {
+          return new Response("{}", {
+            headers: { "set-cookie": "better-auth.session_token=session-value; Path=/; HttpOnly" },
+            status: 200
+          });
+        }
+        if (url.pathname === "/api/updates" && method === "GET") {
+          return new Response(
+            JSON.stringify({
+              available: true,
+              compatible: true,
+              installedVersion: version,
+              release: { version },
+              repairRequired: true
+            }),
+            { headers: { "content-type": "application/json" } }
+          );
+        }
+        if (url.pathname === "/api/updates/apply") {
+          const cookie = init.headers.cookie;
+          expect(cookie).toContain("better-auth.session_token=session-value");
+          expect(cookie).toContain("hqb_cf_oauth_grant=");
+          expect(cookie).not.toContain("disposable-update-token");
+          expect(JSON.parse(init.body)).toEqual({ expectedVersion: version });
+          buildTrigger = trigger(manifest.releaseGate.workersBuild, shortCommand);
+          variables = {
+            HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: version },
+            HQBASE_UPDATER_LOADER: {
+              is_secret: false,
+              value: managedUpdaterLoader(candidate.manifest.updater)
+            }
+          };
+          build = {
+            build_trigger_metadata: {
+              branch: "main",
+              build_command: "sleep 600",
+              build_token_uuid: buildTokenUuid,
+              build_trigger_source: "api",
+              deploy_command: shortCommand,
+              environment_variables: {
+                HQBASE_EXPECTED_RELEASE_VERSION: version,
+                HQBASE_UPDATER_LOADER: managedUpdaterLoader(candidate.manifest.updater)
+              },
+              root_directory: "/"
+            },
+            build_uuid: buildUuid,
+            created_on: new Date().toISOString(),
+            status: "queued",
+            trigger: { trigger_uuid: triggerUuid }
+          };
+          return new Response(JSON.stringify({ buildId: buildUuid, status: "queued" }), {
+            headers: {
+              "content-type": "application/json",
+              "set-cookie": "hqb_cf_oauth_grant=; Path=/; Max-Age=0"
+            },
+            status: 202
+          });
+        }
+      }
+      if (url.origin.includes("workers.dev")) {
+        return fixtureExists ? new Response(candidate.raw) : new Response(null, { status: 404 });
+      }
+      if (url.pathname.endsWith("/workers/subdomain")) {
+        return response({ subdomain: "release-test" });
+      }
+      if (url.pathname.endsWith("/user/tokens/verify")) {
+        expect(init.headers.authorization).toBe("Bearer disposable-update-token");
+        return response({ status: "active" });
+      }
+      if (url.pathname.endsWith("/workers/scripts") && method === "GET") {
+        return response([
+          { id: "hqbase-release-9001", tag: productionWorkerTag },
+          ...(fixtureExists
+            ? [{ id: "hqbase-release-manifest-9001-2", tag: fixtureWorkerTag }]
+            : [])
+        ]);
+      }
+      if (url.pathname.includes(`/builds/workers/${productionWorkerTag}/triggers`)) {
+        return response(buildTrigger ? [buildTrigger] : []);
+      }
+      if (url.pathname.endsWith("/builds/triggers") && method === "POST") {
+        events.push("create-trigger");
+        const body = JSON.parse(init.body);
+        expect(body).toEqual({
+          branch_excludes: [],
+          branch_includes: ["main"],
+          build_caching_enabled: false,
+          build_command: "sleep 600",
+          build_token_uuid: buildTokenUuid,
+          deploy_command: "pnpm deploy",
+          external_script_id: productionWorkerTag,
+          path_excludes: [],
+          path_includes: [".hqbase-release-gate-never"],
+          repo_connection_uuid: repoConnectionUuid,
+          root_directory: "/",
+          trigger_name: "hqbase-release-gate-9001-2"
+        });
+        buildTrigger = trigger(manifest.releaseGate.workersBuild);
+        return response(buildTrigger);
+      }
+      if (url.pathname.endsWith(`/builds/triggers/${triggerUuid}/environment_variables`)) {
+        return response(variables);
+      }
+      if (url.pathname.endsWith(`/builds/builds/${buildUuid}`) && method === "GET") {
+        return response(build);
+      }
+      if (url.pathname.endsWith(`/builds/builds/${buildUuid}/cancel`)) {
+        build = {
+          ...build,
+          build_outcome: "cancelled",
+          status: "stopped",
+          stopped_on: "2026-09-01T04:00:00.000Z"
+        };
+        return response({
+          build_outcome: "cancelled",
+          build_uuid: buildUuid,
+          stopped_on: build.stopped_on
+        });
+      }
+      if (url.pathname.endsWith(`/builds/triggers/${triggerUuid}`) && method === "DELETE") {
+        buildTrigger = null;
+        return response(null);
+      }
+      if (url.pathname.endsWith("/deployments")) {
+        return response({
+          deployments: [{ versions: [{ percentage: 100, version_id: versionId }] }]
+        });
+      }
+      if (url.pathname.includes("/d1/database/") && url.pathname.endsWith("/query")) {
+        return response([{ results: [d1], success: true }]);
+      }
+      if (
+        url.pathname.endsWith("/workers/scripts/hqbase-release-manifest-9001-2") &&
+        method === "DELETE"
+      ) {
+        fixtureExists = false;
+        return response(null);
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+    const options = {
+      environment: environment(workspace),
+      fetcher,
+      loadManifest: () => manifest,
+      manifestExists: () => true,
+      runCommand: (_command, args) => {
+        events.push("deploy-fixture");
+        expect(args.slice(0, 3)).toEqual(["exec", "wrangler", "deploy"]);
+        fixtureExists = true;
+      },
+      sleep: async () => {},
+      writeManifest: (value) => {
+        saved.push(structuredClone(value));
+        events.push(
+          `record-${value.releaseGate.candidateManifest.ownership}-${value.releaseGate.workersBuild.ownership}`
+        );
+      }
+    };
+
+    try {
+      await prepareStagingUpdateGate(options);
+      await probeStagingUpdateGate(options);
+      await cleanupStagingUpdateGate(options);
+      const callsAfterCleanup = calls.length;
+      await cleanupStagingUpdateGate(options);
+
+      expect(events.indexOf("record-creating-unclaimed")).toBeLessThan(
+        events.indexOf("deploy-fixture")
+      );
+      expect(events.indexOf("record-created-creating")).toBeLessThan(
+        events.indexOf("create-trigger")
+      );
+      expect(manifest.releaseGate).toMatchObject({
+        candidateManifest: { ownership: "removed", workerTag: fixtureWorkerTag },
+        workersBuild: {
+          buildOutcome: "cancelled",
+          buildUuid,
+          ownership: "removed",
+          repoConnectionUuid,
+          stoppedOn: "2026-09-01T04:00:00.000Z",
+          triggerUuid
+        }
+      });
+      expect(calls.filter((call) => call.pathname.endsWith("/cancel"))).toHaveLength(1);
+      expect(calls.filter((call) => call.pathname.endsWith("/user/tokens/verify"))).toHaveLength(1);
+      expect(calls.filter((call) => call.pathname.endsWith("/query"))).toHaveLength(2);
+      expect(calls).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            method: "DELETE",
+            pathname: expect.stringContaining("/repos/")
+          }),
+          expect.objectContaining({
+            method: "DELETE",
+            pathname: expect.stringContaining("/tokens/")
+          })
+        ])
+      );
+      expect(calls).toHaveLength(callsAfterCleanup);
+      expect(saved.length).toBeGreaterThanOrEqual(8);
+      expect(() => assertUnambiguousManifest(manifest)).not.toThrow();
+    } finally {
+      fs.rmSync(workspace, { force: true, recursive: true });
+    }
+  });
+
+  it("uses the production AES-GCM grant-cookie contract without exposing the token", () => {
+    const iv = Buffer.alloc(12, 7);
+    const cookie = createRuntimeGrantCookie("disposable-token", "auth-secret", iv);
+    const encoded = cookie.slice(cookie.indexOf("=") + 1);
+    const [encodedIv, encodedCiphertext] = decodeURIComponent(encoded).split(".");
+    const encrypted = Buffer.from(encodedCiphertext, "base64url");
+    const ciphertext = encrypted.subarray(0, -16);
+    const tag = encrypted.subarray(-16);
+    const key = createHash("sha256").update("hqbase-runtime-cloudflare-oauth:auth-secret").digest();
+    const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(encodedIv, "base64url"));
+    decipher.setAuthTag(tag);
+
+    expect(Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString()).toBe(
+      "disposable-token"
+    );
+    expect(cookie).not.toContain("disposable-token");
+  });
+
+  it("blocks lifecycle deletion until both exact gate resources are removed", () => {
+    const manifest = deploymentManifest();
+    manifest.releaseGate = {
+      candidateManifest: {
+        name: "hqbase-release-manifest-9001-2",
+        ownership: "created",
+        path: "/candidate.json",
+        sha256: "a".repeat(64),
+        url: "https://hqbase-release-manifest-9001-2.release-test.workers.dev/candidate.json",
+        workerTag: fixtureWorkerTag
+      },
+      workersBuild: {
+        branch: "main",
+        buildCommand: "sleep 600",
+        buildOutcome: null,
+        buildTokenUuid,
+        buildUuid: null,
+        dispatchStartedAt: null,
+        initialDeployCommand: "pnpm deploy",
+        ownership: "created",
+        pathIncludes: [".hqbase-release-gate-never"],
+        repoConnectionUuid,
+        rootDirectory: "/",
+        stoppedOn: null,
+        triggerName: "hqbase-release-gate-9001-2",
+        triggerUuid,
+        workerTag: productionWorkerTag
+      }
+    };
+
+    expect(() => assertCurrentManifest(manifest)).not.toThrow();
+    expect(() => assertUnambiguousManifest(manifest)).toThrow(/releaseGate\.candidateManifest/);
+    manifest.releaseGate.candidateManifest.ownership = "removed";
+    expect(() => assertUnambiguousManifest(manifest)).toThrow(/releaseGate\.workersBuild/);
+    manifest.releaseGate.workersBuild.ownership = "removed";
+    expect(() => assertUnambiguousManifest(manifest)).not.toThrow();
+  });
+});

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -262,6 +262,41 @@ describe("staging workflow lifecycle record", () => {
     );
   });
 
+  it("gates publication on the deployed update action and exact cleanup", () => {
+    const prepare = releaseWorkflow.indexOf(
+      "      - name: Prepare the deployed update-action release gate"
+    );
+    const candidate = releaseWorkflow.indexOf("      - name: Apply the exact signed candidate");
+    const stale = releaseWorkflow.indexOf(
+      "      - name: Verify the candidate restored the binding while the database remained at S0"
+    );
+    const probe = releaseWorkflow.indexOf(
+      "      - name: Exercise the deployed update action without deployment"
+    );
+    const repair = releaseWorkflow.indexOf(
+      "      - name: Finish the candidate through its canonical signed bootstrap"
+    );
+    const cleanup = releaseWorkflow.indexOf(
+      "      - name: Reconcile deployed update-action gate resources"
+    );
+    const upload = releaseWorkflow.indexOf("      - name: Upload non-secret deployment record");
+
+    expect(prepare).toBeGreaterThan(-1);
+    expect(candidate).toBeGreaterThan(prepare);
+    expect(stale).toBeGreaterThan(candidate);
+    expect(probe).toBeGreaterThan(stale);
+    expect(repair).toBeGreaterThan(probe);
+    expect(cleanup).toBeGreaterThan(repair);
+    expect(upload).toBeGreaterThan(cleanup);
+    expect(releaseWorkflow).toContain("HQBASE_E2E_REPO_CONNECTION_UUID:");
+    expect(releaseWorkflow).toContain("HQBASE_E2E_BUILD_TOKEN_UUID:");
+    expect(releaseWorkflow).toContain("HQBASE_E2E_UPDATE_API_TOKEN:");
+    expect(releaseWorkflow).toContain("staging-update-gate.mjs prepare");
+    expect(releaseWorkflow).toContain("staging-update-gate.mjs probe");
+    expect(releaseWorkflow).toContain("staging-update-gate.mjs cleanup");
+    expect(releaseWorkflow).toContain("steps.reconcile_update_gate.outcome == 'success'");
+  });
+
   it("keeps the customer source checkout unchanged", () => {
     expect(releaseWorkflow).toContain(
       "      - name: Verify the customer source checkout starts unchanged"
@@ -303,6 +338,13 @@ describe("staging workflow lifecycle record", () => {
     expect(releaseWorkflow).toContain('test "$tag_commit" = "$RELEASE_COMMIT"');
     expect(releaseWorkflow).toContain('test "$deploy_commit" = "$RELEASE_COMMIT"');
     expect(releaseWorkflow).toContain("manifest.updater?.protocol !== 2");
+    expect(releaseWorkflow).toContain("fetch-depth: 0");
+    expect(releaseWorkflow).toContain(
+      "const configuredUpdaterCommit = packageJson.hqbaseRelease?.updaterCommit"
+    );
+    expect(releaseWorkflow).toContain("updaterCommitVersion !== version");
+    expect(releaseWorkflow).toContain("Committed release updater commit is invalid.");
+    expect(releaseWorkflow).toContain("!immutableUpdaterUrl.test(manifest.updater.sourceUrl)");
     expect(releaseWorkflow).toContain(["manifest-$", '{HQBASE_RELEASE_VERSION}.json"'].join(""));
     expect(releaseWorkflow).toContain("Published stable and versioned manifests do not match.");
     expect(releaseWorkflow).toContain("manifest.updater.sourceUrl !== expectedUpdaterUrl");

--- a/test/unit/worker/features/updates/cloudflare.test.ts
+++ b/test/unit/worker/features/updates/cloudflare.test.ts
@@ -1,0 +1,142 @@
+import { cloudflare, isAmbiguousCloudflareOperation } from "@worker/features/updates/cloudflare";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  operationalLog: vi.fn()
+}));
+
+vi.mock("@worker/observability/log", () => ({ operationalLog: mocks.operationalLog }));
+
+beforeEach(() => {
+  mocks.operationalLog.mockReset();
+});
+
+describe("Cloudflare update requests", () => {
+  it("reports safe provider diagnostics without provider content", async () => {
+    const error = await rejectedCloudflareCall(
+      responseFetcher(
+        {
+          success: false,
+          errors: [
+            {
+              code: 1000,
+              message: "Invalid request body with customer-secret",
+              source: { pointer: "customer-secret" }
+            }
+          ]
+        },
+        { status: 400, headers: { "cf-ray": "ray-123" } }
+      ),
+      "set_build_command"
+    );
+
+    expect(error).toMatchObject({
+      code: "UPDATE_CLOUDFLARE_ERROR",
+      message:
+        "Cloudflare rejected the request to set the Workers Builds deploy command (HTTP 400, code 1000, request ray-123).",
+      status: 502
+    });
+    expect(String(error)).not.toContain("Invalid request body");
+    expect(String(error)).not.toContain("customer-secret");
+    expect(isAmbiguousCloudflareOperation(error, "set_build_command")).toBe(false);
+    expect(mocks.operationalLog).toHaveBeenCalledOnce();
+    expect(mocks.operationalLog).toHaveBeenCalledWith("warn", "cloudflare_update_request_failed", {
+      operation: "set_build_command",
+      providerCode: "1000",
+      requestId: "ray-123",
+      status: 400
+    });
+    expect(Object.keys(mocks.operationalLog.mock.calls[0]?.[2] ?? {}).sort()).toEqual([
+      "operation",
+      "providerCode",
+      "requestId",
+      "status"
+    ]);
+  });
+
+  it("bounds and redacts a non-JSON provider response", async () => {
+    const providerBody = `customer-secret:${"x".repeat(20_000)}`;
+    const error = await rejectedCloudflareCall(
+      async () =>
+        new Response(providerBody, {
+          status: 502,
+          headers: { "cf-ray": "unsafe request id" }
+        }),
+      "start_build"
+    );
+
+    expect(error).toMatchObject({
+      code: "UPDATE_CLOUDFLARE_INVALID_RESPONSE",
+      message: "Cloudflare rejected the request to start the Workers Build (HTTP 502).",
+      status: 502
+    });
+    expect((error as Error).message.length).toBeLessThan(200);
+    expect(String(error)).not.toContain("customer-secret");
+    expect(isAmbiguousCloudflareOperation(error, "start_build")).toBe(true);
+    expect(mocks.operationalLog).toHaveBeenCalledWith("warn", "cloudflare_update_request_failed", {
+      operation: "start_build",
+      providerCode: null,
+      requestId: null,
+      status: 502
+    });
+  });
+
+  it("separates network failures from timeouts", async () => {
+    const networkError = await rejectedCloudflareCall(async () => {
+      throw new Error("customer-secret network detail");
+    }, "start_build");
+    const signal = AbortSignal.abort();
+    const timeoutError = await rejectedCloudflareCall(
+      async () => {
+        throw new Error("customer-secret timeout detail");
+      },
+      "start_build",
+      signal
+    );
+
+    expect(networkError).toMatchObject({
+      code: "UPDATE_CLOUDFLARE_UNAVAILABLE",
+      status: 502
+    });
+    expect(timeoutError).toMatchObject({
+      code: "UPDATE_CLOUDFLARE_TIMEOUT",
+      status: 504
+    });
+    expect(String(networkError)).not.toContain("customer-secret");
+    expect(String(timeoutError)).not.toContain("customer-secret");
+    expect(isAmbiguousCloudflareOperation(networkError, "start_build")).toBe(true);
+    expect(isAmbiguousCloudflareOperation(timeoutError, "start_build")).toBe(true);
+  });
+
+  it("limits ambiguous provider failures to the matching operation", async () => {
+    const startBuildError = await rejectedCloudflareCall(
+      responseFetcher({ success: false, errors: [{ code: "internal_error" }] }, { status: 503 }),
+      "start_build"
+    );
+
+    expect(isAmbiguousCloudflareOperation(startBuildError, "start_build")).toBe(true);
+    expect(isAmbiguousCloudflareOperation(startBuildError, "set_build_command")).toBe(false);
+  });
+});
+
+async function rejectedCloudflareCall(
+  fetcher: typeof fetch,
+  operation: Parameters<typeof cloudflare>[3],
+  signal?: AbortSignal
+): Promise<unknown> {
+  try {
+    await cloudflare(
+      "https://api.cloudflare.com/client/v4/test",
+      signal ? { signal } : {},
+      fetcher,
+      operation
+    );
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected the Cloudflare request to fail.");
+}
+
+function responseFetcher(body: unknown, init: ResponseInit): typeof fetch {
+  return (async () => Response.json(body, init)) as typeof fetch;
+}

--- a/test/unit/worker/features/updates/service.test.ts
+++ b/test/unit/worker/features/updates/service.test.ts
@@ -9,6 +9,7 @@ import {
   getUpdateStatus,
   isManagedDeployCommand,
   managedDeployCommand,
+  managedUpdaterLoader,
   triggerUpdate
 } from "@worker/features/updates/service";
 import type { WorkerEnv } from "@worker/lib/env";
@@ -94,7 +95,10 @@ describe("HQBase updates", () => {
         String(input).endsWith("/environment_variables") && init?.method === "PATCH"
     );
     expect(pinRequests.map(([, init]) => init?.body)).toEqual([
-      JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.1.0" } })
+      JSON.stringify({
+        HQBASE_UPDATER_LOADER: { is_secret: false, value: managedUpdaterLoader(updater) },
+        HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.1.0" }
+      })
     ]);
     expect(fetcher.mock.calls.some(([, init]) => init?.method === "DELETE")).toBe(false);
     const commandRequests = fetcher.mock.calls.filter(
@@ -102,7 +106,7 @@ describe("HQBase updates", () => {
         String(input).endsWith("/builds/triggers/trigger") && init?.method === "PATCH"
     );
     expect(commandRequests.map(([, init]) => init?.body)).toEqual([
-      JSON.stringify({ deploy_command: managedDeployCommand(updater) })
+      JSON.stringify({ deploy_command: managedDeployCommand() })
     ]);
   });
   it("offers and starts an authorized repair for the already active signed release", async () => {
@@ -135,16 +139,21 @@ describe("HQBase updates", () => {
     });
   });
   it("accepts only the exact canonical updater command", () => {
-    const command = managedDeployCommand(updater);
-    const previousReleaseCommand = managedDeployCommand({
+    const command = managedDeployCommand();
+    const loader = managedUpdaterLoader(updater);
+    const previousReleaseCommand = `node --input-type=module --eval '${managedUpdaterLoader({
       ...updater,
       sha256: "c".repeat(64)
-    });
+    })}'`;
     expect(isManagedDeployCommand(command)).toBe(true);
+    expect(command).toBe('node --input-type=module --eval "$HQBASE_UPDATER_LOADER"');
+    expect(Buffer.byteLength(loader)).toBeLessThan(5_000);
     expect(isManagedDeployCommand(previousReleaseCommand)).toBe(true);
     expect(isManagedDeployCommand(`${command} && pnpm deploy`)).toBe(false);
     expect(
-      isManagedDeployCommand(command.replace("HQBase updater verification failed.", "skip"))
+      isManagedDeployCommand(
+        previousReleaseCommand.replace("HQBase updater verification failed.", "skip")
+      )
     ).toBe(false);
   });
   it("rejects an overlapping update before it can replace the shared release pin", async () => {
@@ -240,7 +249,10 @@ describe("HQBase updates", () => {
           String(input).endsWith("/environment_variables") && init?.method === "PATCH"
       );
       expect(pinRequests.map(([, init]) => init?.body)).toEqual([
-        JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.1.0" } }),
+        JSON.stringify({
+          HQBASE_UPDATER_LOADER: { is_secret: false, value: managedUpdaterLoader(updater) },
+          HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.1.0" }
+        }),
         JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.0.8" } })
       ]);
     } finally {
@@ -325,7 +337,28 @@ describe("HQBase updates", () => {
         "0.1.0",
         fetcher as typeof fetch
       )
-    ).rejects.toThrow("plain build variable");
+    ).rejects.toThrow("plain Workers Builds variables");
+    expect(
+      fetcher.mock.calls.some(
+        ([input, init]) => String(input).endsWith("/builds") && init?.method === "POST"
+      )
+    ).toBe(false);
+  });
+  it("rejects a secret updater loader", async () => {
+    const fetcher = cloudflareUpdateFetcher({
+      variables: {
+        HQBASE_UPDATER_LOADER: { is_secret: true }
+      }
+    });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toThrow("plain Workers Builds variables");
     expect(
       fetcher.mock.calls.some(
         ([input, init]) => String(input).endsWith("/builds") && init?.method === "POST"
@@ -359,6 +392,60 @@ describe("HQBase updates", () => {
       )
     ).rejects.toThrow("changed after you reviewed it");
   });
+  it("reports and rolls back a rejected build-command change without exposing the body", async () => {
+    const fetcher = cloudflareUpdateFetcher({ commandFails: true });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toMatchObject({
+      code: "UPDATE_CLOUDFLARE_ERROR",
+      message:
+        "Cloudflare rejected the request to set the Workers Builds deploy command (HTTP 400, code 1000, request command-ray)."
+    });
+    expect(
+      fetcher.mock.calls.some(
+        ([input, init]) => String(input).endsWith("/builds") && init?.method === "POST"
+      )
+    ).toBe(false);
+    expect(
+      fetcher.mock.calls.some(
+        ([input, init]) =>
+          String(input).endsWith("/environment_variables/HQBASE_UPDATER_LOADER") &&
+          init?.method === "DELETE"
+      )
+    ).toBe(true);
+  });
+  it("does not change the command or start a build when variables are rejected", async () => {
+    const fetcher = cloudflareUpdateFetcher({ variablesFail: true });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toMatchObject({
+      code: "UPDATE_CLOUDFLARE_ERROR",
+      message: "Cloudflare rejected the request to set the updater variables (HTTP 400, code 1002)."
+    });
+    expect(
+      fetcher.mock.calls.some(
+        ([input, init]) =>
+          String(input).endsWith("/builds/triggers/trigger") && init?.method === "PATCH"
+      )
+    ).toBe(false);
+    expect(
+      fetcher.mock.calls.some(
+        ([input, init]) => String(input).endsWith("/builds") && init?.method === "POST"
+      )
+    ).toBe(false);
+  });
   it("restores the previous release pin when the build does not start", async () => {
     const fetcher = cloudflareUpdateFetcher({
       buildFails: true,
@@ -374,14 +461,17 @@ describe("HQBase updates", () => {
         "0.1.0",
         fetcher as typeof fetch
       )
-    ).rejects.toThrow("Build could not start");
+    ).rejects.toThrow("start the Workers Build");
 
     const pinRequests = fetcher.mock.calls.filter(
       ([input, init]) =>
         String(input).endsWith("/environment_variables") && init?.method === "PATCH"
     );
     expect(pinRequests.map(([, init]) => init?.body)).toEqual([
-      JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.1.0" } }),
+      JSON.stringify({
+        HQBASE_UPDATER_LOADER: { is_secret: false, value: managedUpdaterLoader(updater) },
+        HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.1.0" }
+      }),
       JSON.stringify({ HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.0.8" } })
     ]);
     const commandRequests = fetcher.mock.calls.filter(
@@ -389,7 +479,7 @@ describe("HQBase updates", () => {
         String(input).endsWith("/builds/triggers/trigger") && init?.method === "PATCH"
     );
     expect(commandRequests.map(([, init]) => init?.body)).toEqual([
-      JSON.stringify({ deploy_command: managedDeployCommand(updater) }),
+      JSON.stringify({ deploy_command: managedDeployCommand() }),
       JSON.stringify({ deploy_command: "pnpm deploy" })
     ]);
   });
@@ -403,7 +493,7 @@ describe("HQBase updates", () => {
         "0.1.0",
         fetcher as typeof fetch
       )
-    ).rejects.toThrow("Build could not start");
+    ).rejects.toThrow("start the Workers Build");
     expect(
       fetcher.mock.calls.some(
         ([input, init]) =>
@@ -411,6 +501,89 @@ describe("HQBase updates", () => {
           init?.method === "DELETE"
       )
     ).toBe(true);
+    expect(
+      fetcher.mock.calls.some(
+        ([input, init]) =>
+          String(input).endsWith("/environment_variables/HQBASE_UPDATER_LOADER") &&
+          init?.method === "DELETE"
+      )
+    ).toBe(true);
+  });
+  it("restores the previous updater loader when the build is rejected", async () => {
+    const fetcher = cloudflareUpdateFetcher({
+      buildFails: true,
+      variables: {
+        HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "0.0.8" },
+        HQBASE_UPDATER_LOADER: { is_secret: false, value: "previous-loader" }
+      }
+    });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toThrow("start the Workers Build");
+    const variableBodies = fetcher.mock.calls
+      .filter(
+        ([input, init]) =>
+          String(input).endsWith("/environment_variables") && init?.method === "PATCH"
+      )
+      .map(([, init]) => init?.body);
+    expect(variableBodies).toContain(
+      JSON.stringify({
+        HQBASE_UPDATER_LOADER: { is_secret: false, value: "previous-loader" }
+      })
+    );
+  });
+  it("reconciles a build that Cloudflare accepted before the response failed", async () => {
+    const fetcher = cloudflareUpdateFetcher({ ambiguousBuild: "accepted" });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).resolves.toEqual({ buildId: "reconciled-build", status: "queued" });
+    expect(fetcher.mock.calls.some(([, init]) => init?.method === "DELETE")).toBe(false);
+  });
+  it("keeps verified configuration when build acceptance cannot be determined", async () => {
+    const fetcher = cloudflareUpdateFetcher({ ambiguousBuild: "unknown" });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toMatchObject({ code: "UPDATE_BUILD_STATUS_UNKNOWN", status: 502 });
+    expect(fetcher.mock.calls.some(([, init]) => init?.method === "DELETE")).toBe(false);
+    expect(
+      fetcher.mock.calls.filter(
+        ([input, init]) =>
+          String(input).endsWith("/builds/triggers/trigger") && init?.method === "PATCH"
+      )
+    ).toHaveLength(1);
+  });
+  it("does not reconcile a build with a different updater loader", async () => {
+    const fetcher = cloudflareUpdateFetcher({
+      ambiguousBuild: "accepted",
+      reconciledLoader: "different-loader"
+    });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toMatchObject({ code: "UPDATE_BUILD_STATUS_UNKNOWN", status: 502 });
   });
   it("reports an incomplete build-configuration rollback", async () => {
     const fetcher = cloudflareUpdateFetcher({
@@ -434,7 +607,8 @@ describe("HQBase updates", () => {
         String(input).endsWith("/builds/triggers/trigger") && init?.method === "PATCH"
     );
     expect(commandRequests.map(([, init]) => init?.body)).toEqual([
-      JSON.stringify({ deploy_command: managedDeployCommand(updater) })
+      JSON.stringify({ deploy_command: managedDeployCommand() }),
+      JSON.stringify({ deploy_command: "pnpm deploy" })
     ]);
   });
 });
@@ -575,16 +749,23 @@ function migrationQueryResult(
 
 function cloudflareUpdateFetcher(
   options: {
+    ambiguousBuild?: "accepted" | "unknown";
     beforeFirstPin?: () => Promise<void>;
     branchIncludes?: string[];
     buildFails?: boolean;
+    commandFails?: boolean;
     deployCommand?: string;
     rollbackFails?: boolean;
     rootDirectory?: string;
+    reconciledLoader?: string;
     variables?: Record<string, { is_secret: boolean; value?: string | null }>;
+    variablesFail?: boolean;
   } = {}
 ) {
-  let pinPatches = 0;
+  let commandPatches = 0;
+  let deployCommand = options.deployCommand ?? "pnpm deploy";
+  let variablePatches = 0;
+  const variables = structuredClone(options.variables ?? {});
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     if (url.includes("github.com/HQBase/hqbase/releases")) return Response.json(envelope);
@@ -604,35 +785,98 @@ function cloudflareUpdateFetcher(
           {
             id: "trigger",
             branch_includes: options.branchIncludes ?? ["main"],
-            deploy_command: options.deployCommand ?? "pnpm deploy",
+            deploy_command: deployCommand,
             root_directory: options.rootDirectory ?? "/"
           }
         ]
       });
     }
-    if (url.endsWith("/environment_variables")) {
-      if (init?.method === "PATCH") pinPatches += 1;
-      if (pinPatches === 1) await options.beforeFirstPin?.();
-      if (options.rollbackFails && pinPatches > 1) {
-        return Response.json(
-          { success: false, errors: [{ message: "Pin rollback failed." }] },
-          { status: 502 }
+    if (url.endsWith("/builds/triggers/trigger")) {
+      if (init?.method === "PATCH") {
+        commandPatches += 1;
+        if (options.commandFails && commandPatches === 1) {
+          return Response.json(
+            { success: false, errors: [{ code: 1000, message: "Invalid request body" }] },
+            { headers: { "cf-ray": "command-ray" }, status: 400 }
+          );
+        }
+        if (options.rollbackFails && commandPatches > 1) {
+          return Response.json(
+            { success: false, errors: [{ code: 1001, message: "Rollback failed" }] },
+            { status: 502 }
+          );
+        }
+        deployCommand = String(
+          (JSON.parse(String(init.body)) as { deploy_command: string }).deploy_command
         );
       }
-      return Response.json({
-        success: true,
-        result: init?.method === "PATCH" ? {} : (options.variables ?? {})
-      });
+      return Response.json({ success: true, result: { deploy_command: deployCommand } });
+    }
+    if (url.includes("/environment_variables/") && init?.method === "DELETE") {
+      delete variables[decodeURIComponent(url.slice(url.lastIndexOf("/") + 1))];
+      return Response.json({ success: true, result: null });
+    }
+    if (url.endsWith("/environment_variables")) {
+      if (init?.method === "PATCH") {
+        variablePatches += 1;
+        if (variablePatches === 1) await options.beforeFirstPin?.();
+        if (options.variablesFail && variablePatches === 1) {
+          return Response.json(
+            { success: false, errors: [{ code: 1002, message: "Variables failed" }] },
+            { status: 400 }
+          );
+        }
+        Object.assign(
+          variables,
+          JSON.parse(String(init.body)) as Record<
+            string,
+            { is_secret: boolean; value?: string | null }
+          >
+        );
+      }
+      return Response.json({ success: true, result: structuredClone(variables) });
     }
     if (url.endsWith("/builds") && options.buildFails) {
       return Response.json(
-        { success: false, errors: [{ message: "Build could not start." }] },
-        { status: 502 }
+        { success: false, errors: [{ code: 1003, message: "Build could not start." }] },
+        { headers: { "cf-ray": "build-ray" }, status: 400 }
       );
     }
-    return Response.json({
-      success: true,
-      result: { build_uuid: "build-id", status: "queued" }
-    });
+    if (url.endsWith("/builds") && init?.method === "POST") {
+      if (options.ambiguousBuild) throw new TypeError("socket closed after request upload");
+      return Response.json({
+        success: true,
+        result: { build_uuid: "build-id", status: "queued" }
+      });
+    }
+    if (url.includes("/builds/builds/latest?")) {
+      return Response.json({
+        success: true,
+        result: {
+          builds:
+            options.ambiguousBuild === "accepted"
+              ? {
+                  "worker-tag": {
+                    build_trigger_metadata: {
+                      branch: "main",
+                      build_trigger_source: "api",
+                      deploy_command: managedDeployCommand(),
+                      environment_variables: {
+                        HQBASE_EXPECTED_RELEASE_VERSION: "0.1.0",
+                        HQBASE_UPDATER_LOADER:
+                          options.reconciledLoader ?? managedUpdaterLoader(updater)
+                      }
+                    },
+                    build_uuid: "reconciled-build",
+                    created_on: new Date().toISOString(),
+                    status: "queued",
+                    trigger: { trigger_uuid: "trigger" }
+                  }
+                }
+              : {}
+        }
+      });
+    }
+    throw new Error(`Unexpected Cloudflare request: ${init?.method ?? "GET"} ${url}`);
   });
 }

--- a/worker/features/updates/build-trigger.ts
+++ b/worker/features/updates/build-trigger.ts
@@ -1,0 +1,352 @@
+import { AppError } from "../../lib/errors";
+import { cloudflare } from "./cloudflare";
+import type { ReleaseManifest } from "./types";
+
+export const expectedReleaseVariable = "HQBASE_EXPECTED_RELEASE_VERSION";
+export const forceSourceDeployVariable = "HQBASE_FORCE_SOURCE_DEPLOY";
+export const updaterLoaderVariable = "HQBASE_UPDATER_LOADER";
+const legacyManagedDeployCommands = new Set(["pnpm deploy", "pnpm run deploy"]);
+
+export type BuildVariable = { is_secret: boolean; value?: string | null };
+export type BuildConfiguration = {
+  deployCommand: string;
+  variables: Record<string, BuildVariable>;
+};
+type BuildResponse = {
+  build_trigger_metadata?: {
+    branch?: string;
+    build_trigger_source?: string;
+    deploy_command?: string;
+    environment_variables?: Record<string, string>;
+  };
+  build_uuid?: string;
+  created_on?: string;
+  status?: string;
+  trigger?: { trigger_uuid?: string };
+};
+
+export function assertManagedTrigger(trigger: {
+  deploy_command?: string | null;
+  root_directory?: string | null;
+}): void {
+  const command = trigger.deploy_command?.trim() ?? "";
+  const root = trigger.root_directory?.trim() ?? "";
+  if (!isManagedDeployCommand(command) || !["", "/", ".", "./"].includes(root)) {
+    throw new AppError(
+      "UPDATE_TRIGGER_UNMANAGED",
+      "Signed updates require a repository-root Workers Builds trigger that uses the HQBase updater. Use the custom-source deployment process instead.",
+      409
+    );
+  }
+}
+
+export function managedDeployCommand(): string {
+  return 'node --input-type=module --eval "$HQBASE_UPDATER_LOADER"';
+}
+
+export function managedUpdaterLoader(updater: NonNullable<ReleaseManifest["updater"]>): string {
+  const { sha256, size, sourceUrl } = updater;
+  return `const u="${sourceUrl}";const h="${sha256}";const n=${size};const r=await fetch(u);if(!r.ok)throw new Error("HQBase updater download failed.");const b=Buffer.from(await r.arrayBuffer());const {createHash}=await import("node:crypto");if(b.length!==n||createHash("sha256").update(b).digest("hex")!==h)throw new Error("HQBase updater verification failed.");await import("data:text/javascript;base64,"+b.toString("base64"));`;
+}
+
+export function isManagedDeployCommand(command: string): boolean {
+  const trimmed = command.trim();
+  if (legacyManagedDeployCommands.has(trimmed.replace(/\s+/g, " "))) return true;
+  if (trimmed === managedDeployCommand()) return true;
+  const match = trimmed.match(
+    /^node --input-type=module --eval 'const u="(https:\/\/raw\.githubusercontent\.com\/HQBase\/hqbase\/[a-f0-9]{40}\/scripts\/release\/bootstrap\.mjs)";const h="([a-f0-9]{64})";const n=([1-9]\d*);/
+  );
+  if (!match) return false;
+  const sourceUrl = match[1];
+  const sha256 = match[2];
+  const size = match[3];
+  if (!sourceUrl || !sha256 || !size) return false;
+  return (
+    trimmed ===
+    `node --input-type=module --eval '${managedUpdaterLoader({
+      protocol: 2,
+      sha256,
+      size: Number(size),
+      sourceUrl
+    })}'`
+  );
+}
+
+export async function setBuildDeployCommand(
+  url: string,
+  deployCommand: string,
+  headers: Record<string, string>,
+  fetcher: typeof fetch
+): Promise<void> {
+  await cloudflare(
+    url,
+    { method: "PATCH", headers, body: JSON.stringify({ deploy_command: deployCommand }) },
+    fetcher,
+    "set_build_command"
+  );
+}
+
+export async function setBuildUpdaterVariables(
+  url: string,
+  loader: string,
+  version: string,
+  headers: Record<string, string>,
+  fetcher: typeof fetch
+): Promise<void> {
+  await cloudflare(
+    url,
+    {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({
+        [updaterLoaderVariable]: { is_secret: false, value: loader },
+        [expectedReleaseVariable]: { is_secret: false, value: version }
+      })
+    },
+    fetcher,
+    "set_build_variables"
+  );
+}
+
+async function restoreBuildConfiguration(
+  triggerUrl: string,
+  triggersUrl: string,
+  triggerId: string,
+  variablesUrl: string,
+  previous: BuildConfiguration,
+  headers: Record<string, string>,
+  fetcher: typeof fetch
+): Promise<void> {
+  let current = await readBuildConfiguration(
+    triggersUrl,
+    triggerId,
+    variablesUrl,
+    headers,
+    fetcher
+  );
+  if (current.deployCommand !== previous.deployCommand) {
+    await setBuildDeployCommand(triggerUrl, previous.deployCommand, headers, fetcher);
+  }
+  for (const name of [updaterLoaderVariable, expectedReleaseVariable]) {
+    if (!sameBuildVariable(current.variables[name], previous.variables[name])) {
+      await restoreBuildVariable(variablesUrl, name, previous.variables[name], headers, fetcher);
+    }
+  }
+  current = await readBuildConfiguration(triggersUrl, triggerId, variablesUrl, headers, fetcher);
+  if (
+    current.deployCommand !== previous.deployCommand ||
+    !sameBuildVariable(
+      current.variables[updaterLoaderVariable],
+      previous.variables[updaterLoaderVariable]
+    ) ||
+    !sameBuildVariable(
+      current.variables[expectedReleaseVariable],
+      previous.variables[expectedReleaseVariable]
+    )
+  ) {
+    throw new Error("Workers Builds configuration rollback could not be verified.");
+  }
+}
+
+async function restoreBuildVariable(
+  url: string,
+  name: string,
+  previous: BuildVariable | undefined,
+  headers: Record<string, string>,
+  fetcher: typeof fetch
+): Promise<void> {
+  if (typeof previous?.value === "string") {
+    await cloudflare(
+      url,
+      {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({ [name]: { is_secret: false, value: previous.value } })
+      },
+      fetcher,
+      "set_build_variables"
+    );
+    return;
+  }
+  await cloudflare(
+    `${url}/${name}`,
+    { method: "DELETE", headers },
+    fetcher,
+    "delete_build_variable"
+  );
+}
+
+export async function verifyBuildConfiguration(
+  triggersUrl: string,
+  triggerId: string,
+  variablesUrl: string,
+  expected: { deployCommand: string; loader: string; version: string },
+  headers: Record<string, string>,
+  fetcher: typeof fetch
+): Promise<void> {
+  const current = await readBuildConfiguration(
+    triggersUrl,
+    triggerId,
+    variablesUrl,
+    headers,
+    fetcher
+  );
+  if (
+    current.deployCommand !== expected.deployCommand ||
+    !buildVariableEquals(current.variables[updaterLoaderVariable], expected.loader) ||
+    !buildVariableEquals(current.variables[expectedReleaseVariable], expected.version)
+  ) {
+    throw new AppError(
+      "UPDATE_TRIGGER_CONFIGURATION_MISMATCH",
+      "Cloudflare did not keep the verified signed updater configuration. The build did not start.",
+      502
+    );
+  }
+}
+
+async function readBuildConfiguration(
+  triggersUrl: string,
+  triggerId: string,
+  variablesUrl: string,
+  headers: Record<string, string>,
+  fetcher: typeof fetch
+): Promise<BuildConfiguration> {
+  const [triggers, variables] = await Promise.all([
+    cloudflare<{
+      result: Array<{ id?: string; trigger_uuid?: string; deploy_command?: string | null }>;
+    }>(triggersUrl, { headers }, fetcher, "read_build_trigger"),
+    cloudflare<{ result: Record<string, BuildVariable> }>(
+      variablesUrl,
+      { headers },
+      fetcher,
+      "read_build_variables"
+    )
+  ]);
+  const trigger = triggers.result.find(
+    (candidate) => (candidate.trigger_uuid ?? candidate.id) === triggerId
+  );
+  if (!trigger) {
+    throw new AppError(
+      "UPDATE_TRIGGER_NOT_FOUND",
+      "Cloudflare no longer reports the production build trigger.",
+      502
+    );
+  }
+  return {
+    deployCommand: trigger.deploy_command?.trim() ?? "",
+    variables: variables.result
+  };
+}
+
+export function isRestorableBuildVariable(variable: BuildVariable | undefined): boolean {
+  return variable === undefined || (!variable.is_secret && typeof variable.value === "string");
+}
+
+export function buildVariableEquals(variable: BuildVariable | undefined, value: string): boolean {
+  return variable?.is_secret === false && variable.value === value;
+}
+
+function sameBuildVariable(
+  left: BuildVariable | undefined,
+  right: BuildVariable | undefined
+): boolean {
+  if (!left || !right) return left === right;
+  return left.is_secret === right.is_secret && left.value === right.value;
+}
+
+export async function restoreOrThrow(
+  triggerUrl: string,
+  triggersUrl: string,
+  triggerId: string,
+  variablesUrl: string,
+  previous: BuildConfiguration,
+  headers: Record<string, string>,
+  fetcher: typeof fetch
+): Promise<void> {
+  try {
+    await restoreBuildConfiguration(
+      triggerUrl,
+      triggersUrl,
+      triggerId,
+      variablesUrl,
+      previous,
+      headers,
+      fetcher
+    );
+  } catch {
+    throw new AppError(
+      "UPDATE_TRIGGER_ROLLBACK_FAILED",
+      "The build did not start, and HQBase could not restore the previous Cloudflare build configuration. Review the production Workers Builds trigger before trying again.",
+      502
+    );
+  }
+}
+
+export async function startBuild(
+  accountId: string,
+  triggerId: string,
+  headers: Record<string, string>,
+  fetcher: typeof fetch
+): Promise<{ buildId: string; status: string }> {
+  const build = await cloudflare<{
+    result: { build_uuid?: string; id?: string; status?: string };
+  }>(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${triggerId}/builds`,
+    { method: "POST", headers, body: JSON.stringify({ branch: "main" }) },
+    fetcher,
+    "start_build"
+  );
+  const buildId = build.result.build_uuid ?? build.result.id;
+  if (buildId) return { buildId, status: build.result.status ?? "queued" };
+  throw new AppError(
+    "UPDATE_BUILD_STATUS_UNKNOWN",
+    "Cloudflare accepted the build request but did not return a build identifier.",
+    502
+  );
+}
+
+export async function reconcileAcceptedBuild(
+  accountId: string,
+  scriptTag: string,
+  triggerId: string,
+  expectedVersion: string,
+  expectedLoader: string,
+  dispatchStartedAt: number,
+  headers: Record<string, string>,
+  fetcher: typeof fetch
+): Promise<{ buildId: string; status: string } | null> {
+  let latest: { result: { builds?: Record<string, BuildResponse> } };
+  try {
+    latest = await cloudflare(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/builds/latest?external_script_ids=${encodeURIComponent(scriptTag)}`,
+      { headers },
+      fetcher,
+      "read_latest_build"
+    );
+  } catch {
+    return null;
+  }
+  const earliestAcceptedTime = dispatchStartedAt - 30_000;
+  const latestAcceptedTime = Date.now() + 30_000;
+  const accepted = Object.values(latest.result.builds ?? {}).find((build) => {
+    const createdAt = Date.parse(build.created_on ?? "");
+    const source = build.build_trigger_metadata?.build_trigger_source;
+    return (
+      typeof build.build_uuid === "string" &&
+      build.trigger?.trigger_uuid === triggerId &&
+      build.build_trigger_metadata?.branch === "main" &&
+      build.build_trigger_metadata.deploy_command === managedDeployCommand() &&
+      build.build_trigger_metadata.environment_variables?.[expectedReleaseVariable] ===
+        expectedVersion &&
+      build.build_trigger_metadata.environment_variables?.[updaterLoaderVariable] ===
+        expectedLoader &&
+      (source === "api" || source === "manual") &&
+      Number.isFinite(createdAt) &&
+      createdAt >= earliestAcceptedTime &&
+      createdAt <= latestAcceptedTime
+    );
+  });
+  return accepted?.build_uuid
+    ? { buildId: accepted.build_uuid, status: accepted.status ?? "queued" }
+    : null;
+}

--- a/worker/features/updates/cloudflare.ts
+++ b/worker/features/updates/cloudflare.ts
@@ -1,35 +1,143 @@
 import { AppError } from "../../lib/errors";
+import { operationalLog } from "../../observability/log";
 
 const cloudflareRequestTimeoutMs = 30_000;
+const operationLabels = {
+  read_zones: "read the Cloudflare zones",
+  read_workers: "read the Worker list",
+  read_build_triggers: "read the Workers Builds triggers",
+  read_build_trigger: "read the Workers Builds trigger",
+  read_build_variables: "read the Workers Builds variables",
+  read_latest_build: "read the latest Workers Build",
+  set_build_command: "set the Workers Builds deploy command",
+  set_build_variables: "set the updater variables",
+  delete_build_variable: "remove a signed updater variable",
+  start_build: "start the Workers Build"
+} as const;
+
+export type CloudflareUpdateOperation = keyof typeof operationLabels;
+
+class CloudflareUpdateError extends AppError {
+  readonly ambiguous: boolean;
+  readonly operation: CloudflareUpdateOperation;
+
+  constructor(
+    code: string,
+    message: string,
+    status: number,
+    operation: CloudflareUpdateOperation,
+    ambiguous: boolean
+  ) {
+    super(code, message, status);
+    this.name = "CloudflareUpdateError";
+    this.ambiguous = ambiguous;
+    this.operation = operation;
+  }
+}
+
+export function isAmbiguousCloudflareOperation(
+  error: unknown,
+  operation: CloudflareUpdateOperation
+): boolean {
+  return error instanceof CloudflareUpdateError && error.operation === operation && error.ambiguous;
+}
 
 export async function cloudflare<T>(
   url: string,
   init: RequestInit,
-  fetcher: typeof fetch
+  fetcher: typeof fetch,
+  operation: CloudflareUpdateOperation
 ): Promise<T> {
   const signal = init.signal ?? AbortSignal.timeout(cloudflareRequestTimeoutMs);
   let response: Response;
   try {
     response = await fetcher(url, { ...init, signal });
-  } catch (error) {
+  } catch {
+    logFailure(operation, null, null, null);
     if (signal.aborted) {
-      throw new AppError(
+      throw new CloudflareUpdateError(
         "UPDATE_CLOUDFLARE_TIMEOUT",
-        "Cloudflare did not respond before the update request timed out.",
-        504
+        `Cloudflare did not respond while HQBase tried to ${operationLabels[operation]}.`,
+        504,
+        operation,
+        true
       );
     }
-    throw error;
-  }
-  const body = (await response.json()) as {
-    success?: boolean;
-    errors?: Array<{ message?: string }>;
-  };
-  if (!response.ok || body.success === false)
-    throw new AppError(
-      "UPDATE_CLOUDFLARE_ERROR",
-      body.errors?.[0]?.message ?? "Cloudflare rejected the update request.",
-      response.status === 401 || response.status === 403 ? 403 : 502
+    throw new CloudflareUpdateError(
+      "UPDATE_CLOUDFLARE_UNAVAILABLE",
+      `HQBase could not ${operationLabels[operation]} because the Cloudflare request failed.`,
+      502,
+      operation,
+      true
     );
+  }
+
+  let body: {
+    success?: boolean;
+    errors?: Array<{ code?: number | string }>;
+  };
+  try {
+    body = (await response.json()) as typeof body;
+  } catch {
+    const requestId = safeRequestId(response.headers.get("cf-ray"));
+    logFailure(operation, response.status, null, requestId);
+    throw new CloudflareUpdateError(
+      "UPDATE_CLOUDFLARE_INVALID_RESPONSE",
+      diagnosticMessage(operation, response.status, null, requestId),
+      502,
+      operation,
+      true
+    );
+  }
+
+  if (!response.ok || body.success === false) {
+    const providerCode = safeProviderCode(body.errors?.[0]?.code);
+    const requestId = safeRequestId(response.headers.get("cf-ray"));
+    logFailure(operation, response.status, providerCode, requestId);
+    throw new CloudflareUpdateError(
+      "UPDATE_CLOUDFLARE_ERROR",
+      diagnosticMessage(operation, response.status, providerCode, requestId),
+      response.status === 401 || response.status === 403 ? 403 : 502,
+      operation,
+      response.status >= 500
+    );
+  }
   return body as T;
+}
+
+function diagnosticMessage(
+  operation: CloudflareUpdateOperation,
+  status: number,
+  providerCode: string | null,
+  requestId: string | null
+): string {
+  const details = [
+    `HTTP ${status}`,
+    ...(providerCode ? [`code ${providerCode}`] : []),
+    ...(requestId ? [`request ${requestId}`] : [])
+  ];
+  return `Cloudflare rejected the request to ${operationLabels[operation]} (${details.join(", ")}).`;
+}
+
+function logFailure(
+  operation: CloudflareUpdateOperation,
+  status: number | null,
+  providerCode: string | null,
+  requestId: string | null
+): void {
+  operationalLog("warn", "cloudflare_update_request_failed", {
+    operation,
+    providerCode,
+    requestId,
+    status
+  });
+}
+
+function safeProviderCode(value: number | string | undefined): string | null {
+  const code = String(value ?? "");
+  return /^[0-9A-Za-z_.:-]{1,64}$/.test(code) ? code : null;
+}
+
+function safeRequestId(value: string | null): string | null {
+  return value && /^[0-9A-Za-z-]{1,128}$/.test(value) ? value : null;
 }

--- a/worker/features/updates/service.ts
+++ b/worker/features/updates/service.ts
@@ -4,13 +4,31 @@ import type { WorkerEnv } from "../../lib/env";
 import { AppError } from "../../lib/errors";
 import { hqbaseProductConfig } from "../../lib/product-config";
 import { withUpdateBuildLock } from "./build-lock";
-import { cloudflare } from "./cloudflare";
+import {
+  assertManagedTrigger,
+  type BuildConfiguration,
+  type BuildVariable,
+  buildVariableEquals,
+  expectedReleaseVariable,
+  forceSourceDeployVariable,
+  isManagedDeployCommand,
+  isRestorableBuildVariable,
+  managedDeployCommand,
+  managedUpdaterLoader,
+  reconcileAcceptedBuild,
+  restoreOrThrow,
+  setBuildDeployCommand,
+  setBuildUpdaterVariables,
+  startBuild,
+  updaterLoaderVariable,
+  verifyBuildConfiguration
+} from "./build-trigger";
+import { cloudflare, isAmbiguousCloudflareOperation } from "./cloudflare";
 import { inspectManagedMigrationState, type ManagedMigrationState } from "./migration-state";
 import type { ReleaseManifest, UpdateStatus } from "./types";
 
-const expectedReleaseVariable = "HQBASE_EXPECTED_RELEASE_VERSION";
-const forceSourceDeployVariable = "HQBASE_FORCE_SOURCE_DEPLOY";
-const legacyManagedDeployCommands = new Set(["pnpm deploy", "pnpm run deploy"]);
+export { isManagedDeployCommand, managedDeployCommand, managedUpdaterLoader };
+
 const envelopeSchema = z.object({ payload: z.string().min(1), signature: z.string().min(1) });
 const manifestSchema = z.object({
   format: z.literal("hqbase-release-v1"),
@@ -124,7 +142,8 @@ export async function triggerUpdate(
   const zones = await cloudflare<{ result: Array<{ name: string; account: { id: string } }> }>(
     "https://api.cloudflare.com/client/v4/zones?per_page=50",
     { headers },
-    fetcher
+    fetcher,
+    "read_zones"
   );
   const zone = zones.result
     .filter((candidate) => domain === candidate.name || domain.endsWith(`.${candidate.name}`))
@@ -139,7 +158,8 @@ export async function triggerUpdate(
   const scripts = await cloudflare<{ result: Array<{ id: string; tag?: string }> }>(
     `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/scripts`,
     { headers },
-    fetcher
+    fetcher,
+    "read_workers"
   );
   const script = scripts.result.find(
     (candidate) => candidate.id === (env.HQBASE_WORKER_NAME ?? "hqbase")
@@ -150,6 +170,8 @@ export async function triggerUpdate(
       "The production Worker build could not be found.",
       404
     );
+  const scriptTag = script.tag;
+  const triggersUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/workers/${scriptTag}/triggers`;
   const triggers = await cloudflare<{
     result: Array<{
       id?: string;
@@ -158,11 +180,7 @@ export async function triggerUpdate(
       deploy_command?: string | null;
       root_directory?: string | null;
     }>;
-  }>(
-    `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/workers/${script.tag}/triggers`,
-    { headers },
-    fetcher
-  );
+  }>(triggersUrl, { headers }, fetcher, "read_build_triggers");
   const trigger = triggers.result.find((item) => item.branch_includes?.includes("main"));
   if (!trigger)
     throw new AppError(
@@ -182,8 +200,8 @@ export async function triggerUpdate(
     const triggerUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${triggerId}`;
     const variablesUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${triggerId}/environment_variables`;
     const variables = await cloudflare<{
-      result: Record<string, { is_secret: boolean; value?: string | null }>;
-    }>(variablesUrl, { headers }, fetcher);
+      result: Record<string, BuildVariable>;
+    }>(variablesUrl, { headers }, fetcher, "read_build_variables");
     const sourceDeploy = variables.result[forceSourceDeployVariable];
     if (sourceDeploy?.is_secret || sourceDeploy?.value?.trim() === "1") {
       throw new AppError(
@@ -193,141 +211,98 @@ export async function triggerUpdate(
       );
     }
     const previousPin = variables.result[expectedReleaseVariable];
-    if (previousPin?.is_secret) {
+    const previousLoader = variables.result[updaterLoaderVariable];
+    if (!isRestorableBuildVariable(previousPin) || !isRestorableBuildVariable(previousLoader)) {
       throw new AppError(
         "UPDATE_TRIGGER_UNMANAGED",
-        "Signed updates require HQBASE_EXPECTED_RELEASE_VERSION to be a plain build variable.",
+        "Signed updates require the updater loader and release version to be plain Workers Builds variables.",
         409
       );
     }
     const previousDeployCommand = trigger.deploy_command?.trim() ?? "";
-    const nextDeployCommand = managedDeployCommand(update.release.updater);
-    let deployCommandChanged = false;
+    const previousConfiguration: BuildConfiguration = {
+      deployCommand: previousDeployCommand,
+      variables: structuredClone(variables.result)
+    };
+    const nextConfiguration = {
+      deployCommand: managedDeployCommand(),
+      loader: managedUpdaterLoader(update.release.updater),
+      version: expectedVersion
+    };
     try {
-      if (previousDeployCommand !== nextDeployCommand) {
-        await setBuildDeployCommand(triggerUrl, nextDeployCommand, headers, fetcher);
-        deployCommandChanged = true;
+      if (
+        !buildVariableEquals(previousLoader, nextConfiguration.loader) ||
+        !buildVariableEquals(previousPin, nextConfiguration.version)
+      ) {
+        await setBuildUpdaterVariables(
+          variablesUrl,
+          nextConfiguration.loader,
+          nextConfiguration.version,
+          headers,
+          fetcher
+        );
       }
-      await setBuildVersionPin(variablesUrl, expectedVersion, headers, fetcher);
-      const build = await cloudflare<{
-        result: { build_uuid?: string; id?: string; status?: string };
-      }>(
-        `https://api.cloudflare.com/client/v4/accounts/${accountId}/builds/triggers/${triggerId}/builds`,
-        { method: "POST", headers, body: JSON.stringify({ branch: "main" }) },
+      if (previousDeployCommand !== nextConfiguration.deployCommand) {
+        await setBuildDeployCommand(triggerUrl, nextConfiguration.deployCommand, headers, fetcher);
+      }
+      await verifyBuildConfiguration(
+        triggersUrl,
+        triggerId,
+        variablesUrl,
+        nextConfiguration,
+        headers,
         fetcher
       );
-      const buildId = build.result.build_uuid ?? build.result.id;
-      if (!buildId)
-        throw new AppError(
-          "UPDATE_TRIGGER_FAILED",
-          "Cloudflare did not return a build identifier.",
-          502
-        );
-      return { buildId, status: build.result.status ?? "queued" };
     } catch (error) {
-      let rollbackFailed = false;
-      let releasePinRestored = false;
-      try {
-        await restoreBuildVersionPin(variablesUrl, previousPin, headers, fetcher);
-        releasePinRestored = true;
-      } catch {
-        rollbackFailed = true;
-      }
-      if (deployCommandChanged && releasePinRestored) {
-        try {
-          await setBuildDeployCommand(triggerUrl, previousDeployCommand, headers, fetcher);
-        } catch {
-          rollbackFailed = true;
-        }
-      }
-      if (rollbackFailed) {
+      await restoreOrThrow(
+        triggerUrl,
+        triggersUrl,
+        triggerId,
+        variablesUrl,
+        previousConfiguration,
+        headers,
+        fetcher
+      );
+      throw error;
+    }
+
+    const dispatchStartedAt = Date.now();
+    try {
+      return await startBuild(accountId, triggerId, headers, fetcher);
+    } catch (error) {
+      if (
+        isAmbiguousCloudflareOperation(error, "start_build") ||
+        (error instanceof AppError && error.code === "UPDATE_BUILD_STATUS_UNKNOWN")
+      ) {
+        const accepted = await reconcileAcceptedBuild(
+          accountId,
+          scriptTag,
+          triggerId,
+          expectedVersion,
+          nextConfiguration.loader,
+          dispatchStartedAt,
+          headers,
+          fetcher
+        );
+        if (accepted) return accepted;
         throw new AppError(
-          "UPDATE_TRIGGER_ROLLBACK_FAILED",
-          "The build did not start, and HQBase could not restore the previous Cloudflare build configuration. Review the production Workers Builds trigger before trying again.",
+          "UPDATE_BUILD_STATUS_UNKNOWN",
+          "Cloudflare did not confirm whether the Workers Build started. The verified update configuration remains in place. Check the production Workers Builds history before you try again.",
           502
         );
       }
+      await restoreOrThrow(
+        triggerUrl,
+        triggersUrl,
+        triggerId,
+        variablesUrl,
+        previousConfiguration,
+        headers,
+        fetcher
+      );
       throw error;
     }
   });
-}
-
-function assertManagedTrigger(trigger: {
-  deploy_command?: string | null;
-  root_directory?: string | null;
-}): void {
-  const command = trigger.deploy_command?.trim() ?? "";
-  const root = trigger.root_directory?.trim() ?? "";
-  if (!isManagedDeployCommand(command) || !["", "/", ".", "./"].includes(root)) {
-    throw new AppError(
-      "UPDATE_TRIGGER_UNMANAGED",
-      "Signed updates require a repository-root Workers Builds trigger that uses the HQBase updater. Use the custom-source deployment process instead.",
-      409
-    );
-  }
-}
-
-export function managedDeployCommand(updater: NonNullable<ReleaseManifest["updater"]>): string {
-  const { sha256, size, sourceUrl } = updater;
-  return `node --input-type=module --eval 'const u="${sourceUrl}";const h="${sha256}";const n=${size};const r=await fetch(u);if(!r.ok)throw new Error("HQBase updater download failed.");const b=Buffer.from(await r.arrayBuffer());const {createHash}=await import("node:crypto");if(b.length!==n||createHash("sha256").update(b).digest("hex")!==h)throw new Error("HQBase updater verification failed.");await import("data:text/javascript;base64,"+b.toString("base64"));'`;
-}
-
-export function isManagedDeployCommand(command: string): boolean {
-  if (legacyManagedDeployCommands.has(command.trim().replace(/\s+/g, " "))) return true;
-  const match = command.match(
-    /^node --input-type=module --eval 'const u="(https:\/\/raw\.githubusercontent\.com\/HQBase\/hqbase\/[a-f0-9]{40}\/scripts\/release\/bootstrap\.mjs)";const h="([a-f0-9]{64})";const n=([1-9]\d*);/
-  );
-  if (!match) return false;
-  const sourceUrl = match[1];
-  const sha256 = match[2];
-  const size = match[3];
-  if (!sourceUrl || !sha256 || !size) return false;
-  return command === managedDeployCommand({ protocol: 2, sha256, size: Number(size), sourceUrl });
-}
-
-async function setBuildDeployCommand(
-  url: string,
-  deployCommand: string,
-  headers: Record<string, string>,
-  fetcher: typeof fetch
-): Promise<void> {
-  await cloudflare(
-    url,
-    { method: "PATCH", headers, body: JSON.stringify({ deploy_command: deployCommand }) },
-    fetcher
-  );
-}
-
-async function setBuildVersionPin(
-  url: string,
-  version: string,
-  headers: Record<string, string>,
-  fetcher: typeof fetch
-): Promise<void> {
-  await cloudflare(
-    url,
-    {
-      method: "PATCH",
-      headers,
-      body: JSON.stringify({
-        [expectedReleaseVariable]: { is_secret: false, value: version }
-      })
-    },
-    fetcher
-  );
-}
-
-async function restoreBuildVersionPin(
-  url: string,
-  previous: { is_secret: boolean; value?: string | null } | undefined,
-  headers: Record<string, string>,
-  fetcher: typeof fetch
-): Promise<void> {
-  if (typeof previous?.value === "string") {
-    await setBuildVersionPin(url, previous.value, headers, fetcher);
-    return;
-  }
-  await cloudflare(`${url}/${expectedReleaseVariable}`, { method: "DELETE", headers }, fetcher);
 }
 
 async function verifyEnvelope(


### PR DESCRIPTION
## Summary

- replace the rejected 611-character updater command with a 56-character command and a verified plain loader variable
- verify and restore Workers Builds configuration, reconcile ambiguous dispatches, and redact provider response bodies
- add a deployed release gate with a real disposable trigger and canceled build
- keep the exact 1.3.3 updater identity for installations where that command was already saved
- document that affected 1.3.3 installations still using `pnpm deploy` need the one-time Cloudflare recovery before 1.3.4 can repair them

No customer source repository is changed.

## Verification

- `pnpm check`
- `pnpm deploy:dry-run`
- 1.3.3 legacy command reproduced against a disposable Cloudflare trigger: code 12002, Invalid request body
- 1.3.4 short command accepted against the same trigger
- diagnostic trigger removed and absence verified
