### PR TITLE
Prepare 1.4.0 Nightly and fix public upgrade workflow

### DIFF
--- a/.github/workflows/public-upgrade.yml
+++ b/.github/workflows/public-upgrade.yml
@@ -52,8 +52,9 @@ jobs:
       HQBASE_E2E_UPDATE_API_TOKEN: ${{ secrets.HQBASE_E2E_UPDATE_API_TOKEN }}
       DEPLOYMENT_NAME: public-${{ github.run_id }}-${{ matrix.edge }}
       STAGING_WORKER_NAME: hqbase-public-${{ github.run_id }}-${{ matrix.edge }}
-      HQBASE_UPGRADE_RECEIPT: ${{ runner.temp }}/upgrade-${{ matrix.edge }}.json
     steps:
+      - name: Set the upgrade receipt path
+        run: echo "HQBASE_UPGRADE_RECEIPT=$RUNNER_TEMP/upgrade-$UPGRADE_EDGE.json" >> "$GITHUB_ENV"
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 1.4.0
+
+### New
+
+- Add owner-controlled Nightly updates. Stable remains the default. Turning Nightly off keeps the
+  installed version until Stable catches up.
+- Publish signed Nightly candidates and promote the same tested archive to Stable only after
+  public upgrade checks and a reviewed test report pass.
+
+### Fixed
+
+- Prevent duplicate delivery when a send is retried. Recover accepted mail after a storage failure
+  and protect pending drafts when the delivery result is uncertain.
+- Store inbound messages and attachment records together. Preserve large plain-text bodies and
+  Reply-To addresses, and support attachment names with Unicode characters.
+- Reject conflicting draft saves and concurrent changes that would remove the last active owner.
+  Tighten session-write checks and disabled signup routes.
+- Keep draft paging and live mail refresh consistent, and bound conversation queries and object
+  scans for larger workspaces.
+- Resume failed maintenance jobs and verify the database, Worker version, and referenced mail
+  objects during recovery.
+- Find the correct Cloudflare account when an update token can access many zones, and let owners
+  change their update channel when release discovery is unavailable.
+- Initialize public upgrade receipt paths after the runner starts so GitHub can validate the
+  upgrade workflow.
+
+### Changed
+
+- Apply the default 30-day Trash retention period when a mailbox has no custom policy. Older Trash
+  messages can be permanently removed by maintenance after this update.
+- Update the database to schema version 4. Sending waits until the post-deploy draft protections
+  are installed.
+
 ## 1.3.4
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
   "name": "hqbase",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "hqbaseRelease": {
-    "minimumVersion": "1.0.0",
-    "updaterCommit": "7d67e4ae54fe4deafba41c0b5daab5a34cdfe4f9",
-    "updaterCommitVersion": "1.3.4"
+    "minimumVersion": "1.0.0"
   },
   "scripts": {
     "dev": "node scripts/dev.mjs",

--- a/test/unit/scripts/package.test.mjs
+++ b/test/unit/scripts/package.test.mjs
@@ -6,25 +6,18 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const releaseFiles = ["package.mjs", "notes.mjs", "version.mjs"];
-const recoveryUpdaterCommit = "7d67e4ae54fe4deafba41c0b5daab5a34cdfe4f9";
-const recoveryUpdaterSha256 = "4f6c7d5c4b57c7211e3db047fec3766792d946b99b1075628d286a6d8b43bffe";
-const recoveryUpdaterSize = 6928;
-const repositoryRoot = resolve(import.meta.dirname, "../../..");
 
 function git(cwd, ...args) {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 }
 
 describe("release package", () => {
-  it("pins the recovery release to the exact 1.3.3 updater commit", () => {
+  it("does not carry the 1.3.4 recovery updater override into a new release", () => {
     const packageJson = JSON.parse(
       readFileSync(new URL("../../../package.json", import.meta.url), "utf8")
     );
-    expect(packageJson.hqbaseRelease.updaterCommit).toBe(recoveryUpdaterCommit);
-    expect(packageJson.hqbaseRelease.updaterCommitVersion).toBe("1.3.4");
-    const currentUpdater = readFileSync(resolve(repositoryRoot, "scripts/release/bootstrap.mjs"));
-    expect(currentUpdater.length).toBe(recoveryUpdaterSize);
-    expect(createHash("sha256").update(currentUpdater).digest("hex")).toBe(recoveryUpdaterSha256);
+    expect(packageJson.hqbaseRelease.updaterCommit).toBeUndefined();
+    expect(packageJson.hqbaseRelease.updaterCommitVersion).toBeUndefined();
   });
 
   it("uses the committed updater override for signed source metadata", () => {


### PR DESCRIPTION
Prepare HQBase 1.4.0 as the first signed Nightly candidate. The public upgrade workflow currently fails GitHub validation because job-level environment values cannot use `runner.temp`. Set the receipt path in a runner step before upgrade work starts.

Remove the updater override scoped to 1.3.4, update its regression assertion, and add release notes for Nightly updates, mail reliability, schema version 4, and the 30-day Trash default.

Validation: full `pnpm check` and `pnpm deploy:dry-run` passed locally. Actionlint accepts the receipt-path fix with its unsupported `concurrency.queue` diagnostic excluded; existing GitHub runs already accept that setting. Signed staging and Berman testing follow after protected merge. Related canonical documentation: HQBase/hqbase-site#49 and HQBase/hqbase-site#51.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Owners can control Nightly update availability, with Stable as the default channel.
  * Signed Nightly candidates can be promoted to Stable after upgrade checks and review.

* **Bug Fixes**
  * Improved mail delivery recovery, draft protection, attachment handling, paging, live refresh, and maintenance-job reliability.
  * Strengthened session, signup, upgrade-token, and public-upgrade safeguards.

* **Changed**
  * Trash now defaults to 30-day retention, with maintenance removing older messages.
  * Updated the database schema and delayed sending until draft protections are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->