### PR TITLE
Find unpublished Nightly drafts before publication

### DIFF
--- a/scripts/release/channels.mjs
+++ b/scripts/release/channels.mjs
@@ -70,10 +70,31 @@ export async function verifiedCandidate(version) {
   return { manifest, nightlyEnvelope, versionEnvelope };
 }
 
+export function candidateRelease(version, runGh = gh) {
+  const release = JSON.parse(
+    runGh([
+      "release",
+      "view",
+      `v${version}`,
+      "--repo",
+      repository,
+      "--json",
+      "tagName,isDraft,isPrerelease"
+    ])
+  );
+  if (
+    release.tagName !== `v${version}` ||
+    typeof release.isDraft !== "boolean" ||
+    typeof release.isPrerelease !== "boolean"
+  )
+    throw new Error("Candidate release identity is invalid.");
+  return { draft: release.isDraft, prerelease: release.isPrerelease };
+}
+
 async function publish(version) {
   const before = api("releases/latest");
   const deployBefore = api("git/ref/heads/deploy").object.sha;
-  const release = api(`releases/tags/v${version}`);
+  const release = candidateRelease(version);
   if (!release.draft && !release.prerelease) throw new Error("This version is already Stable.");
   gh([
     "release",

--- a/test/unit/scripts/candidate-release.test.mjs
+++ b/test/unit/scripts/candidate-release.test.mjs
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { candidateRelease } from "../../../scripts/release/channels.mjs";
+
+describe("candidate release lookup", () => {
+  it.each([
+    [true, false],
+    [false, true],
+    [false, false]
+  ])("reads draft=%s and prerelease=%s through the draft-aware CLI", (isDraft, isPrerelease) => {
+    const runGh = vi.fn(() => JSON.stringify({ tagName: "v1.4.0", isDraft, isPrerelease }));
+    expect(candidateRelease("1.4.0", runGh)).toEqual({ draft: isDraft, prerelease: isPrerelease });
+    expect(runGh).toHaveBeenCalledWith([
+      "release",
+      "view",
+      "v1.4.0",
+      "--repo",
+      "HQBase/hqbase",
+      "--json",
+      "tagName,isDraft,isPrerelease"
+    ]);
+  });
+
+  it.each([
+    { tagName: "v1.4.1", isDraft: true, isPrerelease: false },
+    { tagName: "v1.4.0", isPrerelease: false },
+    { tagName: "v1.4.0", isDraft: true }
+  ])("rejects a changed or incomplete release identity", (release) => {
+    expect(() => candidateRelease("1.4.0", () => JSON.stringify(release))).toThrow(
+      "identity is invalid"
+    );
+  });
+
+  it("propagates a missing release without assuming it is a draft", () => {
+    expect(() =>
+      candidateRelease("1.4.0", () => {
+        throw new Error("release not found");
+      })
+    ).toThrow("release not found");
+  });
+});


### PR DESCRIPTION
Nightly publication stops after successful signed staging because GitHub's release-by-tag REST endpoint does not return the unpublished draft. The 1.4.0 draft and signed archive remain intact.

Use the draft-aware `gh release view` lookup before publication and reject a changed or incomplete release identity. Existing Stable releases still stop at the existing guard. Public candidate verification and Stable isolation remain unchanged.

Validation: seven regression cases passed, including draft, prerelease, Stable, invalid identity, and lookup failure. The corrected lookup also read the real 1.4.0 draft without changing it. Full `pnpm check` and `pnpm deploy:dry-run` passed.

Recovery preserves the 1.4.0 archive from source `9e1aedccd357875dd1fca56dadb81e27819b6fe0`, SHA-256 `4495abaa496e7aee0f006cc63a25a9eb2493e27d2388ac165819ec49a7375673`. Its signature and bytes were independently verified. Signing and all staging/cleanup checks passed in https://github.com/HQBase/hqbase/actions/runs/34058089481; only publication needs to resume.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing validation by confirming release identity and status before publishing.
  * Preserved accurate handling of missing releases and draft or prerelease states.

* **Tests**
  * Added coverage for release lookup, identity validation, status handling, and error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->