### PR TITLE
Wait for complete build metadata

### DIFF
--- a/scripts/release/staging-update-gate-resources.mjs
+++ b/scripts/release/staging-update-gate-resources.mjs
@@ -7,7 +7,6 @@ import {
   branch,
   cloudflareHeaders,
   cloudflareResult,
-  initialBuildCommand,
   initialDeployCommand,
   listTriggers,
   listWorkers,
@@ -150,23 +149,67 @@ export async function verifyAcceptedBuild(manifest, release, context, dependenci
   ) {
     throw new Error("The accepted build did not keep the exact signed updater variables.");
   }
-  const build = await waitForBuild(record.buildUuid, context, dependencies);
-  const metadata = build.build_trigger_metadata ?? {};
-  if (
-    build.build_uuid !== record.buildUuid ||
-    build.trigger?.trigger_uuid !== record.triggerUuid ||
-    metadata.branch !== branch ||
-    !["api", "manual"].includes(metadata.build_trigger_source) ||
-    metadata.build_command !== initialBuildCommand ||
-    metadata.deploy_command !== managedCommand ||
-    metadata.environment_variables?.HQBASE_UPDATER_LOADER !==
-      managedUpdaterLoader(release.updater) ||
-    metadata.environment_variables?.HQBASE_EXPECTED_RELEASE_VERSION !== context.candidateVersion ||
-    metadata.build_token_uuid !== record.buildTokenUuid ||
-    metadata.root_directory !== "/"
-  ) {
-    throw new Error("Cloudflare did not record the exact release-gate build configuration.");
+  await waitForAcceptedBuildConfiguration(record, release, context, dependencies);
+}
+
+async function waitForAcceptedBuildConfiguration(record, release, context, dependencies) {
+  const deadline = dependencies.now() + 60_000;
+  let mismatches = ["build_record"];
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const remaining = deadline - dependencies.now();
+    if (remaining <= 0) break;
+    const build = await cloudflareResult(
+      `/accounts/${context.accountId}/builds/builds/${record.buildUuid}`,
+      { headers: cloudflareHeaders(context.cleanupToken) },
+      dependencies.fetcher,
+      { allowNotFound: true, timeoutMilliseconds: Math.min(30_000, remaining) }
+    );
+    if (build) {
+      mismatches = acceptedBuildMismatches(build, record, release, context);
+      if (mismatches.length === 0) return build;
+      if (build.status === "stopped") break;
+    }
+    const sleepMilliseconds = Math.min(1_000, deadline - dependencies.now());
+    if (sleepMilliseconds <= 0) break;
+    await dependencies.sleep(sleepMilliseconds);
   }
+  throw new Error(
+    `Cloudflare did not record the exact release-gate build configuration. Mismatched fields: ${mismatches.join(", ")}.`
+  );
+}
+
+function acceptedBuildMismatches(build, record, release, context) {
+  const metadata = build.build_trigger_metadata ?? {};
+  const expected = {
+    HQBASE_EXPECTED_RELEASE_VERSION: context.candidateVersion,
+    HQBASE_UPDATER_LOADER: managedUpdaterLoader(release.updater),
+    branch,
+    build_command: record.buildCommand,
+    build_token_uuid: record.buildTokenUuid,
+    deploy_command: managedCommand,
+    root_directory: record.rootDirectory,
+    trigger_uuid: record.triggerUuid
+  };
+  return [
+    ...(build.build_uuid === record.buildUuid ? [] : ["build_uuid"]),
+    ...(build.trigger?.trigger_uuid === expected.trigger_uuid ? [] : ["trigger_uuid"]),
+    ...(metadata.branch === expected.branch ? [] : ["branch"]),
+    ...(["api", "manual"].includes(metadata.build_trigger_source) ? [] : ["build_trigger_source"]),
+    ...(metadata.build_command === expected.build_command ? [] : ["build_command"]),
+    ...(metadata.deploy_command === expected.deploy_command ? [] : ["deploy_command"]),
+    ...(metadata.environment_variables?.HQBASE_UPDATER_LOADER === expected.HQBASE_UPDATER_LOADER
+      ? []
+      : ["HQBASE_UPDATER_LOADER"]),
+    ...(metadata.environment_variables?.HQBASE_EXPECTED_RELEASE_VERSION ===
+    expected.HQBASE_EXPECTED_RELEASE_VERSION
+      ? []
+      : ["HQBASE_EXPECTED_RELEASE_VERSION"]),
+    ...(metadata.environment_variables?.HQBASE_FORCE_SOURCE_DEPLOY === undefined
+      ? []
+      : ["HQBASE_FORCE_SOURCE_DEPLOY"]),
+    ...(metadata.build_token_uuid === expected.build_token_uuid ? [] : ["build_token_uuid"]),
+    ...(metadata.root_directory === expected.root_directory ? [] : ["root_directory"])
+  ];
 }
 
 export async function reconcileAndCancelBuild(manifest, context, dependencies) {

--- a/scripts/release/staging-update-gate-shared.mjs
+++ b/scripts/release/staging-update-gate-shared.mjs
@@ -54,9 +54,10 @@ export async function listTriggers(workerTag, context, dependencies) {
 }
 
 export async function cloudflareResult(pathname, init, fetcher, options = {}) {
+  const timeoutMilliseconds = Math.max(1, options.timeoutMilliseconds ?? 30_000);
   const response = await fetcher(`${apiBase}${pathname}`, {
     ...init,
-    signal: AbortSignal.timeout(30_000)
+    signal: AbortSignal.timeout(timeoutMilliseconds)
   });
   if (options.allowNotFound && response.status === 404) return null;
   let body;
@@ -272,6 +273,7 @@ export function resolveDependencies(options) {
     fetcher: options.fetcher ?? fetch,
     loadManifest: options.loadManifest ?? loadManifest,
     manifestExists: options.manifestExists ?? manifestExists,
+    now: options.now ?? Date.now,
     readFile: options.readFile ?? fs.readFileSync,
     runCommand: options.runCommand ?? run,
     sleep:

--- a/test/unit/scripts/staging-update-gate.test.mjs
+++ b/test/unit/scripts/staging-update-gate.test.mjs
@@ -16,6 +16,10 @@ import {
   prepareStagingUpdateGate,
   probeStagingUpdateGate
 } from "../../../scripts/release/staging-update-gate.mjs";
+import {
+  cancelRecordedBuild,
+  verifyAcceptedBuild
+} from "../../../scripts/release/staging-update-gate-resources.mjs";
 
 const accountId = "a".repeat(32);
 const productionWorkerTag = "b".repeat(32);
@@ -121,6 +125,46 @@ function trigger(record, deployCommand = "pnpm deploy") {
   };
 }
 
+function workersBuildRecord() {
+  return {
+    branch: "main",
+    buildCommand: "sleep 600",
+    buildOutcome: null,
+    buildTokenUuid,
+    buildUuid,
+    initialDeployCommand: "pnpm deploy",
+    ownership: "created",
+    pathIncludes: [".hqbase-release-gate-never"],
+    repoConnectionUuid,
+    rootDirectory: "/",
+    stoppedOn: null,
+    triggerName: "hqbase-release-gate-9001-2",
+    triggerUuid,
+    workerTag: productionWorkerTag
+  };
+}
+
+function exactBuild(record, updater, environmentVariables = {}) {
+  return {
+    build_trigger_metadata: {
+      branch: record.branch,
+      build_command: record.buildCommand,
+      build_token_uuid: record.buildTokenUuid,
+      build_trigger_source: "api",
+      deploy_command: shortCommand,
+      environment_variables: {
+        HQBASE_EXPECTED_RELEASE_VERSION: version,
+        HQBASE_UPDATER_LOADER: managedUpdaterLoader(updater),
+        ...environmentVariables
+      },
+      root_directory: record.rootDirectory
+    },
+    build_uuid: record.buildUuid,
+    status: "queued",
+    trigger: { trigger_uuid: record.triggerUuid }
+  };
+}
+
 describe("deployed update-action release gate", () => {
   it("records, exercises, cancels, and exactly reconciles its real Cloudflare resources", async () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "hqbase-gate-test-"));
@@ -134,6 +178,7 @@ describe("deployed update-action release gate", () => {
     let fixtureExists = false;
     let buildTrigger = null;
     let build = null;
+    let buildReads = 0;
     let variables = {};
     const d1 = {
       after_deploy_ledger_table_count: 0,
@@ -258,9 +303,20 @@ describe("deployed update-action release gate", () => {
         return response(variables);
       }
       if (url.pathname.endsWith(`/builds/builds/${buildUuid}`) && method === "GET") {
+        buildReads += 1;
+        if (buildReads === 1 && build?.status === "queued") {
+          events.push("read-partial-build");
+          return response({
+            build_uuid: build.build_uuid,
+            created_on: build.created_on,
+            status: build.status,
+            trigger: build.trigger
+          });
+        }
         return response(build);
       }
       if (url.pathname.endsWith(`/builds/builds/${buildUuid}/cancel`)) {
+        events.push("cancel-build");
         build = {
           ...build,
           build_outcome: "cancelled",
@@ -326,6 +382,7 @@ describe("deployed update-action release gate", () => {
       expect(events.indexOf("record-created-creating")).toBeLessThan(
         events.indexOf("create-trigger")
       );
+      expect(events.indexOf("read-partial-build")).toBeLessThan(events.indexOf("cancel-build"));
       expect(manifest.releaseGate).toMatchObject({
         candidateManifest: { ownership: "removed", workerTag: fixtureWorkerTag },
         workersBuild: {
@@ -358,6 +415,118 @@ describe("deployed update-action release gate", () => {
     } finally {
       fs.rmSync(workspace, { force: true, recursive: true });
     }
+  });
+
+  it("ends slow build-metadata polling in time to cancel the probe build", async () => {
+    const release = releaseEnvelope().manifest;
+    const record = workersBuildRecord();
+    const manifest = { releaseGate: { workersBuild: record } };
+    const context = { accountId, candidateVersion: version, cleanupToken: "cleanup-token" };
+    const variables = {
+      HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: version },
+      HQBASE_UPDATER_LOADER: {
+        is_secret: false,
+        value: managedUpdaterLoader(release.updater)
+      }
+    };
+    let clock = 0;
+    let checkingMetadata = true;
+    let stopped = false;
+    let cancelStartedAt = null;
+
+    const fetcher = vi.fn(async (input, init = {}) => {
+      const url = new URL(String(input));
+      const method = init.method ?? "GET";
+      if (url.pathname.includes(`/builds/workers/${productionWorkerTag}/triggers`)) {
+        return response([trigger(record, shortCommand)]);
+      }
+      if (url.pathname.endsWith(`/builds/triggers/${triggerUuid}/environment_variables`)) {
+        return response(variables);
+      }
+      if (url.pathname.endsWith(`/builds/builds/${buildUuid}`) && method === "GET") {
+        if (checkingMetadata) {
+          clock = Math.min(clock + 20_000, 60_000);
+          return response({
+            build_uuid: buildUuid,
+            status: "queued",
+            trigger: { trigger_uuid: triggerUuid }
+          });
+        }
+        return response({
+          ...exactBuild(record, release.updater),
+          ...(stopped
+            ? {
+                build_outcome: "cancelled",
+                status: "stopped",
+                stopped_on: "2026-09-01T04:00:00.000Z"
+              }
+            : {})
+        });
+      }
+      if (url.pathname.endsWith(`/builds/builds/${buildUuid}/cancel`) && method === "PUT") {
+        cancelStartedAt = clock;
+        stopped = true;
+        return response({ build_uuid: buildUuid });
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+    const dependencies = {
+      fetcher,
+      now: () => clock,
+      sleep: async (milliseconds) => {
+        clock += milliseconds;
+      },
+      writeManifest: vi.fn()
+    };
+
+    await expect(verifyAcceptedBuild(manifest, release, context, dependencies)).rejects.toThrow(
+      /Mismatched fields:/
+    );
+    checkingMetadata = false;
+    await cancelRecordedBuild(manifest, context, dependencies);
+
+    expect(cancelStartedAt).toBeLessThanOrEqual(60_000);
+    expect(record).toMatchObject({
+      buildOutcome: "cancelled",
+      stoppedOn: "2026-09-01T04:00:00.000Z"
+    });
+  });
+
+  it("rejects the source-deploy override in the accepted build snapshot", async () => {
+    const release = releaseEnvelope().manifest;
+    const record = workersBuildRecord();
+    const manifest = { releaseGate: { workersBuild: record } };
+    const context = { accountId, candidateVersion: version, cleanupToken: "cleanup-token" };
+    const fetcher = vi.fn(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.includes(`/builds/workers/${productionWorkerTag}/triggers`)) {
+        return response([trigger(record, shortCommand)]);
+      }
+      if (url.pathname.endsWith(`/builds/triggers/${triggerUuid}/environment_variables`)) {
+        return response({
+          HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: version },
+          HQBASE_UPDATER_LOADER: {
+            is_secret: false,
+            value: managedUpdaterLoader(release.updater)
+          }
+        });
+      }
+      if (url.pathname.endsWith(`/builds/builds/${buildUuid}`)) {
+        return response({
+          ...exactBuild(record, release.updater, { HQBASE_FORCE_SOURCE_DEPLOY: "1" }),
+          status: "stopped"
+        });
+      }
+      throw new Error(`Unexpected request: GET ${url}`);
+    });
+
+    await expect(
+      verifyAcceptedBuild(manifest, release, context, {
+        fetcher,
+        now: () => 0,
+        sleep: async () => {}
+      })
+    ).rejects.toThrow(/HQBASE_FORCE_SOURCE_DEPLOY/);
   });
 
   it("uses the production AES-GCM grant-cookie contract without exposing the token", () => {


### PR DESCRIPTION
## Summary

- wait for Cloudflare to complete the accepted build metadata before the release gate evaluates it
- enforce a 60-second deadline and cancel the probe build well before its deploy command can run
- reject HQBASE_FORCE_SOURCE_DEPLOY in the immutable build snapshot
- report only mismatched field names

## Evidence

- focused release-gate tests: 5 passed
- pnpm check: passed (861 unit tests; 193 Worker integration tests)
- pnpm deploy:dry-run: passed
- independent safety review: clean

The second 1.3.4 release attempt proved that the product dispatched the exact build configuration. It failed because the gate read Cloudflare build metadata before all optional fields appeared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved staging deployment validation by waiting for complete build details before proceeding.
  - Added stricter checks for build status, source, configuration overrides, and build identity.
  - Improved handling of temporary service responses while deployment information propagates.
  - Ensured stalled or invalid builds are cancelled within the expected time window.
  - Added clearer reporting when deployment metadata does not match expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->