### PR TITLE
Report staging update and sign-in failures safely

### DIFF
--- a/scripts/release/staging-update-gate.mjs
+++ b/scripts/release/staging-update-gate.mjs
@@ -149,7 +149,18 @@ export async function probeStagingUpdateGate(options = {}) {
     status.compatible !== true ||
     status.repairRequired !== !context.publicUpgrade
   ) {
-    throw new Error("The deployed candidate did not report the expected same-version repair.");
+    const checks = {
+      installedVersion:
+        status.installedVersion ===
+        (context.publicUpgrade ? context.sourceVersion : context.candidateVersion),
+      candidateVersion: status.release?.version === context.candidateVersion,
+      available: status.available === true,
+      compatible: status.compatible === true,
+      repairRequired: status.repairRequired === !context.publicUpgrade
+    };
+    throw new Error(
+      `The deployed update status did not match the gate: ${JSON.stringify(checks)}.`
+    );
   }
 
   manifest.releaseGate.workersBuild.dispatchStartedAt = new Date().toISOString();

--- a/test/e2e/staging/update-channel.spec.ts
+++ b/test/e2e/staging/update-channel.spec.ts
@@ -9,9 +9,10 @@ test("owner can leave Nightly without changing the installed release", async ({ 
       email: process.env.HQBASE_STAGING_OWNER_EMAIL,
       password: process.env.HQBASE_STAGING_OWNER_PASSWORD,
       rememberMe: false
-    }
+    },
+    headers: { origin: new URL(process.env.HQBASE_STAGING_URL!).origin }
   });
-  expect(login.ok()).toBeTruthy();
+  expect(login.ok(), `Owner sign-in returned HTTP ${login.status()}.`).toBeTruthy();
   const before = await (await request.get("/api/health")).json();
   try {
     await page.goto("/settings/updates");


### PR DESCRIPTION
The public upgrade gate stopped with a same-version repair error even during a version upgrade. Report which of the five strict status checks failed as booleans, without logging response values. The checks remain unchanged.

The channel E2E test now sends the same explicit origin as the other staging sign-in tests and includes the HTTP status when sign-in fails. This makes the two failures in public run 34142366293 actionable.

Validation: full local check passed (946 unit tests, 216 integration tests, coverage, architecture, and build); deployment dry run passed. A fresh public upgrade run will verify both paths after merge. No product behavior, signed archive, or schema changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update-check error reporting. When an update probe fails, the message now provides clearer details about the installed version, candidate version availability, compatibility, and repair status.
  - This makes staging update issues easier to understand and troubleshoot than the previous generic error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->