### PR TITLE
Complete public upgrade lifecycle verification

### DIFF
--- a/.github/workflows/public-upgrade.yml
+++ b/.github/workflows/public-upgrade.yml
@@ -139,10 +139,33 @@ jobs:
           '
       - name: Complete the customer update through Workers Builds
         run: node scripts/release/staging-update-gate.mjs probe
+      - name: Reset disposable sign-in probes before final lifecycle
+        run: |
+          manifest=".hqbase/deployments/$DEPLOYMENT_NAME/manifest.json"
+          config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          database="hqbase-$DEPLOYMENT_NAME"
+          jq -e --arg account "$CLOUDFLARE_ACCOUNT_ID" --arg database "$database" \
+            '.accountId == $account and .d1.name == $database and .d1.ownership == "created"' \
+            "$manifest" >/dev/null
+          pnpm exec wrangler d1 execute "$database" --remote --config "$config" \
+            --command "DELETE FROM rate_limits WHERE scope IN ('auth.email', 'auth.ip')"
       - name: Verify mail, lifecycle, backup, restore, and PWA after the update
         run: |
           pnpm test:e2e:staging
           pnpm test:pwa
+      - name: Exercise populated remote backup and restore
+        run: |
+          config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"
+          database="hqbase-$DEPLOYMENT_NAME"
+          pnpm exec wrangler d1 execute "$database" --remote --config "$config" \
+            --command "INSERT INTO app_settings (key, value_json, created_at, updated_at) VALUES ('staging-restore-probe', '{\"state\":\"before\"}', datetime('now'), datetime('now'))"
+          pnpm hqbase backup --name "$DEPLOYMENT_NAME" --output /tmp/hqbase-backup.json
+          pnpm exec wrangler d1 execute "$database" --remote --config "$config" \
+            --command "UPDATE app_settings SET value_json = '{\"state\":\"after\"}', updated_at = datetime('now') WHERE key = 'staging-restore-probe'"
+          pnpm hqbase restore --name "$DEPLOYMENT_NAME" --backup /tmp/hqbase-backup.json --yes
+          result="$(pnpm exec wrangler d1 execute "$database" --remote --config "$config" --json \
+            --command "SELECT value_json FROM app_settings WHERE key = 'staging-restore-probe'")"
+          jq -e '.[0].results[0].value_json == "{\"state\":\"before\"}"' <<<"$result"
       - name: Seal the successful upgrade receipt
         run: |
           node --input-type=module -e '

--- a/.github/workflows/public-upgrade.yml
+++ b/.github/workflows/public-upgrade.yml
@@ -150,9 +150,15 @@ jobs:
           pnpm exec wrangler d1 execute "$database" --remote --config "$config" \
             --command "DELETE FROM rate_limits WHERE scope IN ('auth.email', 'auth.ip')"
       - name: Verify mail, lifecycle, backup, restore, and PWA after the update
+        run: pnpm test:e2e:staging
+      - name: Verify candidate PWA from its signed archive
         run: |
-          pnpm test:e2e:staging
-          pnpm test:pwa
+          target_source="$RUNNER_TEMP/hqbase-target-$UPGRADE_EDGE"
+          mkdir -p "$target_source"
+          tar -xzf "$GITHUB_WORKSPACE/release/target/archive.tar.gz" -C "$target_source"
+          pnpm --dir "$target_source" install --frozen-lockfile
+          pnpm --dir "$target_source" build
+          pnpm --dir "$target_source" test:pwa
       - name: Exercise populated remote backup and restore
         run: |
           config=".hqbase/deployments/$DEPLOYMENT_NAME/wrangler.jsonc"

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -370,6 +370,24 @@ describe("staging workflow lifecycle record", () => {
     expect(step).toContain("DELETE FROM rate_limits WHERE scope IN ('auth.email', 'auth.ip')");
   });
 
