### PR TITLE
Accept Cloudflare build variable records

### DIFF
--- a/scripts/release/staging-update-gate-resources.mjs
+++ b/scripts/release/staging-update-gate-resources.mjs
@@ -197,11 +197,16 @@ function acceptedBuildMismatches(build, record, release, context) {
     ...(["api", "manual"].includes(metadata.build_trigger_source) ? [] : ["build_trigger_source"]),
     ...(metadata.build_command === expected.build_command ? [] : ["build_command"]),
     ...(metadata.deploy_command === expected.deploy_command ? [] : ["deploy_command"]),
-    ...(metadata.environment_variables?.HQBASE_UPDATER_LOADER === expected.HQBASE_UPDATER_LOADER
+    ...(buildSnapshotVariableEquals(
+      metadata.environment_variables?.HQBASE_UPDATER_LOADER,
+      expected.HQBASE_UPDATER_LOADER
+    )
       ? []
       : ["HQBASE_UPDATER_LOADER"]),
-    ...(metadata.environment_variables?.HQBASE_EXPECTED_RELEASE_VERSION ===
-    expected.HQBASE_EXPECTED_RELEASE_VERSION
+    ...(buildSnapshotVariableEquals(
+      metadata.environment_variables?.HQBASE_EXPECTED_RELEASE_VERSION,
+      expected.HQBASE_EXPECTED_RELEASE_VERSION
+    )
       ? []
       : ["HQBASE_EXPECTED_RELEASE_VERSION"]),
     ...(metadata.environment_variables?.HQBASE_FORCE_SOURCE_DEPLOY === undefined
@@ -210,6 +215,11 @@ function acceptedBuildMismatches(build, record, release, context) {
     ...(metadata.build_token_uuid === expected.build_token_uuid ? [] : ["build_token_uuid"]),
     ...(metadata.root_directory === expected.root_directory ? [] : ["root_directory"])
   ];
+}
+
+function buildSnapshotVariableEquals(variable, expected) {
+  if (typeof variable === "string") return variable === expected;
+  return variable?.is_secret === false && variable.value === expected;
 }
 
 export async function reconcileAndCancelBuild(manifest, context, dependencies) {

--- a/test/unit/scripts/staging-update-gate.test.mjs
+++ b/test/unit/scripts/staging-update-gate.test.mjs
@@ -144,6 +144,17 @@ function workersBuildRecord() {
   };
 }
 
+function buildSnapshotVariables(updater, shape = "record") {
+  const values = {
+    HQBASE_EXPECTED_RELEASE_VERSION: version,
+    HQBASE_UPDATER_LOADER: managedUpdaterLoader(updater)
+  };
+  if (shape === "string") return values;
+  return Object.fromEntries(
+    Object.entries(values).map(([name, value]) => [name, { is_secret: false, value }])
+  );
+}
+
 function exactBuild(record, updater, environmentVariables = {}) {
   return {
     build_trigger_metadata: {
@@ -153,8 +164,7 @@ function exactBuild(record, updater, environmentVariables = {}) {
       build_trigger_source: "api",
       deploy_command: shortCommand,
       environment_variables: {
-        HQBASE_EXPECTED_RELEASE_VERSION: version,
-        HQBASE_UPDATER_LOADER: managedUpdaterLoader(updater),
+        ...buildSnapshotVariables(updater),
         ...environmentVariables
       },
       root_directory: record.rootDirectory
@@ -238,10 +248,7 @@ describe("deployed update-action release gate", () => {
               build_token_uuid: buildTokenUuid,
               build_trigger_source: "api",
               deploy_command: shortCommand,
-              environment_variables: {
-                HQBASE_EXPECTED_RELEASE_VERSION: version,
-                HQBASE_UPDATER_LOADER: managedUpdaterLoader(candidate.manifest.updater)
-              },
+              environment_variables: buildSnapshotVariables(candidate.manifest.updater),
               root_directory: "/"
             },
             build_uuid: buildUuid,
@@ -417,6 +424,47 @@ describe("deployed update-action release gate", () => {
     }
   });
 
+  it.each(["record", "string"])("accepts the %s build-variable snapshot shape", async (shape) => {
+    const release = releaseEnvelope().manifest;
+    const record = workersBuildRecord();
+    const manifest = { releaseGate: { workersBuild: record } };
+    const context = { accountId, candidateVersion: version, cleanupToken: "cleanup-token" };
+    const variables = {
+      HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: version },
+      HQBASE_UPDATER_LOADER: {
+        is_secret: false,
+        value: managedUpdaterLoader(release.updater)
+      }
+    };
+    const fetcher = vi.fn(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.includes(`/builds/workers/${productionWorkerTag}/triggers`)) {
+        return response([trigger(record, shortCommand)]);
+      }
+      if (url.pathname.endsWith(`/builds/triggers/${triggerUuid}/environment_variables`)) {
+        return response(variables);
+      }
+      if (url.pathname.endsWith(`/builds/builds/${buildUuid}`)) {
+        return response({
+          ...exactBuild(record, release.updater),
+          build_trigger_metadata: {
+            ...exactBuild(record, release.updater).build_trigger_metadata,
+            environment_variables: buildSnapshotVariables(release.updater, shape)
+          }
+        });
+      }
+      throw new Error(`Unexpected request: GET ${url}`);
+    });
+
+    await expect(
+      verifyAcceptedBuild(manifest, release, context, {
+        fetcher,
+        now: () => 0,
+        sleep: async () => {}
+      })
+    ).resolves.toBeUndefined();
+  });
+
   it("ends slow build-metadata polling in time to cancel the probe build", async () => {
     const release = releaseEnvelope().manifest;
     const record = workersBuildRecord();
@@ -513,7 +561,9 @@ describe("deployed update-action release gate", () => {
       }
       if (url.pathname.endsWith(`/builds/builds/${buildUuid}`)) {
         return response({
-          ...exactBuild(record, release.updater, { HQBASE_FORCE_SOURCE_DEPLOY: "1" }),
+          ...exactBuild(record, release.updater, {
+            HQBASE_FORCE_SOURCE_DEPLOY: { is_secret: false, value: "0" }
+          }),
           status: "stopped"
         });
       }
@@ -527,6 +577,46 @@ describe("deployed update-action release gate", () => {
         sleep: async () => {}
       })
     ).rejects.toThrow(/HQBASE_FORCE_SOURCE_DEPLOY/);
+  });
+
+  it.each([
+    ["secret", { is_secret: true, value: "hidden" }],
+    ["null", { is_secret: false, value: null }]
+  ])("rejects a %s required variable in the accepted build snapshot", async (_name, loader) => {
+    const release = releaseEnvelope().manifest;
+    const record = workersBuildRecord();
+    const manifest = { releaseGate: { workersBuild: record } };
+    const context = { accountId, candidateVersion: version, cleanupToken: "cleanup-token" };
+    const fetcher = vi.fn(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.includes(`/builds/workers/${productionWorkerTag}/triggers`)) {
+        return response([trigger(record, shortCommand)]);
+      }
+      if (url.pathname.endsWith(`/builds/triggers/${triggerUuid}/environment_variables`)) {
+        return response({
+          HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: version },
+          HQBASE_UPDATER_LOADER: {
+            is_secret: false,
+            value: managedUpdaterLoader(release.updater)
+          }
+        });
+      }
+      if (url.pathname.endsWith(`/builds/builds/${buildUuid}`)) {
+        return response({
+          ...exactBuild(record, release.updater, { HQBASE_UPDATER_LOADER: loader }),
+          status: "stopped"
+        });
+      }
+      throw new Error(`Unexpected request: GET ${url}`);
+    });
+
+    await expect(
+      verifyAcceptedBuild(manifest, release, context, {
+        fetcher,
+        now: () => 0,
+        sleep: async () => {}
+      })
+    ).rejects.toThrow(/HQBASE_UPDATER_LOADER/);
   });
 
   it("uses the production AES-GCM grant-cookie contract without exposing the token", () => {

--- a/test/unit/worker/features/updates/service.test.ts
+++ b/test/unit/worker/features/updates/service.test.ts
@@ -551,6 +551,21 @@ describe("HQBase updates", () => {
     ).resolves.toEqual({ buildId: "reconciled-build", status: "queued" });
     expect(fetcher.mock.calls.some(([, init]) => init?.method === "DELETE")).toBe(false);
   });
+  it("also reconciles Cloudflare's documented string build-variable shape", async () => {
+    const fetcher = cloudflareUpdateFetcher({
+      ambiguousBuild: "accepted",
+      reconciledVariableShape: "string"
+    });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).resolves.toEqual({ buildId: "reconciled-build", status: "queued" });
+  });
   it("keeps verified configuration when build acceptance cannot be determined", async () => {
     const fetcher = cloudflareUpdateFetcher({ ambiguousBuild: "unknown" });
 
@@ -574,6 +589,24 @@ describe("HQBase updates", () => {
     const fetcher = cloudflareUpdateFetcher({
       ambiguousBuild: "accepted",
       reconciledLoader: "different-loader"
+    });
+
+    await expect(
+      triggerUpdate(
+        updateEnvironment(),
+        "temporary-token-that-is-long-enough",
+        "0.1.0",
+        fetcher as typeof fetch
+      )
+    ).rejects.toMatchObject({ code: "UPDATE_BUILD_STATUS_UNKNOWN", status: 502 });
+  });
+  it.each([
+    "secret",
+    "null"
+  ] as const)("does not reconcile a build with %s required variables", async (reconciledVariableShape) => {
+    const fetcher = cloudflareUpdateFetcher({
+      ambiguousBuild: "accepted",
+      reconciledVariableShape
     });
 
     await expect(
@@ -758,6 +791,7 @@ function cloudflareUpdateFetcher(
     rollbackFails?: boolean;
     rootDirectory?: string;
     reconciledLoader?: string;
+    reconciledVariableShape?: "null" | "record" | "secret" | "string";
     variables?: Record<string, { is_secret: boolean; value?: string | null }>;
     variablesFail?: boolean;
   } = {}
@@ -850,6 +884,18 @@ function cloudflareUpdateFetcher(
       });
     }
     if (url.includes("/builds/builds/latest?")) {
+      const buildVariable = (value: string) => {
+        switch (options.reconciledVariableShape ?? "record") {
+          case "null":
+            return { is_secret: false, value: null };
+          case "secret":
+            return { is_secret: true, value };
+          case "string":
+            return value;
+          default:
+            return { is_secret: false, value };
+        }
+      };
       return Response.json({
         success: true,
         result: {
@@ -862,9 +908,10 @@ function cloudflareUpdateFetcher(
                       build_trigger_source: "api",
                       deploy_command: managedDeployCommand(),
                       environment_variables: {
-                        HQBASE_EXPECTED_RELEASE_VERSION: "0.1.0",
-                        HQBASE_UPDATER_LOADER:
+                        HQBASE_EXPECTED_RELEASE_VERSION: buildVariable("0.1.0"),
+                        HQBASE_UPDATER_LOADER: buildVariable(
                           options.reconciledLoader ?? managedUpdaterLoader(updater)
+                        )
                       }
                     },
                     build_uuid: "reconciled-build",

--- a/worker/features/updates/build-trigger.ts
+++ b/worker/features/updates/build-trigger.ts
@@ -8,6 +8,7 @@ export const updaterLoaderVariable = "HQBASE_UPDATER_LOADER";
 const legacyManagedDeployCommands = new Set(["pnpm deploy", "pnpm run deploy"]);
 
 export type BuildVariable = { is_secret: boolean; value?: string | null };
+type BuildSnapshotVariable = string | BuildVariable;
 export type BuildConfiguration = {
   deployCommand: string;
   variables: Record<string, BuildVariable>;
@@ -17,7 +18,7 @@ type BuildResponse = {
     branch?: string;
     build_trigger_source?: string;
     deploy_command?: string;
-    environment_variables?: Record<string, string>;
+    environment_variables?: Record<string, BuildSnapshotVariable>;
   };
   build_uuid?: string;
   created_on?: string;
@@ -246,6 +247,14 @@ export function buildVariableEquals(variable: BuildVariable | undefined, value: 
   return variable?.is_secret === false && variable.value === value;
 }
 
+function buildSnapshotVariableEquals(
+  variable: BuildSnapshotVariable | undefined,
+  value: string
+): boolean {
+  if (typeof variable === "string") return variable === value;
+  return buildVariableEquals(variable, value);
+}
+
 function sameBuildVariable(
   left: BuildVariable | undefined,
   right: BuildVariable | undefined
@@ -336,10 +345,14 @@ export async function reconcileAcceptedBuild(
       build.trigger?.trigger_uuid === triggerId &&
       build.build_trigger_metadata?.branch === "main" &&
       build.build_trigger_metadata.deploy_command === managedDeployCommand() &&
-      build.build_trigger_metadata.environment_variables?.[expectedReleaseVariable] ===
-        expectedVersion &&
-      build.build_trigger_metadata.environment_variables?.[updaterLoaderVariable] ===
-        expectedLoader &&
+      buildSnapshotVariableEquals(
+        build.build_trigger_metadata.environment_variables?.[expectedReleaseVariable],
+        expectedVersion
+      ) &&
+      buildSnapshotVariableEquals(
+        build.build_trigger_metadata.environment_variables?.[updaterLoaderVariable],
+        expectedLoader
+      ) &&
       (source === "api" || source === "manual") &&
       Number.isFinite(createdAt) &&
       createdAt >= earliestAcceptedTime &&


### PR DESCRIPTION
Fix the 1.3.4 release gate and updater reconciliation for the live Cloudflare Workers Builds snapshot shape.\n\nCloudflare returns each retained build variable as an object with value and is_secret fields, while its public schema documents a string. HQBase now accepts both forms only when the plain value exactly matches. Missing, null, secret, malformed, and wrong values still fail closed. The source-deploy override must still be absent.\n\nThis changes the canonical updater and release gate only. It does not patch any customer repository.\n\nValidation:\n- pnpm check\n- pnpm deploy:dry-run\n- focused update and release-gate tests: 37 passed\n- independent security and completeness review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build snapshot validation to support both plain-text and structured environment variable formats.
  * Build reconciliation now correctly handles Cloudflare metadata returned in either supported format.
  * Added safeguards to reject incomplete or improperly protected required variables, including secret or null values.
  * Configuration rollback comparisons continue to work with structured variable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->