### PR TITLE
Record the staged previous deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,19 @@ jobs:
           done
           echo "Previous stable HQBase was not healthy within 300 seconds"
           exit 1
+      - name: Record the previous stable Worker deployment
+        run: |
+          CONFIG_FILE="$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc" \
+          WORKER_NAME="$STAGING_WORKER_NAME" node --input-type=module -e '
+            import { recordWorkerDeployedForConfig } from "./scripts/hqbase/manifest.mjs";
+            const manifest = recordWorkerDeployedForConfig(
+              process.env.CONFIG_FILE,
+              process.env.WORKER_NAME
+            );
+            if (manifest?.worker?.deployed !== true) {
+              throw new Error("The previous stable staging Worker was not recorded.");
+            }
+          '
       - name: Bootstrap persistent N-1 staging data
         env:
           HQBASE_STAGING_MAIL_API_BASE_PATH: /api

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -263,6 +263,12 @@ describe("staging workflow lifecycle record", () => {
   });
 
   it("gates publication on the deployed update action and exact cleanup", () => {
+    const waitPrevious = releaseWorkflow.indexOf(
+      "      - name: Wait for the previous stable release"
+    );
+    const recordPrevious = releaseWorkflow.indexOf(
+      "      - name: Record the previous stable Worker deployment"
+    );
     const prepare = releaseWorkflow.indexOf(
       "      - name: Prepare the deployed update-action release gate"
     );
@@ -281,7 +287,9 @@ describe("staging workflow lifecycle record", () => {
     );
     const upload = releaseWorkflow.indexOf("      - name: Upload non-secret deployment record");
 
-    expect(prepare).toBeGreaterThan(-1);
+    expect(waitPrevious).toBeGreaterThan(-1);
+    expect(recordPrevious).toBeGreaterThan(waitPrevious);
+    expect(prepare).toBeGreaterThan(recordPrevious);
     expect(candidate).toBeGreaterThan(prepare);
     expect(stale).toBeGreaterThan(candidate);
     expect(probe).toBeGreaterThan(stale);
@@ -295,6 +303,9 @@ describe("staging workflow lifecycle record", () => {
     expect(releaseWorkflow).toContain("staging-update-gate.mjs probe");
     expect(releaseWorkflow).toContain("staging-update-gate.mjs cleanup");
     expect(releaseWorkflow).toContain("steps.reconcile_update_gate.outcome == 'success'");
+    expect(releaseWorkflow.slice(recordPrevious, prepare)).toContain(
+      "recordWorkerDeployedForConfig"
+    );
   });
 
   it("keeps the customer source checkout unchanged", () => {


### PR DESCRIPTION
The first 1.3.4 release run stopped before publication because the oldest updater deployed through a temporary symlink and did not mark the canonical staging manifest as deployed. This change records the confirmed healthy previous-stable Worker through the canonical deployment config before the release gate runs. It also adds a workflow regression assertion for the required step order.\n\nVerified with the focused workflow test, the full pnpm check gate, and pnpm deploy:dry-run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment validation so a release is only marked complete after the previous stable worker is confirmed deployed.
  * Added a safeguard that stops the release process if the deployment record does not match the expected worker status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->