### PR TITLE
Fix Nightly publication and public upgrade preparation

### DIFF
--- a/.github/workflows/public-upgrade.yml
+++ b/.github/workflows/public-upgrade.yml
@@ -93,8 +93,9 @@ jobs:
       - name: Verify and record the source Worker deployment
         run: |
           healthy=false
+          source_deadline=$((SECONDS + 300))
           for attempt in $(seq 1 150); do
-            if curl -fsS \
+            if curl -fsS --connect-timeout 2 --max-time 5 \
               -H "CF-Access-Client-Id: $HQBASE_STAGING_ACCESS_CLIENT_ID" \
               -H "CF-Access-Client-Secret: $HQBASE_STAGING_ACCESS_CLIENT_SECRET" \
               "$HQBASE_STAGING_URL/api/health?source=$SOURCE_VERSION&attempt=$attempt" \
@@ -102,6 +103,7 @@ jobs:
               healthy=true
               break
             fi
+            if test "$SECONDS" -ge "$source_deadline"; then break; fi
             sleep 2
           done
           test "$healthy" = true || { echo "The source release did not become healthy."; exit 1; }

--- a/.github/workflows/public-upgrade.yml
+++ b/.github/workflows/public-upgrade.yml
@@ -90,6 +90,32 @@ jobs:
           HQBASE_RELEASE_MANIFEST_FILE="$GITHUB_WORKSPACE/release/source/manifest.json" \
           HQBASE_RELEASE_ARTIFACT_FILE="$GITHUB_WORKSPACE/release/source/archive.tar.gz" \
             node scripts/release/bootstrap.mjs --config ".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+      - name: Verify and record the source Worker deployment
+        run: |
+          healthy=false
+          for attempt in $(seq 1 150); do
+            if curl -fsS \
+              -H "CF-Access-Client-Id: $HQBASE_STAGING_ACCESS_CLIENT_ID" \
+              -H "CF-Access-Client-Secret: $HQBASE_STAGING_ACCESS_CLIENT_SECRET" \
+              "$HQBASE_STAGING_URL/api/health?source=$SOURCE_VERSION&attempt=$attempt" \
+              | jq -e --arg version "$SOURCE_VERSION" '.ok == true and .version == $version' >/dev/null; then
+              healthy=true
+              break
+            fi
+            sleep 2
+          done
+          test "$healthy" = true || { echo "The source release did not become healthy."; exit 1; }
+          CONFIG_FILE="$GITHUB_WORKSPACE/.hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc" \
+          WORKER_NAME="$STAGING_WORKER_NAME" node --input-type=module -e '
+            import { recordWorkerDeployedForConfig } from "./scripts/hqbase/manifest.mjs";
+            const manifest = recordWorkerDeployedForConfig(
+              process.env.CONFIG_FILE,
+              process.env.WORKER_NAME
+            );
+            if (manifest?.worker?.deployed !== true) {
+              throw new Error("The source staging Worker was not recorded.");
+            }
+          '
       - name: Create persistent source-version data
         env:
           HQBASE_STAGING_MAIL_API_BASE_PATH: /api

--- a/scripts/release/channels.mjs
+++ b/scripts/release/channels.mjs
@@ -148,13 +148,7 @@ async function publish(version) {
     const file = resolve(temporary, "nightly.json");
     writeFileSync(file, `${JSON.stringify(nightlyEnvelope)}\n`);
     gh(["release", "upload", "nightly", file, "--repo", repository, "--clobber"]);
-    const published = verifyManifest(
-      await json(`${base}/nightly/nightly.json`),
-      undefined,
-      "nightly"
-    );
-    if (published.version !== version || published.artifact.sha256 !== manifest.artifact.sha256)
-      throw new Error("Nightly pointer verification failed.");
+    await waitForNightlyPointer(manifest);
   } finally {
     rmSync(temporary, { recursive: true, force: true });
   }
@@ -165,6 +159,21 @@ async function publish(version) {
     throw new Error("Stable or the Deploy Button changed during Nightly publication.");
   }
   console.log(`Nightly ${version} is verified. Stable remains ${before.tag_name}.`);
