### PR TITLE
Reset staging sign-in counters between release phases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,6 +425,12 @@ jobs:
             (["DB", "MAIL_OBJECTS", "HQBASE_JOBS", "MAIL_SENDER", "MAIL_EVENTS"] - $names) |
             length == 0
           ' <<<"$version"
+      - name: Reset disposable sign-in probes before final lifecycle
+        run: |
+          config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          database="hqbase-$DEPLOYMENT_NAME"
+          pnpm exec wrangler d1 execute "$database" --remote --config "$config" \
+            --command "DELETE FROM rate_limits WHERE scope IN ('auth.email', 'auth.ip')"
       - name: Verify PWA, app shell, access, and operator lifecycle
         run: pnpm test:e2e:staging
       - name: Exercise populated remote backup and restore

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -225,6 +225,9 @@ describe("staging workflow lifecycle record", () => {
       "      - name: Prove the canonical same-version retry is idempotent"
     );
     const bindings = releaseWorkflow.indexOf("      - name: Verify active Worker bindings");
+    const resetSignInProbes = releaseWorkflow.indexOf(
+      "      - name: Reset disposable sign-in probes before final lifecycle"
+    );
     const lifecycle = releaseWorkflow.indexOf(
       "      - name: Verify PWA, app shell, access, and operator lifecycle"
     );
@@ -238,7 +241,8 @@ describe("staging workflow lifecycle record", () => {
     expect(final).toBeGreaterThan(repair);
     expect(retry).toBeGreaterThan(final);
     expect(bindings).toBeGreaterThan(retry);
-    expect(lifecycle).toBeGreaterThan(bindings);
+    expect(resetSignInProbes).toBeGreaterThan(bindings);
+    expect(lifecycle).toBeGreaterThan(resetSignInProbes);
     expect(backup).toBeGreaterThan(lifecycle);
     expect(releaseWorkflow.slice(stale, repair)).toContain("after_deploy_ledger_table_count:0");
     expect(releaseWorkflow.slice(stale, repair)).toContain("alias_table_count:2");
@@ -259,6 +263,9 @@ describe("staging workflow lifecycle record", () => {
     expect(releaseWorkflow.slice(final, retry)).toContain("hqbase-pre-repair-data.json");
     expect(releaseWorkflow.slice(retry, bindings)).toContain(
       'node "$GITHUB_WORKSPACE/scripts/release/bootstrap.mjs" --config "$config"'
+    );
+    expect(releaseWorkflow.slice(resetSignInProbes, lifecycle)).toContain(
+      "DELETE FROM rate_limits WHERE scope IN ('auth.email', 'auth.ip')"
     );
   });
 


### PR DESCRIPTION
The 1.3.4 release gate completed the real 1.3.3 to 1.3.4 repair, then hit the production sign-in limit on its eleventh staged login in one 15-minute window.

This change clears only auth.email and auth.ip rate-limit rows in the disposable release-gate D1 database after the repair checks and before the final lifecycle suite. It does not change the production limit or customer data.

Checks:
- pnpm check
- pnpm deploy:dry-run
- focused staging-workflow test
- independent review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging lifecycle validation by clearing temporary authentication rate limits before final end-to-end checks.
  * Ensured disposable sign-in probes are reset after binding checks, preventing stale authentication state from affecting test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->