### PR TITLE
Isolate packaging fixture from the release job version

### DIFF
--- a/test/unit/scripts/package.test.mjs
+++ b/test/unit/scripts/package.test.mjs
@@ -73,6 +73,7 @@ describe("release package", () => {
         cwd: workspace,
         env: {
           ...process.env,
+          HQBASE_RELEASE_VERSION: "1.3.4",
           HQBASE_RELEASE_PRIVATE_KEY: privateKey.export({ type: "pkcs8", format: "pem" }).toString()
         }
       });


### PR DESCRIPTION
The Nightly release job exports `HQBASE_RELEASE_VERSION=1.4.0` before `pnpm check`. The packaging test inherited it while building a 1.3.4 fixture, so it failed with missing 1.4.0 release notes before signing started.

Pin the subprocess to the fixture's 1.3.4 version. Application and release implementation stay the same.

Validation: the packaging test and full `pnpm check` passed with `HQBASE_RELEASE_VERSION=1.4.0`; `pnpm deploy:dry-run` passed. Failed run: https://github.com/HQBase/hqbase/actions/runs/34056989784. No draft or archive was created.
