### PR TITLE
Prepare 1.4.1 Nightly for public upgrade proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.1
+
+### Fixed
+
+- Find unpublished Nightly drafts before publication so the release workflow can publish the
+  verified archive.
+
 ## 1.4.0
 
 ### New

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hqbase",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",


### PR DESCRIPTION
Prepare signed Nightly 1.4.1 with the tested draft-publication fix. This provides the later public candidate needed to test the 1.4.0 to 1.4.1 customer upgrade before considering Stable promotion of 1.4.0.

Validation: `pnpm check` and `pnpm deploy:dry-run` passed. Product behavior and schema remain the same as 1.4.0; this change updates the version and release notes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added changelog notes for version 1.4.1, including a fix to locate unpublished Nightly drafts before publication.

- **Release**
  - Updated the package version from 1.4.0 to 1.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->