+  it("builds the verified target archive before testing its PWA", () => {
+    const pwa = publicUpgradeWorkflow.indexOf(
+      "      - name: Verify candidate PWA from its signed archive"
+    );
+    const seal = publicUpgradeWorkflow.indexOf("      - name: Seal the successful upgrade receipt");
+    expect(pwa).toBeGreaterThan(-1);
+    expect(seal).toBeGreaterThan(pwa);
+    const step = publicUpgradeWorkflow.slice(pwa, seal);
+    expect(step).toContain(
+      'tar -xzf "$GITHUB_WORKSPACE/release/target/archive.tar.gz" -C "$target_source"'
+    );
+    expect(step).toContain('pnpm --dir "$target_source" install --frozen-lockfile');
+    expect(step.indexOf('pnpm --dir "$target_source" build')).toBeLessThan(
+      step.indexOf('pnpm --dir "$target_source" test:pwa')
+    );
+    expect(step).not.toContain("pnpm build");
+  });
+
   it("requires populated remote backup and restore before sealing public receipts", () => {
     const lifecycle = publicUpgradeWorkflow.indexOf(
       "      - name: Verify mail, lifecycle, backup, restore, and PWA after the update"

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -349,6 +349,47 @@ describe("staging workflow lifecycle record", () => {
     );
   });
 
+  it("resets only disposable sign-in probes after public upgrade preservation checks", () => {
+    const probe = publicUpgradeWorkflow.indexOf(
+      "run: node scripts/release/staging-update-gate.mjs probe"
+    );
+    const reset = publicUpgradeWorkflow.indexOf(
+      "      - name: Reset disposable sign-in probes before final lifecycle"
+    );
+    const lifecycle = publicUpgradeWorkflow.indexOf(
+      "      - name: Verify mail, lifecycle, backup, restore, and PWA after the update"
+    );
+    expect(reset).toBeGreaterThan(probe);
+    expect(lifecycle).toBeGreaterThan(reset);
+    const step = publicUpgradeWorkflow.slice(reset, lifecycle);
+    expect(step).toContain(
+      '.accountId == $account and .d1.name == $database and .d1.ownership == "created"'
+    );
+    expect(step).toContain('database="hqbase-$DEPLOYMENT_NAME"');
+    expect(step).toContain('--remote --config "$config"');
+    expect(step).toContain("DELETE FROM rate_limits WHERE scope IN ('auth.email', 'auth.ip')");
+  });
+
+  it("requires populated remote backup and restore before sealing public receipts", () => {
+    const lifecycle = publicUpgradeWorkflow.indexOf(
+      "      - name: Verify mail, lifecycle, backup, restore, and PWA after the update"
+    );
+    const backup = publicUpgradeWorkflow.indexOf(
+      "      - name: Exercise populated remote backup and restore"
+    );
+    const seal = publicUpgradeWorkflow.indexOf("      - name: Seal the successful upgrade receipt");
+    expect(backup).toBeGreaterThan(lifecycle);
+    expect(seal).toBeGreaterThan(backup);
+    const step = publicUpgradeWorkflow.slice(backup, seal);
+    expect(step).toContain('pnpm hqbase backup --name "$DEPLOYMENT_NAME"');
+    expect(step).toContain('pnpm hqbase restore --name "$DEPLOYMENT_NAME"');
+    expect(step).toContain("UPDATE app_settings SET value_json");
+    expect(step).toContain(
+      "SELECT value_json FROM app_settings WHERE key = 'staging-restore-probe'"
+    );
+    expect(step).toContain("jq -e");
+  });
+
   it("keeps the customer source checkout unchanged", () => {
     expect(releaseWorkflow).toContain(
       "      - name: Verify the customer source checkout starts unchanged"

--- a/test/unit/scripts/staging-workflow.test.mjs
+++ b/test/unit/scripts/staging-workflow.test.mjs
@@ -401,11 +401,17 @@ describe("staging workflow lifecycle record", () => {
     const step = publicUpgradeWorkflow.slice(backup, seal);
     expect(step).toContain('pnpm hqbase backup --name "$DEPLOYMENT_NAME"');
     expect(step).toContain('pnpm hqbase restore --name "$DEPLOYMENT_NAME"');
-    expect(step).toContain("UPDATE app_settings SET value_json");
+    expect(step).toContain("INSERT INTO app_settings (key, value_json, created_at, updated_at)");
+    expect(step).toContain(String.raw`'staging-restore-probe', '{\"state\":\"before\"}'`);
+    expect(step).toContain(
+      String.raw`UPDATE app_settings SET value_json = '{\"state\":\"after\"}'`
+    );
     expect(step).toContain(
       "SELECT value_json FROM app_settings WHERE key = 'staging-restore-probe'"
     );
-    expect(step).toContain("jq -e");
+    expect(step).toContain(
+      String.raw`jq -e '.[0].results[0].value_json == "{\"state\":\"before\"}"'`
+    );
   });
 
   it("keeps the customer source checkout unchanged", () => {


### PR DESCRIPTION
The public upgrade workflow runs lifecycle tests before and after deployment. Those sign-in probes exceed the per-email authentication quota, so the final channel test receives HTTP 429 before it can test Nightly. The workflow also named backup and restore in its final test step but did not execute them.

Reset only the auth.email and auth.ip probe counters in the disposable database before the final lifecycle suite, as the signed release workflow already does. Require the lifecycle record to match the account and generated database name and to mark that database as created by the test. This follows completed upgrade and data-preservation checks. Product authentication limits remain unchanged.

Run the existing populated remote backup-and-restore check before sealing the public receipt: save a probe, take a backup, change the probe, restore the backup, and verify its original value. This fulfills the current release policy.

The PWA probe previously failed because the main checkout had no dist directory. Extract the already verified target archive in a temporary directory, install its locked dependencies, build it, and run its PWA test before receipt sealing.

Validation: 15 focused workflow tests pass, including reset ordering, resource scope, exact-archive PWA build, and backup/restore before receipt sealing. Final local gates passed: 949 unit tests, 216 integration tests, coverage, architecture, build, and deployment dry run. The exact signed 1.4.0 archive also passed its PWA test locally: zero installability errors, 38 cached assets, and offline fallback. A fresh public upgrade run will follow merge.
