### PR TITLE
Record verified Stable readiness evidence for 1.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,10 @@ dist
 .env
 *.local
 coverage
-/release/
+/release/*
+!/release/evidence/
+/release/evidence/*
+!/release/evidence/*.json
 playwright-report
 test-results
 .DS_Store

--- a/release/evidence/1.4.0.json
+++ b/release/evidence/1.4.0.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.4.0",
+  "artifactSha256": "4495abaa496e7aee0f006cc63a25a9eb2493e27d2388ac165819ec49a7375673",
+  "sourceCommit": "9e1aedccd357875dd1fca56dadb81e27819b6fe0",
+  "successorVersion": "1.4.1",
+  "publicUpgradeRunId": "34145611385",
+  "reportUrl": "https://github.com/HQBase/hqbase/issues/122",
+  "startedAt": "2026-09-06T21:02:32Z",
+  "finishedAt": "2026-09-07T17:12:06Z",
+  "checks": {
+    "send": true,
+    "receive": true,
+    "attachments": true,
+    "search": true,
+    "backgroundJobs": true,
+    "backupRestore": true,
+    "noOpenBlockers": true
+  }
+}


### PR DESCRIPTION
Record the completed real-use and public upgrade evidence for signed 1.4.0. The exact candidate passed on the maintainer workspace, and canonical run 34145611385 passed both 1.3.4 → 1.4.0 and 1.4.0 → 1.4.1, including application tests, exact-archive PWA checks, populated backup/restore, and cleanup.

The report is https://github.com/HQBase/hqbase/issues/122. This adds the reviewed evidence required by promotion; it does not publish Stable or change an archive. Read-only promotion validation passed for the exact candidate and both sealed receipts. Required local checks passed: 949 unit tests, 216 integration tests, coverage, architecture, build, and deployment dry run. The ignore rules now allow only release/evidence/*.json reports while keeping generated release artifacts ignored.