+}
+
+export async function waitForNightlyPointer(expected, options = {}) {
+  const readManifest =
+    options.readManifest ??
+    (async () => verifyManifest(await json(`${base}/nightly/nightly.json`), undefined, "nightly"));
+  const sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const published = await readManifest();
+    const order = compareVersions(published.version, expected.version);
+    if (order === 0 && published.artifact.sha256 === expected.artifact.sha256) return;
+    if (order >= 0) throw new Error("Nightly pointer verification failed.");
+    if (attempt < 29) await sleep(2_000);
+  }
+  throw new Error("Nightly pointer did not advance to the verified candidate.");
 }
 
 async function promote(version) {

--- a/test/unit/scripts/nightly-pointer.test.mjs
+++ b/test/unit/scripts/nightly-pointer.test.mjs
@@ -1,0 +1,48 @@
+import { expect, it, vi } from "vitest";
+import { waitForNightlyPointer } from "../../../scripts/release/channels.mjs";
+
+const expected = { version: "1.4.1", artifact: { sha256: "a".repeat(64) } };
+
+it("waits for an older valid pointer to advance to the exact candidate", async () => {
+  const readManifest = vi
+    .fn()
+    .mockResolvedValueOnce({ ...expected, version: "1.4.0" })
+    .mockResolvedValueOnce(expected);
+  const sleep = vi.fn();
+  await waitForNightlyPointer(expected, { readManifest, sleep });
+  expect(readManifest).toHaveBeenCalledTimes(2);
+  expect(sleep).toHaveBeenCalledExactlyOnceWith(2_000);
+});
+
+it.each([
+  { ...expected, version: "1.4.2" },
+  { ...expected, artifact: { sha256: "b".repeat(64) } }
+])("rejects a newer or changed candidate without retrying", async (published) => {
+  const readManifest = vi.fn().mockResolvedValue(published);
+  const sleep = vi.fn();
+  await expect(waitForNightlyPointer(expected, { readManifest, sleep })).rejects.toThrow(
+    "verification failed"
+  );
+  expect(readManifest).toHaveBeenCalledTimes(1);
+  expect(sleep).not.toHaveBeenCalled();
+});
+
+it("does not retry signature or download verification failures", async () => {
+  const readManifest = vi.fn().mockRejectedValue(new Error("Invalid signature"));
+  const sleep = vi.fn();
+  await expect(waitForNightlyPointer(expected, { readManifest, sleep })).rejects.toThrow(
+    "Invalid signature"
+  );
+  expect(readManifest).toHaveBeenCalledTimes(1);
+  expect(sleep).not.toHaveBeenCalled();
+});
+
+it("fails after bounded retries when the old pointer persists", async () => {
+  const readManifest = vi.fn().mockResolvedValue({ ...expected, version: "1.4.0" });
+  const sleep = vi.fn();
+  await expect(waitForNightlyPointer(expected, { readManifest, sleep })).rejects.toThrow(
+    "did not advance"
+  );
+  expect(readManifest).toHaveBeenCalledTimes(30);
+  expect(sleep).toHaveBeenCalledTimes(29);
+});

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -37,6 +37,9 @@ describe("staging workflow lifecycle record", () => {
     expect(prepare).toBeGreaterThan(seed);
     expect(checkpoint).toContain('jq -e --arg version "$SOURCE_VERSION"');
     expect(checkpoint).toContain(".ok == true and .version == $version");
+    expect(checkpoint).toContain("--connect-timeout 2 --max-time 5");
+    expect(checkpoint).toContain("source_deadline=$((SECONDS + 300))");
+    expect(checkpoint).toContain('test "$SECONDS" -ge "$source_deadline"');
     expect(checkpoint).toContain("recordWorkerDeployedForConfig");
     expect(checkpoint).toContain("manifest?.worker?.deployed !== true");
   });

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -9,12 +9,38 @@ const releaseWorkflow = readFileSync(
   new URL("../../../.github/workflows/release.yml", import.meta.url),
   "utf8"
 );
+const publicUpgradeWorkflow = readFileSync(
+  new URL("../../../.github/workflows/public-upgrade.yml", import.meta.url),
+  "utf8"
+);
 const migrationCount = (directory) =>
   readdirSync(new URL(`../../../${directory}/`, import.meta.url)).filter((name) =>
     name.endsWith(".sql")
   ).length;
 
 describe("staging workflow lifecycle record", () => {
+  it("verifies and records older public source deployments before preparing their update", () => {
+    const install = publicUpgradeWorkflow.indexOf("      - name: Install the source release");
+    const record = publicUpgradeWorkflow.indexOf(
+      "      - name: Verify and record the source Worker deployment"
+    );
+    const seed = publicUpgradeWorkflow.indexOf(
+      "      - name: Create persistent source-version data"
+    );
+    const prepare = publicUpgradeWorkflow.indexOf(
+      "      - name: Prepare a public upgrade trigger and signed discovery fixture"
+    );
+    const checkpoint = publicUpgradeWorkflow.slice(record, seed);
+    expect(install).toBeGreaterThan(-1);
+    expect(record).toBeGreaterThan(install);
+    expect(seed).toBeGreaterThan(record);
+    expect(prepare).toBeGreaterThan(seed);
+    expect(checkpoint).toContain('jq -e --arg version "$SOURCE_VERSION"');
+    expect(checkpoint).toContain(".ok == true and .version == $version");
+    expect(checkpoint).toContain("recordWorkerDeployedForConfig");
+    expect(checkpoint).toContain("manifest?.worker?.deployed !== true");
+  });
+
   it("tests a populated two-phase SQL cutover around deployment", () => {
     const legacy = workflow.indexOf('set_migrations_dir "migrations-before-0014"');
     const current = workflow.indexOf('set_migrations_dir "../../../migrations"');


### PR DESCRIPTION
Publishing Nightly 1.4.1 succeeded, but the immediate public pointer read still returned the valid 1.4.0 record and failed the job. Wait for up to 30 reads, two seconds apart, when the pointer is older than the verified candidate.

The check still fails immediately for a signature or download-verification error, a newer version, or a changed checksum for the expected version. A permanently stale pointer fails after the retry limit. The signed archive and app behavior do not change.

The first public upgrade run also stopped before trigger preparation because older source installers left `worker.deployed` unset. Wait for the exact source version to become healthy, then record the deployment before seeding and trigger preparation. Both failed test environments were cleaned up.

Validation: `pnpm check`, `pnpm deploy:dry-run`, and actionlint passed. Regression tests cover propagation, conflicting identities, verification failures, the retry limit, and source-deployment verification order. Canonical specification and maintainer instructions are updated in HQBase/hqbase-site#52.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved upgrade reliability by waiting for deployed source releases to become healthy before continuing.
  - Health checks now use bounded connection and overall request timeouts and stop retrying after a fixed deadline.
  - Added verification that deployment records are correctly updated during upgrade workflows.
  - Nightly publications now wait for the expected release candidate and reject mismatched or outdated release pointers.

- **Tests**
  - Added coverage for deployment health checks, release verification, manifest updates, and bounded retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->