### PR TITLE
Supply disposable configuration to public upgrade builds

### DIFF
--- a/scripts/hqbase/lifecycle-manifest.mjs
+++ b/scripts/hqbase/lifecycle-manifest.mjs
@@ -221,7 +221,11 @@ function assertReleaseGate(gate) {
       'Refusing to continue: a created release-gate trigger must record "releaseGate.workersBuild.triggerUuid".'
     );
   }
-  if (!["sleep 600", "pnpm install --frozen-lockfile"].includes(build?.buildCommand)) {
+  const publicBuildCommands = [
+    "pnpm install --frozen-lockfile",
+    "pnpm install --frozen-lockfile && node scripts/release/staging-build-config.mjs"
+  ];
+  if (!["sleep 600", ...publicBuildCommands].includes(build?.buildCommand)) {
     throw new Error("The release gate must use a fixed probe or public-upgrade build command.");
   }
   for (const [field, expected] of [
@@ -249,7 +253,7 @@ function assertReleaseGate(gate) {
     build.buildOutcome !== "cancelled" &&
     build.buildOutcome !== "terminated" &&
     !(
-      build.buildCommand === "pnpm install --frozen-lockfile" &&
+      publicBuildCommands.includes(build.buildCommand) &&
       ["success", "fail", "skipped"].includes(build.buildOutcome)
     )
   ) {

--- a/scripts/release/staging-build-config.mjs
+++ b/scripts/release/staging-build-config.mjs
@@ -54,22 +54,25 @@ function assertPublicResources(manifest) {
 
 export function publicBuildConfiguration(manifest) {
   assertPublicResources(manifest);
-  const fields = [
-    "version",
-    "name",
-    "accountId",
-    "worker",
-    "d1",
-    "r2",
-    "queue",
-    "appDomain",
-    "authUrl",
-    "cloudflareOAuth"
-  ];
+  const pick = (value, fields) =>
+    Object.fromEntries(
+      fields.filter((key) => value[key] !== undefined).map((key) => [key, value[key]])
+    );
+  const resourceFields = ["id", "name", "ownership"];
   return JSON.stringify({
-    manifest: Object.fromEntries(
-      fields.filter((key) => manifest[key] !== undefined).map((key) => [key, manifest[key]])
-    ),
+    manifest: {
+      ...pick(manifest, ["version", "name", "accountId", "appDomain", "authUrl"]),
+      worker: pick(manifest.worker, ["name", "deployed"]),
+      d1: pick(manifest.d1, resourceFields),
+      r2: pick(manifest.r2, ["bucket", "ownership"]),
+      queue: {
+        primary: pick(manifest.queue.primary, resourceFields),
+        deadLetter: pick(manifest.queue.deadLetter, resourceFields)
+      },
+      ...(manifest.cloudflareOAuth
+        ? { cloudflareOAuth: pick(manifest.cloudflareOAuth, ["mode", "clientId"]) }
+        : {})
+    },
     workerTag: manifest.releaseGate.workersBuild.workerTag,
     manifestUrl: manifest.releaseGate.candidateManifest.url
   });

--- a/scripts/release/staging-build-config.mjs
+++ b/scripts/release/staging-build-config.mjs
@@ -1,0 +1,105 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createWranglerConfig } from "../hqbase/config.mjs";
+import { assertCurrentManifest } from "../hqbase/lifecycle-manifest.mjs";
+import { cloudflareHeaders, cloudflareResult } from "./staging-update-gate-shared.mjs";
+
+export const publicConfigVariable = "HQBASE_STAGING_BUILD_CONFIG";
+
+export async function configurePublicBuild(manifest, context, dependencies) {
+  if (!context.publicUpgrade) return;
+  await cloudflareResult(
+    `/accounts/${context.accountId}/builds/triggers/${manifest.releaseGate.workersBuild.triggerUuid}/environment_variables`,
+    {
+      method: "PATCH",
+      headers: cloudflareHeaders(context.cleanupToken, true),
+      body: JSON.stringify({
+        [publicConfigVariable]: { is_secret: false, value: publicBuildConfiguration(manifest) }
+      })
+    },
+    dependencies.fetcher
+  );
+}
+
+export function configuredBuildRecord(manifest, context, variables) {
+  const record = manifest.releaseGate.workersBuild;
+  if (!context.publicUpgrade) return record;
+  const expected = publicBuildConfiguration(manifest);
+  const variable = variables?.[publicConfigVariable];
+  if (variable?.is_secret !== false || variable.value !== expected) {
+    throw new Error("The accepted build did not keep its disposable resource configuration.");
+  }
+  return { ...record, publicBuildConfiguration: expected };
+}
+
+function assertPublicResources(manifest) {
+  assertCurrentManifest(manifest);
+  const name = manifest.worker.name;
+  if (
+    !/^hqbase-public-\d+-(inbound|outbound)$/.test(name) ||
+    manifest.name !== name.slice("hqbase-".length) ||
+    manifest.worker.deployed !== true ||
+    manifest.d1.name !== name ||
+    manifest.r2.bucket !== `${name}-mail` ||
+    manifest.queue.primary.name !== `${name}-jobs` ||
+    manifest.queue.deadLetter.name !== `${name}-jobs-dlq` ||
+    [manifest.d1, manifest.r2, manifest.queue.primary, manifest.queue.deadLetter].some(
+      (resource) => resource.ownership !== "created"
+    )
+  ) {
+    throw new Error("Public upgrade builds require their recorded disposable resources.");
+  }
+}
+
+export function publicBuildConfiguration(manifest) {
+  assertPublicResources(manifest);
+  const fields = [
+    "version",
+    "name",
+    "accountId",
+    "worker",
+    "d1",
+    "r2",
+    "queue",
+    "appDomain",
+    "authUrl",
+    "cloudflareOAuth"
+  ];
+  return JSON.stringify({
+    manifest: Object.fromEntries(
+      fields.filter((key) => manifest[key] !== undefined).map((key) => [key, manifest[key]])
+    ),
+    workerTag: manifest.releaseGate.workersBuild.workerTag,
+    manifestUrl: manifest.releaseGate.candidateManifest.url
+  });
+}
+
+export function writePublicBuildConfiguration(environment = process.env, write = writeFileSync) {
+  const payload = JSON.parse(environment[publicConfigVariable] ?? "null");
+  if (!payload?.manifest) throw new Error("The public upgrade build configuration is missing.");
+  assertPublicResources(payload.manifest);
+  if (
+    !/^[a-f0-9]{32}$/.test(payload.workerTag ?? "") ||
+    payload.workerTag !== environment.WRANGLER_CI_MATCH_TAG ||
+    payload.manifest.worker.name !== environment.WRANGLER_CI_OVERRIDE_NAME
+  ) {
+    throw new Error("The public upgrade configuration does not match this Cloudflare build.");
+  }
+  const url = new URL(payload.manifestUrl);
+  if (
+    url.protocol !== "https:" ||
+    !url.hostname.endsWith(".workers.dev") ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("The public upgrade discovery fixture URL is invalid.");
+  }
+  const config = createWranglerConfig(payload.manifest);
+  config.vars.HQBASE_RELEASE_MANIFEST_URL = payload.manifestUrl;
+  write(resolve("wrangler.jsonc"), `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  writePublicBuildConfiguration();
+}

--- a/scripts/release/staging-update-gate-resources.mjs
+++ b/scripts/release/staging-update-gate-resources.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { configuredBuildRecord, publicConfigVariable } from "./staging-build-config.mjs";
 
 import {
   assertExactTrigger,
@@ -150,7 +151,12 @@ export async function verifyAcceptedBuild(manifest, release, context, dependenci
   ) {
     throw new Error("The accepted build did not keep the exact signed updater variables.");
   }
-  await waitForAcceptedBuildConfiguration(record, release, context, dependencies);
+  await waitForAcceptedBuildConfiguration(
+    configuredBuildRecord(manifest, context, variables),
+    release,
+    context,
+    dependencies
+  );
 }
 
 async function waitForAcceptedBuildConfiguration(record, release, context, dependencies) {
@@ -213,6 +219,13 @@ function acceptedBuildMismatches(build, record, release, context) {
     ...(metadata.environment_variables?.HQBASE_FORCE_SOURCE_DEPLOY === undefined
       ? []
       : ["HQBASE_FORCE_SOURCE_DEPLOY"]),
+    ...(!context.publicUpgrade ||
+    buildSnapshotVariableEquals(
+      metadata.environment_variables?.[publicConfigVariable],
+      record.publicBuildConfiguration
+    )
+      ? []
+      : [publicConfigVariable]),
     ...(metadata.build_token_uuid === expected.build_token_uuid ? [] : ["build_token_uuid"]),
     ...(metadata.root_directory === expected.root_directory ? [] : ["root_directory"])
   ];
@@ -278,7 +291,7 @@ export async function cancelRecordedBuild(manifest, context, dependencies) {
     build.status !== "stopped" ||
     !(
       terminalOutcomes.has(build.build_outcome) ||
-      (record.buildCommand === publicBuildCommand &&
+      ([publicBuildCommand, "pnpm install --frozen-lockfile"].includes(record.buildCommand) &&
         ["success", "fail", "skipped"].includes(build.build_outcome))
     ) ||
     !Number.isFinite(Date.parse(build.stopped_on ?? ""))

--- a/scripts/release/staging-update-gate-shared.mjs
+++ b/scripts/release/staging-update-gate-shared.mjs
@@ -13,7 +13,8 @@ export const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-
 export const workerTagPattern = /^[0-9a-f]{32}$/i;
 export const managedCommand = 'node --input-type=module --eval "$HQBASE_UPDATER_LOADER"';
 export const initialBuildCommand = "sleep 600";
-export const publicBuildCommand = "pnpm install --frozen-lockfile";
+export const publicBuildCommand =
+  "pnpm install --frozen-lockfile && node scripts/release/staging-build-config.mjs";
 export const initialDeployCommand = "pnpm deploy";
 export const gatePath = ".hqbase-release-gate-never";
 export const branch = "main";

--- a/scripts/release/staging-update-gate.mjs
+++ b/scripts/release/staging-update-gate.mjs
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { assertCurrentManifest } from "../hqbase/lifecycle-manifest.mjs";
+import { configurePublicBuild } from "./staging-build-config.mjs";
 import { finishPublicUpgrade } from "./staging-public-upgrade.mjs";
 import {
   appErrorCode,
@@ -118,6 +119,7 @@ export async function prepareStagingUpdateGate(options = {}) {
   await ensureCandidateManifestWorker(manifest, candidate.raw, context, dependencies);
   writeCandidateManifestUrl(context.configFile, manifest.releaseGate.candidateManifest.url);
   await ensureBuildTrigger(manifest, context, dependencies);
+  await configurePublicBuild(manifest, context, dependencies);
   console.log("The deployed update-action release gate is ready.");
 }
 

--- a/test/unit/scripts/staging-build-config.test.mjs
+++ b/test/unit/scripts/staging-build-config.test.mjs
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { assertCurrentManifest } from "../../../scripts/hqbase/lifecycle-manifest.mjs";
 import {
   configurePublicBuild,
   publicBuildConfiguration,
@@ -82,9 +83,14 @@ describe("public upgrade build configuration", () => {
     const f = fixture();
     f.gate.workersBuild.buildCommand = buildCommand;
     f.gate.workersBuild.buildUuid = "55555555-5555-4555-8555-555555555555";
-    const writeManifest = vi.fn();
+    f.gate.workersBuild.dispatchStartedAt = "2026-09-07T00:00:00Z";
+    const manifest = JSON.parse(JSON.stringify({ ...f.manifest, releaseGate: f.gate }));
+    expect(() => assertCurrentManifest(manifest)).not.toThrow();
+    const writeManifest = vi.fn((saved) =>
+      assertCurrentManifest(JSON.parse(JSON.stringify(saved)))
+    );
     await cancelRecordedBuild(
-      { releaseGate: f.gate },
+      manifest,
       { accountId: f.manifest.accountId, cleanupToken: "test-token" },
       {
         fetcher: async () =>
@@ -97,7 +103,8 @@ describe("public upgrade build configuration", () => {
       }
     );
     expect(writeManifest).toHaveBeenCalledOnce();
-    expect(f.gate.workersBuild.buildOutcome).toBe("fail");
+    expect(manifest.releaseGate.workersBuild.buildOutcome).toBe("fail");
+    expect(manifest.version).toBe(3);
   });
   it("writes only the recorded disposable bindings and discovery fixture", () => {
     const f = fixture();
@@ -149,6 +156,16 @@ describe("public upgrade build configuration", () => {
 
   it("passes only lifecycle configuration to the recorded trigger", async () => {
     const f = fixture();
+    for (const nested of [
+      f.manifest.worker,
+      f.manifest.d1,
+      f.manifest.r2,
+      f.manifest.queue.primary,
+      f.manifest.queue.deadLetter,
+      f.manifest.cloudflareOAuth
+    ]) {
+      nested.unexpectedCredential = "must-not-copy";
+    }
     const manifest = { ...f.manifest, releaseGate: f.gate, unrelatedPrivateField: "must-not-copy" };
     const serialized = publicBuildConfiguration(manifest);
     expect(serialized).not.toContain("must-not-copy");

--- a/test/unit/scripts/staging-build-config.test.mjs
+++ b/test/unit/scripts/staging-build-config.test.mjs
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  configurePublicBuild,
+  publicBuildConfiguration,
+  publicConfigVariable,
+  writePublicBuildConfiguration
+} from "../../../scripts/release/staging-build-config.mjs";
+import { managedUpdaterLoader } from "../../../scripts/release/staging-update-gate.mjs";
+import {
+  cancelRecordedBuild,
+  verifyAcceptedBuild
+} from "../../../scripts/release/staging-update-gate-resources.mjs";
+import { publicBuildCommand } from "../../../scripts/release/staging-update-gate-shared.mjs";
+
+function fixture() {
+  const name = "hqbase-public-9001-inbound";
+  const manifest = {
+    version: 3,
+    name: "public-9001-inbound",
+    accountId: "a".repeat(32),
+    worker: { name, deployed: true },
+    d1: { id: "11111111-1111-4111-8111-111111111111", name, ownership: "created" },
+    r2: { bucket: `${name}-mail`, ownership: "created" },
+    queue: {
+      primary: { id: "b".repeat(32), name: `${name}-jobs`, ownership: "created" },
+      deadLetter: { id: "c".repeat(32), name: `${name}-jobs-dlq`, ownership: "created" }
+    },
+    appDomain: "staging.example.com",
+    authUrl: "https://staging.example.com",
+    cloudflareOAuth: { mode: "customer", clientId: "test-client" }
+  };
+  const gate = {
+    workersBuild: {
+      workerTag: "d".repeat(32),
+      triggerUuid: "22222222-2222-4222-8222-222222222222",
+      repoConnectionUuid: "33333333-3333-4333-8333-333333333333",
+      buildTokenUuid: "44444444-4444-4444-8444-444444444444",
+      triggerName: "hqbase-release-gate-9001-1",
+      ownership: "created",
+      buildUuid: null,
+      branch: "main",
+      buildCommand: publicBuildCommand,
+      initialDeployCommand: "pnpm deploy",
+      rootDirectory: "/",
+      pathIncludes: [".hqbase-release-gate-never"],
+      buildOutcome: null,
+      stoppedOn: null,
+      dispatchStartedAt: null
+    },
+    candidateManifest: {
+      url: "https://fixture.example.workers.dev/candidate.json",
+      name: "fixture",
+      path: "/candidate.json",
+      sha256: "e".repeat(64),
+      workerTag: "f".repeat(32),
+      ownership: "created"
+    }
+  };
+  // The gate is validated by its owning code; payload validation uses only lifecycle resources.
+  const payload = {
+    manifest,
+    workerTag: gate.workersBuild.workerTag,
+    manifestUrl: gate.candidateManifest.url
+  };
+  return {
+    manifest,
+    gate,
+    payload,
+    environment: {
+      [publicConfigVariable]: JSON.stringify(payload),
+      WRANGLER_CI_MATCH_TAG: payload.workerTag,
+      WRANGLER_CI_OVERRIDE_NAME: name
+    }
+  };
+}
+
+describe("public upgrade build configuration", () => {
+  it.each([
+    publicBuildCommand,
+    "pnpm install --frozen-lockfile"
+  ])("keeps cleanup compatible with %s", async (buildCommand) => {
+    const f = fixture();
+    f.gate.workersBuild.buildCommand = buildCommand;
+    f.gate.workersBuild.buildUuid = "55555555-5555-4555-8555-555555555555";
+    const writeManifest = vi.fn();
+    await cancelRecordedBuild(
+      { releaseGate: f.gate },
+      { accountId: f.manifest.accountId, cleanupToken: "test-token" },
+      {
+        fetcher: async () =>
+          Response.json({
+            success: true,
+            result: { status: "stopped", build_outcome: "fail", stopped_on: "2026-09-07T00:00:00Z" }
+          }),
+        writeManifest,
+        sleep: vi.fn()
+      }
+    );
+    expect(writeManifest).toHaveBeenCalledOnce();
+    expect(f.gate.workersBuild.buildOutcome).toBe("fail");
+  });
+  it("writes only the recorded disposable bindings and discovery fixture", () => {
+    const f = fixture();
+    const write = vi.fn();
+    writePublicBuildConfiguration(f.environment, write);
+    const config = JSON.parse(write.mock.calls[0][1]);
+    expect(config.name).toBe(f.manifest.worker.name);
+    expect(config.d1_databases[0].database_id).toBe(f.manifest.d1.id);
+    expect(config.r2_buckets[0].bucket_name).toBe(f.manifest.r2.bucket);
+    expect(config.queues.producers[0].queue).toBe(f.manifest.queue.primary.name);
+    expect(config.queues.consumers[0].dead_letter_queue).toBe(f.manifest.queue.deadLetter.name);
+    expect(config.vars.HQBASE_RELEASE_MANIFEST_URL).toBe(f.payload.manifestUrl);
+    expect(config.vars.CLOUDFLARE_OAUTH_CLIENT_ID).toBe("test-client");
+  });
+
+  it.each([
+    "WRANGLER_CI_MATCH_TAG",
+    "WRANGLER_CI_OVERRIDE_NAME"
+  ])("rejects another build's %s before writing", (key) => {
+    const f = fixture();
+    const write = vi.fn();
+    f.environment[key] = "wrong";
+    expect(() => writePublicBuildConfiguration(f.environment, write)).toThrow("does not match");
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it.each(["name", "ownership"])("rejects an unrecorded database %s", (key) => {
+    const f = fixture();
+    f.payload.manifest.d1[key] = key === "name" ? "hqbase" : "reused";
+    f.environment[publicConfigVariable] = JSON.stringify(f.payload);
+    expect(() => writePublicBuildConfiguration(f.environment, vi.fn())).toThrow(
+      "disposable resources"
+    );
+  });
+
+  it("rejects missing configuration and invalid discovery URLs", () => {
+    expect(() => writePublicBuildConfiguration({}, vi.fn())).toThrow("missing");
+    const f = fixture();
+    f.payload.manifestUrl = "http://example.com/fixture";
+    f.environment[publicConfigVariable] = JSON.stringify(f.payload);
+    expect(() => writePublicBuildConfiguration(f.environment, vi.fn())).toThrow("fixture URL");
+  });
+
+  it("does not configure the cancelled draft-release probe", async () => {
+    const fetcher = vi.fn();
+    await configurePublicBuild({}, { publicUpgrade: false }, { fetcher });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("passes only lifecycle configuration to the recorded trigger", async () => {
+    const f = fixture();
+    const manifest = { ...f.manifest, releaseGate: f.gate, unrelatedPrivateField: "must-not-copy" };
+    const serialized = publicBuildConfiguration(manifest);
+    expect(serialized).not.toContain("must-not-copy");
+    const fetcher = vi.fn(async () => Response.json({ success: true, result: {} }));
+    await configurePublicBuild(
+      manifest,
+      { publicUpgrade: true, accountId: manifest.accountId, cleanupToken: "test-token" },
+      { fetcher }
+    );
+    const [url, request] = fetcher.mock.calls[0];
+    expect(url).toContain(
+      `/builds/triggers/${f.gate.workersBuild.triggerUuid}/environment_variables`
+    );
+    expect(request.method).toBe("PATCH");
+    expect(JSON.parse(request.body)).toEqual({
+      [publicConfigVariable]: { is_secret: false, value: serialized }
+    });
+    const write = vi.fn();
+    writePublicBuildConfiguration({ ...f.environment, [publicConfigVariable]: serialized }, write);
+    expect(write).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    "exact",
+    "changed-trigger",
+    "changed-build"
+  ])("checks the accepted build configuration: %s", async (mode) => {
+    const f = fixture();
+    const record = f.gate.workersBuild;
+    record.buildUuid = "55555555-5555-4555-8555-555555555555";
+    record.dispatchStartedAt = "2026-09-07T00:00:00Z";
+    const manifest = { ...f.manifest, releaseGate: f.gate };
+    const release = {
+      updater: {
+        sourceUrl: `https://raw.githubusercontent.com/HQBase/hqbase/${"a".repeat(40)}/scripts/release/bootstrap.mjs`,
+        size: 1234,
+        sha256: "b".repeat(64)
+      }
+    };
+    const variables = {
+      HQBASE_EXPECTED_RELEASE_VERSION: { is_secret: false, value: "1.4.1" },
+      HQBASE_UPDATER_LOADER: { is_secret: false, value: managedUpdaterLoader(release.updater) },
+      [publicConfigVariable]: { is_secret: false, value: publicBuildConfiguration(manifest) }
+    };
+    const command = 'node --input-type=module --eval "$HQBASE_UPDATER_LOADER"';
+    const fetcher = vi.fn(async (input) => {
+      const url = String(input);
+      let result;
+      if (url.endsWith("/triggers"))
+        result = [
+          {
+            trigger_uuid: record.triggerUuid,
+            trigger_name: record.triggerName,
+            external_script_id: record.workerTag,
+            branch_includes: ["main"],
+            branch_excludes: [],
+            build_caching_enabled: false,
+            path_includes: record.pathIncludes,
+            path_excludes: [],
+            root_directory: "/",
+            build_command: publicBuildCommand,
+            deploy_command: command,
+            build_token_uuid: record.buildTokenUuid,
+            repo_connection: { repo_connection_uuid: record.repoConnectionUuid }
+          }
+        ];
+      else if (url.endsWith("/environment_variables"))
+        result =
+          mode === "changed-trigger"
+            ? { ...variables, [publicConfigVariable]: { is_secret: false, value: "wrong" } }
+            : variables;
+      else
+        result = {
+          build_uuid: record.buildUuid,
+          trigger: { trigger_uuid: record.triggerUuid },
+          status: "stopped",
+          build_trigger_metadata: {
+            branch: "main",
+            build_command: publicBuildCommand,
+            deploy_command: command,
+            build_trigger_source: "api",
+            build_token_uuid: record.buildTokenUuid,
+            root_directory: "/",
+            environment_variables:
+              mode === "changed-build"
+                ? { ...variables, [publicConfigVariable]: "wrong" }
+                : variables
+          }
+        };
+      return Response.json({ success: true, result });
+    });
+    const check = verifyAcceptedBuild(
+      manifest,
+      release,
+      {
+        publicUpgrade: true,
+        candidateVersion: "1.4.1",
+        accountId: manifest.accountId,
+        cleanupToken: "test-token"
+      },
+      { fetcher, now: Date.now, sleep: vi.fn() }
+    );
+    if (mode === "exact") await expect(check).resolves.toBeUndefined();
+    else await expect(check).rejects.toThrow(/configuration/);
+  });
+});


### PR DESCRIPTION
Public upgrade builds cloned the canonical checkout without the disposable workspace configuration. The signed updater would therefore read the repository defaults instead of the recorded staging bindings.

Pass the recorded lifecycle configuration through a build variable and write the disposable configuration before the managed updater runs. Require the Cloudflare Worker name and tag to match, and reject reused resources or unexpected generated names. Verify the exact variable on both the trigger and accepted build. Keep cleanup compatible with earlier public-test records.

The payload includes only known public fields, including nested resource and OAuth fields. Extra nested fields are omitted. Lifecycle records stay at version 3: there are no new stored fields or conversions of existing records. Tests load and validate both the earlier and new command records, then validate their completed cleanup state without a migration.

Validation: `CI=true VITEST_MAX_WORKERS=4 pnpm check` and `pnpm deploy:dry-run` passed, including 946 unit tests, 216 integration tests, coverage, and production build. The generated payload was also checked against both recorded manifests from run 34132772500. Canonical rules are in HQBase/hqbase-site#53. The full public upgrade workflow will run from the reviewed main commit after merge.

The nested-field review correction passed the 22 focused build-configuration and update-gate tests. Full local and exact-head CI checks are rerunning for that correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring public staging builds with release-specific settings.
  - Staging builds now generate configuration from the release manifest and validate worker, manifest, and resource details before deployment.
  - Public build configuration now includes only approved release settings, excluding unexpected sensitive fields.

- **Bug Fixes**
  - Improved release-gate handling for both supported staging build commands.
  - Added validation to detect mismatched or altered build configuration before an accepted build proceeds.
  - Preserved cleanup and cancellation behavior across supported build flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->